### PR TITLE
🔧 (openwebui) Explicitly configure default values, address out-of-sync on secrets

### DIFF
--- a/openwebui/external-secret.yaml
+++ b/openwebui/external-secret.yaml
@@ -21,7 +21,13 @@ spec:
       remoteRef:
         key: openwebui.postgres-shared.credentials.postgresql.acid.zalan.do
         property: username
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
     - secretKey: DB_PASSWORD
       remoteRef:
         key: openwebui.postgres-shared.credentials.postgresql.acid.zalan.do
         property: password
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None


### PR DESCRIPTION
The `openwebui` namespace contains an external resource called `ExternalSecret` that has been marked as out-of-sync because the default configuration values are not explicitly specified. This PR explicitly defines required properties, avoid argocd marking those resources as out-of-sync.