### PR TITLE
chore(renovate): simplify config and add lumos-web repo

### DIFF
--- a/renovate/scripts-configmap.yaml
+++ b/renovate/scripts-configmap.yaml
@@ -12,14 +12,6 @@ data:
     # echo "Running Renovate against Shion1305/k8s-GitOps only for testing..."
     # exec /scripts/run-renovate-core.sh Shion1305/k8s-GitOps
 
-  run-bug-discussion-41912.sh: |
-    #!/bin/bash
-    set -e
-    export RENOVATE_AUTODISCOVER="false"
-    export LOG_LEVEL="debug"
-    echo "Running Renovate against Shion1305/renovate-bug-discussion-41912 specifically..."
-    exec /scripts/run-renovate-core.sh Shion1305/renovate-bug-discussion-41912
-
   run-renovate-core.sh: |
     #!/bin/bash
     set -e

--- a/renovate/values.yaml
+++ b/renovate/values.yaml
@@ -27,76 +27,6 @@ extraVolumeMounts:
   - name: scripts
     mountPath: /scripts
 
-extraObjects:
-  - apiVersion: batch/v1
-    kind: CronJob
-    metadata:
-      name: renovate-bug-discussion-41912
-    spec:
-      schedule: "0 * * * *"
-      suspend: true
-      concurrencyPolicy: Forbid
-      failedJobsHistoryLimit: 1
-      successfulJobsHistoryLimit: 1
-      jobTemplate:
-        metadata:
-          labels:
-            app.kubernetes.io/name: renovate
-            app.kubernetes.io/instance: renovate
-        spec:
-          template:
-            metadata:
-              labels:
-                app.kubernetes.io/name: renovate
-                app.kubernetes.io/instance: renovate
-            spec:
-              serviceAccountName: renovate
-              restartPolicy: Never
-              containers:
-                - name: renovate
-                  image: "ghcr.io/renovatebot/renovate:43.110.3"
-                  imagePullPolicy: IfNotPresent
-                  command:
-                    - /bin/bash
-                    - /scripts/run-bug-discussion-41912.sh
-                  volumeMounts:
-                    - name: config-volume
-                      mountPath: /usr/src/app/config.json
-                      subPath: config.json
-                    - mountPath: /scripts
-                      name: scripts
-                  env:
-                    - name: RENOVATE_CONFIG_FILE
-                      value: /usr/src/app/config.json
-                    - name: "LOG_LEVEL"
-                      value: "debug"
-                    - name: "RENOVATE_AUTODISCOVER"
-                      value: "false"
-                  envFrom:
-                    - secretRef:
-                        name: renovate-secret
-                  resources:
-                    limits:
-                      cpu: 2000m
-                      memory: 2Gi
-                    requests:
-                      cpu: 200m
-                      memory: 512Mi
-              volumes:
-                - name: config-volume
-                  configMap:
-                    name: renovate-config
-                - configMap:
-                    defaultMode: 0755
-                    name: renovate-scripts
-                  name: scripts
-              securityContext:
-                fsGroup: 1000
-                runAsNonRoot: true
-                runAsUser: 1000
-                seccompProfile:
-                  type: RuntimeDefault
-
 # Environment variables
 env:
   LOG_LEVEL: "info"
@@ -117,7 +47,7 @@ renovate:
       "requireConfig": "optional",
       "gitAuthor": "Automation by Shion1305 <bot@github.shion.pro>",
       "username": "renovate-by-shion1305[bot]",
-      "repositories": [],
+      "repositories": ["Lumos-Programming/lumos-web"],
       "ignorePaths": [],
       "enabledManagers": [
         "argocd",


### PR DESCRIPTION
## Summary
- Remove the dedicated `renovate-bug-discussion-41912` CronJob and its wrapper script, as the workaround is no longer needed
- Add `Lumos-Programming/lumos-web` to the Renovate repositories list

## Test plan
- [ ] Verify Renovate CronJob runs successfully without the removed resources
- [ ] Confirm `Lumos-Programming/lumos-web` receives Renovate PRs