### PR TITLE
fix(renovate): enable automerge for custom regex managers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -55,6 +55,13 @@
       ]
     },
     {
+      "description": "Custom manager updates (aqua, etc)",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "automerge": true
+    },
+    {
       "description": "Major updates",
       "matchUpdateTypes": [
         "major"


### PR DESCRIPTION
## Summary
- Enable automerge for custom regex managers (e.g., aqua-registry updates)

## Problem
Renovate automerge was working for Helm charts, Docker images, and ArgoCD applications, but was not enabled for updates detected by custom regex managers (like aqua-registry). This caused PRs #123, #115, and #112 to not have automerge enabled.

## Solution
Added a new `packageRule` in `renovate.json` to match `custom.regex` managers and enable automerge for them.

## Test Plan
- [x] Verified existing automerge still works for Helm/Docker/ArgoCD updates
- [ ] Wait for next aqua-registry update to verify automerge is enabled
- [ ] Confirm automerge respects branch protection requirements

## Related PRs
- #123, #115, #112 - Previous aqua-registry updates without automerge