### PR TITLE
feat(vault): switch to longhorn-hdd-ha for high availability storage

### DIFF
--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -145,12 +145,12 @@ server:
   dataStorage:
     enabled: true
     size: 10Gi
-    storageClass: longhorn-hdd
+    storageClass: longhorn-hdd-ha
     accessMode: ReadWriteOnce
   auditStorage:
     enabled: true
     size: 10Gi
-    storageClass: longhorn-hdd
+    storageClass: longhorn-hdd-ha
     accessMode: ReadWriteOnce
 ui:
   enabled: true


### PR DESCRIPTION
## Summary

Switch Vault to use `longhorn-hdd-ha` StorageClass for 2-replica HA storage now that disk tags have been safely separated.

## Changes

- ✅ Vault `dataStorage.storageClass`: `longhorn-hdd` → `longhorn-hdd-ha`
- ✅ Vault `auditStorage.storageClass`: `longhorn-hdd` → `longhorn-hdd-ha`

## Context

After PR #118 separated OCI disk tags (`hdd-oci`), the `longhorn-hdd-ha` StorageClass can now safely distribute replicas across all nodes:
- `shion-ubuntu-2505`: Primary replicas (20TB)
- `instance-2024-1` + `instance-k8s-proxy`: Secondary replicas (50GB each)

## Benefits

✅ **Data Redundancy**: 2 replicas protect against single node storage failure  
✅ **Cross-Node Distribution**: Replicas spread across nodes with soft anti-affinity  
✅ **HA for Critical Service**: Vault is critical infrastructure  
✅ **Utilizes OCI Nodes**: Puts 50GB nodes to good use for replicas

## Storage Capacity

With 3 Vault pods × 2 volumes × 2 replicas:
- **Data volumes**: 30Gi × 2 = 60Gi
- **Audit volumes**: 30Gi × 2 = 60Gi  
- **Total**: 120Gi distributed across cluster

**Fits comfortably:**
- Primary replicas: shion-ubuntu-2505 (has 20TB)
- Secondary replicas: ~30-40GB each on OCI nodes (have 50GB each)

## Important: Existing PVCs

⚠️ **StatefulSets do NOT update existing PVCs automatically.**

After merging this PR:
- **New Vault pods**: Will use `longhorn-hdd-ha` (2 replicas)
- **Existing Vault pods**: Continue using `longhorn-hdd` (1 replica) until recreated

### To Apply HA Storage to Existing Pods

**Option 1: Delete pods one at a time (safer, rolling)**
```bash
kubectl delete pod vault-2 -n vault
# Wait for vault-2 to be Ready (2/2)
kubectl delete pod vault-1 -n vault  
# Wait for vault-1 to be Ready
kubectl delete pod vault-0 -n vault
# Wait for vault-0 to be Ready
```

**Option 2: Scale down (requires backup)**
```bash
# 1. Create Raft snapshot
kubectl exec -n vault vault-0 -- vault operator raft snapshot save /tmp/backup.snap

# 2. Scale down
kubectl scale statefulset vault -n vault --replicas=0

# 3. Delete old PVCs
kubectl delete pvc -n vault --all

# 4. Scale up (ArgoCD creates new PVCs with longhorn-hdd-ha)
kubectl scale statefulset vault -n vault --replicas=3
```

## Recommendation

✅ **Safe approach**: Merge this PR but don't force PVC recreation unless needed  
✅ **Future pods**: Will automatically get HA storage  
✅ **Current pods**: Continue working with single-replica storage (still reliable)

You can optionally apply HA to existing pods later using Option 1 above.

## Test Plan

- [ ] ArgoCD syncs successfully
- [ ] Existing Vault pods remain healthy (no disruption)
- [ ] Future new pods will use `longhorn-hdd-ha`
- [ ] (Optional) Test pod deletion/recreation to verify HA storage

## Related

- Builds on PR #118 (disk tag separation)
- Complements PR #117 (replica soft anti-affinity)
- Reverts temporary change from PR #118 commit cf24363