### PR TITLE
feat(vault): make Vault to use longhorn-hdd

### DIFF
--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -133,12 +133,12 @@ server:
   dataStorage:
     enabled: true
     size: 10Gi
-    storageClass: longhorn-ssd
+    storageClass: longhorn-hdd
     accessMode: ReadWriteOnce
   auditStorage:
     enabled: true
     size: 10Gi
-    storageClass: longhorn-ssd
+    storageClass: longhorn-hdd
     accessMode: ReadWriteOnce
 ui:
   enabled: true


### PR DESCRIPTION
## Overview

This PR makes Vault to use `longhorn-hdd` instead of `longorn-ssd`
