### PR TITLE
fix(longhorn): use hdd-ha tag for HA-capable nodes

### DIFF
--- a/longhorn/node-longhorn-instance-2024-1.yaml
+++ b/longhorn/node-longhorn-instance-2024-1.yaml
@@ -11,6 +11,6 @@ spec:
       allowScheduling: true
       diskType: filesystem
       path: /var/lib/longhorn/longhorn-hdd
-      tags: ["hdd-oci"]
+      tags: ["hdd-ha"]
       # Reserve 1 GiB for system use (in bytes)
       storageReserved: 1073741824

--- a/longhorn/node-longhorn-instance-k8s-proxy.yaml
+++ b/longhorn/node-longhorn-instance-k8s-proxy.yaml
@@ -11,6 +11,6 @@ spec:
       allowScheduling: true
       diskType: filesystem
       path: /var/lib/longhorn/longhorn-hdd
-      tags: ["hdd-oci"]
+      tags: ["hdd-ha"]
       # Reserve 1 GiB for system use (in bytes)
       storageReserved: 1073741824

--- a/longhorn/node-longhorn-shion-ubuntu-2505.yaml
+++ b/longhorn/node-longhorn-shion-ubuntu-2505.yaml
@@ -19,6 +19,6 @@ spec:
       allowScheduling: true
       diskType: filesystem
       path: /var/lib/longhorn/longhorn-hdd-202508-20tb
-      tags: ["hdd"]
+      tags: ["hdd", "hdd-ha"]
       # Reserve 10 GiB on the HDD for system use (in bytes).
       storageReserved: 10737418240

--- a/longhorn/storageclass.yaml
+++ b/longhorn/storageclass.yaml
@@ -41,7 +41,7 @@ parameters:
   numberOfReplicas: "2"
   dataEngine: "v1"
   fsType: "ext4"
-  diskSelector: "hdd,hdd-oci"
+  diskSelector: "hdd-ha"
   # Prefer spreading replicas across different nodes
   replicaAutoBalance: "best-effort"
 volumeBindingMode: Immediate


### PR DESCRIPTION
## Problem

Longhorn `diskSelector` with comma-separated tags uses **AND logic**, not OR. 

Previous PR #118 used:
- OCI nodes: `tags: ["hdd-oci"]`  
- StorageClass: `diskSelector: "hdd,hdd-oci"`

This caused **"tags not fulfilled"** error because Longhorn requires disks to have **BOTH** `hdd` AND `hdd-oci` tags simultaneously.

## Root Cause

According to [Longhorn documentation](https://longhorn.io/docs/latest/nodes-and-volumes/nodes/storage-tags/):
> When multiple tags are specified for a volume, the disk and the node must have **all the specified tags** to become usable.

Comma-separated tags = AND condition, not OR.

## Solution

Rename tags with clearer semantics and proper distribution:

### Tag Names:
- **`hdd`**: Single-replica capable  
- **`hdd-ha`**: HA-replica capable

### Tag Distribution:
```
shion-ubuntu-2505:     ["hdd", "hdd-ha"]  ← Can host both
instance-2024-1:       ["hdd-ha"]          ← Only HA replicas
instance-k8s-proxy:    ["hdd-ha"]          ← Only HA replicas
```

### StorageClass Selectors:
```yaml
longhorn-hdd:     diskSelector: "hdd"     → Only shion-ubuntu-2505
longhorn-hdd-ha:  diskSelector: "hdd-ha"  → All nodes
```

## Benefits

✅ **Clear naming**: `hdd-ha` explicitly means "available for HA distribution"  
✅ **Protects OCI nodes**: Single-replica volumes can't match `hdd-ha` only  
✅ **Enables HA**: Multi-replica volumes find all nodes with `hdd-ha`  
✅ **Works with AND logic**: Each storage class matches required tags

## Result

| Workload Type | StorageClass | Nodes Used |
|--------------|--------------|------------|
| Single replica | longhorn-hdd | shion-ubuntu-2505 only |
| HA (2 replicas) | longhorn-hdd-ha | All 3 nodes |

**OCI nodes (50GB)** reserved for HA replica distribution only ✅

## Test Plan

- [ ] ArgoCD syncs successfully
- [ ] Vault can create PVCs with longhorn-hdd-ha
- [ ] Replicas spread across nodes (check with `kubectl get replica.longhorn.io -n longhorn-system`)
- [ ] Single-replica test PVC only uses shion-ubuntu-2505

## Fixes

Resolves the "tags not fulfilled" error introduced in PR #118 and PR #119.