### PR TITLE
feat(longhorn): enable replica soft anti-affinity and restrict single-replica HDD storage

### DIFF
--- a/longhorn/kustomization.yaml
+++ b/longhorn/kustomization.yaml
@@ -11,3 +11,5 @@ resources:
   - storageclass.yaml
   # Internal ingress for Longhorn UI
   - ingress.yaml
+  # Longhorn settings
+  - settings.yaml

--- a/longhorn/settings.yaml
+++ b/longhorn/settings.yaml
@@ -1,0 +1,15 @@
+apiVersion: longhorn.io/v1beta2
+kind: Setting
+metadata:
+  name: replica-soft-anti-affinity
+  namespace: longhorn-system
+spec:
+  value: "true"
+---
+apiVersion: longhorn.io/v1beta2
+kind: Setting
+metadata:
+  name: replica-zone-soft-anti-affinity
+  namespace: longhorn-system
+spec:
+  value: "true"

--- a/longhorn/storageclass.yaml
+++ b/longhorn/storageclass.yaml
@@ -18,6 +18,8 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: longhorn-hdd
+  annotations:
+    storageclass.kubernetes.io/description: "Single replica HDD storage on main storage node only"
 provisioner: driver.longhorn.io
 allowVolumeExpansion: true
 reclaimPolicy: Retain
@@ -26,6 +28,7 @@ parameters:
   dataEngine: "v1"
   fsType: "ext4"
   diskSelector: "hdd"
+  nodeSelector: "kubernetes.io/hostname:shion-ubuntu-2505"
 volumeBindingMode: Immediate
 ---
 apiVersion: storage.k8s.io/v1


### PR DESCRIPTION
## Summary

- Enable Longhorn replica soft anti-affinity to spread replicas across nodes
- Restrict longhorn-hdd (single replica) to main storage node only
- Prevent OCI instances with limited storage from being used for single-replica volumes

## Changes

### 1. New Longhorn Settings (settings.yaml)

- replica-soft-anti-affinity: true
- replica-zone-soft-anti-affinity: true

Longhorn will prefer to place replicas on different nodes, improving HA distribution.

### 2. StorageClass Update

**longhorn-hdd (single replica):**
- Added nodeSelector to restrict to shion-ubuntu-2505 only
- Prevents consuming limited 50GB storage on OCI instances

**longhorn-hdd-ha (2 replicas):**
- No node selector, can use all nodes
- Benefits from replica soft anti-affinity

## Problem This Solves

**Before:** Single-replica volumes could fill up small OCI nodes (50GB), leaving no space for HA replicas.

**After:** Small OCI nodes reserved for HA replica storage only.

## Storage Strategy

- longhorn-ssd (1 replica): shion-ubuntu-2505 only
- longhorn-hdd (1 replica): shion-ubuntu-2505 only
- longhorn-hdd-ha (2 replicas): All HDD nodes

## Benefits

- Better replica distribution across nodes
- Resource protection for small nodes
- Vault replicas can now spread to instance-2024-1

## Related

Addresses issue where Vault replicas weren't scheduling on instance-2024-1. Complements PR #114.