### PR TITLE
feat: namespace-scoped DB secret isolation with Kubernetes provider

### DIFF
--- a/external-secrets/kustomization.yaml
+++ b/external-secrets/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cluster-secret-store.yaml
+  - rbac-db-reader.yaml
   - cluster-external-secret.yaml

--- a/external-secrets/rbac-db-reader.yaml
+++ b/external-secrets/rbac-db-reader.yaml
@@ -1,0 +1,80 @@
+# Per-namespace RBAC for reading postgres-operator DB credentials.
+# Each Role uses resourceNames to restrict access to only that namespace's secret.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: eso-db-langfuse
+  namespace: postgres-operator-deployment
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - langfuse.postgres-shared.credentials.postgresql.acid.zalan.do
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: eso-db-langfuse
+  namespace: postgres-operator-deployment
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: eso-db-langfuse
+subjects:
+  - kind: ServiceAccount
+    name: eso-db
+    namespace: langfuse
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: eso-db-openwebui
+  namespace: postgres-operator-deployment
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - openwebui.postgres-shared.credentials.postgresql.acid.zalan.do
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: eso-db-openwebui
+  namespace: postgres-operator-deployment
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: eso-db-openwebui
+subjects:
+  - kind: ServiceAccount
+    name: eso-db
+    namespace: openwebui
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: eso-db-keycloak
+  namespace: postgres-operator-deployment
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - keycloak.postgres-shared.credentials.postgresql.acid.zalan.do
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: eso-db-keycloak
+  namespace: postgres-operator-deployment
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: eso-db-keycloak
+subjects:
+  - kind: ServiceAccount
+    name: eso-db
+    namespace: keycloak

--- a/keycloak-operator/db-secret-store.yaml
+++ b/keycloak-operator/db-secret-store.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso-db
+  namespace: keycloak
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: k8s-postgres
+  namespace: keycloak
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: postgres-operator-deployment
+      server:
+        url: "https://kubernetes.default.svc"
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+          namespace: keycloak
+      auth:
+        serviceAccount:
+          name: eso-db

--- a/keycloak-operator/external-secret.yaml
+++ b/keycloak-operator/external-secret.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   refreshInterval: 5m
   secretStoreRef:
-    name: vault
+    name: k8s-postgres
     kind: SecretStore
   target:
     name: keycloak-db-secret
@@ -19,9 +19,9 @@ spec:
   data:
     - secretKey: username
       remoteRef:
-        key: shared/keycloak
-        property: DB_USER
+        key: keycloak.postgres-shared.credentials.postgresql.acid.zalan.do
+        property: username
     - secretKey: password
       remoteRef:
-        key: shared/keycloak
-        property: DB_PASSWORD
+        key: keycloak.postgres-shared.credentials.postgresql.acid.zalan.do
+        property: password

--- a/langfuse/db-secret-store.yaml
+++ b/langfuse/db-secret-store.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso-db
+  namespace: langfuse
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: k8s-postgres
+  namespace: langfuse
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: postgres-operator-deployment
+      server:
+        url: "https://kubernetes.default.svc"
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+          namespace: langfuse
+      auth:
+        serviceAccount:
+          name: eso-db

--- a/langfuse/external-secret.yaml
+++ b/langfuse/external-secret.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   refreshInterval: 5m
   secretStoreRef:
-    name: vault
+    name: k8s-postgres
     kind: SecretStore
   target:
     name: langfuse-db-credentials
@@ -19,9 +19,9 @@ spec:
   data:
     - secretKey: DB_USER
       remoteRef:
-        key: shared/langfuse
-        property: DB_USER
+        key: langfuse.postgres-shared.credentials.postgresql.acid.zalan.do
+        property: username
     - secretKey: DB_PASSWORD
       remoteRef:
-        key: shared/langfuse
-        property: DB_PASSWORD
+        key: langfuse.postgres-shared.credentials.postgresql.acid.zalan.do
+        property: password

--- a/langfuse/kustomization.yaml
+++ b/langfuse/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - ingress.yaml
   - vault-secret-store.yaml
+  - db-secret-store.yaml
   - external-secret.yaml

