### PR TITLE
feat(vault): add pod anti-affinity to spread replicas across nodes

### DIFF
--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -43,6 +43,16 @@ server:
                   - shion-ubuntu-2505
                   - instance-2024-1
                   - instance-k8s-proxy
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: vault
+                app.kubernetes.io/instance: vault
+                component: server
+            topologyKey: kubernetes.io/hostname
   serviceAccount:
     create: true
     name: "vault-unsealer"


### PR DESCRIPTION
## Summary
- Add pod anti-affinity rule to ensure Vault replicas prefer to be scheduled on different nodes
- Improves high availability by distributing the 3 Vault replicas across available nodes

## Changes
- Added `podAntiAffinity` with `preferredDuringSchedulingIgnoredDuringExecution` strategy
- Uses soft affinity (preferred) rather than hard requirement for flexibility
- Targets pods with matching Vault labels on the same hostname topology

## Impact
- Vault pods will automatically spread across `shion-ubuntu-2505`, `instance-2024-1`, and `instance-k8s-proxy`
- Improves resilience: if one node fails, Vault cluster remains operational on other nodes
- Uses "preferred" rather than "required" to allow scheduling even if perfect spread isn't possible

## Test Plan
- [ ] ArgoCD syncs successfully
- [ ] Verify Vault pods are distributed across different nodes: `kubectl get pods -n vault -o wide`
- [ ] Verify Vault cluster health: check all replicas are unsealed and joined to Raft cluster