--- a/openwebui/db-secret-store.yaml
+++ b/openwebui/db-secret-store.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso-db
+  namespace: openwebui
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: k8s-postgres
+  namespace: openwebui
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: postgres-operator-deployment
+      server:
+        url: "https://kubernetes.default.svc"
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+          namespace: openwebui
+      auth:
+        serviceAccount:
+          name: eso-db

--- a/openwebui/external-secret.yaml
+++ b/openwebui/external-secret.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   refreshInterval: 5m
   secretStoreRef:
-    name: vault
+    name: k8s-postgres
     kind: SecretStore
   target:
     name: openwebui-db-credentials
@@ -19,9 +19,9 @@ spec:
   data:
     - secretKey: DB_USER
       remoteRef:
-        key: shared/openwebui
-        property: DB_USER
+        key: openwebui.postgres-shared.credentials.postgresql.acid.zalan.do
+        property: username
     - secretKey: DB_PASSWORD
       remoteRef:
-        key: shared/openwebui
-        property: DB_PASSWORD
+        key: openwebui.postgres-shared.credentials.postgresql.acid.zalan.do
+        property: password

--- a/openwebui/kustomization.yaml
+++ b/openwebui/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - vault-secret-store.yaml
+  - db-secret-store.yaml
   - external-secret.yaml
   - mcpo-deployment.yaml
   - network-policy-to-mcp.yaml

--- a/vault/README.md
+++ b/vault/README.md
@@ -91,16 +91,16 @@ Each namespace has its own Vault policy and Kubernetes auth role, scoped to only
 | Vault Role | Namespace | Allowed Paths |
 |------------|-----------|---------------|
 | `eso` | external-secrets | `secret/data/shared/app` |
-| `eso-langfuse` | langfuse | `secret/data/shared/langfuse` |
-| `eso-openwebui` | openwebui | `secret/data/shared/openwebui` |
-| `eso-keycloak` | keycloak | `secret/data/shared/keycloak` |
-| `eso-atc` | atc | `secret/data/atc/*` |
+| `eso-atc` | atc | `atc/data/*` |
 
-To add a new namespace, update `vault/scripts/setup-eso-policies.sh` and run it.
+> **Note**: DB credentials for langfuse, openwebui, and keycloak are synced directly from the postgres-operator via ESO's Kubernetes provider (not Vault). See `../external-secrets/README.md`.
+
+To add a new namespace with Vault access, update `vault/scripts/setup-eso-policies.sh` and run it.
 
 ## Notes
 
-- Uses KV v2 secrets engine mounted at `secret/` path
+- Uses KV v2 secrets engine mounted at `secret/` path (and `atc/` for ATC-specific secrets)
 - Per-namespace Vault policies enforce least-privilege access
-- Each namespace has its own `SecretStore` + `ServiceAccount` for isolation
-- Kubernetes auth role `eso` (ClusterExternalSecret) bound to `external-secrets` SA
+- DB credentials use ESO Kubernetes provider for automatic rotation
+- Non-DB secrets use per-namespace `SecretStore` + `ServiceAccount` for Vault isolation
+


### PR DESCRIPTION
## Summary

Replaces broad Vault/K8s secret access with strict per-namespace isolation.

### Changes

**DB secrets (postgres-operator → ESO K8s provider)**
- Per-namespace `SecretStore` + `ServiceAccount` (`eso-db`) for langfuse, openwebui, keycloak
- RBAC with `resourceNames` restricting each SA to only its own postgres-operator secret
- Auto-rotation: credentials sync directly from postgres-operator, no manual Vault step

**Vault secrets (non-DB)**
- Per-namespace `SecretStore` + `ServiceAccount` (`eso`) for Vault access
- Scoped Vault policies per namespace (`eso-atc` → `atc/data/*`, etc.)
- ATC namespace: `ExternalSecret` for `gmo-coin-api-secret` via dedicated `atc` KV mount

### Security Model

| Layer | Before | After |
|-------|--------|-------|
| Vault policy | `secret/data/*` (everything) | Per-namespace scoped policies |
| Vault SecretStore | `ClusterSecretStore` (any ns) | Namespace-scoped `SecretStore` |
| DB SecretStore | `ClusterSecretStore` (any ns) | Namespace-scoped `SecretStore` |
| DB RBAC | Read all postgres secrets | `resourceNames` per secret |

### Prerequisites
- Run `vault/scripts/setup-eso-policies.sh` before merging (creates scoped Vault policies/roles)