### PR TITLE
feat: deploy MLflow with PostgreSQL backend and Longhorn artifact storage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,11 +27,14 @@ spec:
     path: <app-dir>  # Additional manifests (ingress, secrets, etc.)
 ```
 
+Not all apps use this multi-source pattern. Some apps use a **single-source pattern** pointing directly at a repo directory (e.g., `apps/ingress.yaml`), where ArgoCD deploys raw manifests or Kustomize from the directory. Check the existing app manifest to see which pattern is used.
+
 When modifying applications:
 
 - Helm chart configurations go in `<app-name>/values.yaml`
-- Additional Kubernetes manifests (Ingress, Secrets, Jobs) go in the app's directory
+- Additional Kubernetes manifests (Ingress, Secrets, Jobs) go in the app's directory, referenced by `kustomization.yaml`
 - Version updates are done by changing `targetRevision` in `apps/<app-name>-app.yaml`
+- To decommission an app, move its `apps/*.yaml` manifest to `apps/archived/`
 
 ## Key Commands
 
@@ -245,6 +248,16 @@ kubectl get volumes -n longhorn-system
 # View PV/PVC status
 kubectl get pv,pvc --all-namespaces
 ```
+
+## Dependency Management (Renovate)
+
+Renovate runs in-cluster (deployed via Helm chart in `renovate/`) and automatically creates PRs for dependency updates:
+
+- Configuration: `renovate.json` at repo root
+- Manages: ArgoCD Helm chart versions in `apps/*.yaml`, Docker image tags across all YAML files, and Grafana dashboard revisions
+- All dependency update PRs are set to **automerge**
+- Commit prefix: `chore(deps):` with semantic commits and git sign-off
+- PR limits: 5 concurrent, 2 per hour
 
 ## Important Notes
 

--- a/apps/mlflow-app.yaml
+++ b/apps/mlflow-app.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mlflow
+  namespace: argocd
+spec:
+  project: default
+  sources:
+    - repoURL: https://community-charts.github.io/helm-charts
+      chart: mlflow
+      targetRevision: 1.8.1
+      helm:
+        valueFiles:
+          - $values/mlflow/values.yaml
+    - repoURL: https://github.com/Shion1305/k8s-GitOps.git
+      targetRevision: HEAD
+      ref: values
+    - repoURL: https://github.com/Shion1305/k8s-GitOps.git
+      targetRevision: HEAD
+      path: mlflow
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: mlflow
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/external-secrets/rbac-db-reader.yaml
+++ b/external-secrets/rbac-db-reader.yaml
@@ -78,3 +78,29 @@ subjects:
   - kind: ServiceAccount
     name: eso-db
     namespace: keycloak
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: eso-db-mlflow
+  namespace: postgres-operator-deployment
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - mlflow.postgres-shared.credentials.postgresql.acid.zalan.do
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: eso-db-mlflow
+  namespace: postgres-operator-deployment
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: eso-db-mlflow
+subjects:
+  - kind: ServiceAccount
+    name: eso-db
+    namespace: mlflow

--- a/mlflow/db-secret-store.yaml
+++ b/mlflow/db-secret-store.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso-db
+  namespace: mlflow
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: k8s-postgres
+  namespace: mlflow
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: postgres-operator-deployment
+      server:
+        url: "https://kubernetes.default.svc"
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: eso-db

--- a/mlflow/external-secret.yaml
+++ b/mlflow/external-secret.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mlflow-db-credentials
+  namespace: mlflow
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: k8s-postgres
+    kind: SecretStore
+  target:
+    name: mlflow-db-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+  data:
+    - secretKey: DB_USER
+      remoteRef:
+        key: mlflow.postgres-shared.credentials.postgresql.acid.zalan.do
+        property: username
+    - secretKey: DB_PASSWORD
+      remoteRef:
+        key: mlflow.postgres-shared.credentials.postgresql.acid.zalan.do
+        property: password

--- a/mlflow/ingress.yaml
+++ b/mlflow/ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mlflow
+  namespace: mlflow
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  ingressClassName: nginx-internal
+  tls:
+    - hosts:
+        - mlflow.k.shion1305.com
+      secretName: mlflow-tls
+  rules:
+    - host: mlflow.k.shion1305.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mlflow
+                port:
+                  number: 80

--- a/mlflow/kustomization.yaml
+++ b/mlflow/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ingress.yaml
+  - pvc.yaml
+  - db-secret-store.yaml
+  - external-secret.yaml

--- a/mlflow/pvc.yaml
+++ b/mlflow/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mlflow-artifacts
+  namespace: mlflow
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-hdd
+  resources:
+    requests:
+      storage: 50Gi

--- a/mlflow/values.yaml
+++ b/mlflow/values.yaml
@@ -1,0 +1,36 @@
+backendStore:
+  databaseMigration: true
+  databaseConnectionCheck: true
+  postgres:
+    enabled: true
+    host: "postgres-shared.postgres-operator-deployment.svc.cluster.local"
+    port: 5432
+    database: "mlflow"
+    user: "mlflow"
+    password: "dummy"
+    driver: "psycopg2"
+  existingDatabaseSecret:
+    name: "mlflow-db-credentials"
+    usernameKey: "DB_USER"
+    passwordKey: "DB_PASSWORD"
+
+artifactRoot:
+  defaultArtifactRoot: "/mlflow/artifacts"
+
+extraVolumes:
+  - name: mlflow-artifacts
+    persistentVolumeClaim:
+      claimName: mlflow-artifacts
+
+extraVolumeMounts:
+  - name: mlflow-artifacts
+    mountPath: /mlflow/artifacts
+
+ingress:
+  enabled: false
+
+postgresql:
+  enabled: false
+
+mysql:
+  enabled: false

--- a/mlflow/values.yaml
+++ b/mlflow/values.yaml
@@ -6,8 +6,6 @@ backendStore:
     host: "postgres-shared.postgres-operator-deployment.svc.cluster.local"
     port: 5432
     database: "mlflow"
-    user: "mlflow"
-    password: "dummy"
     driver: "psycopg2"
   existingDatabaseSecret:
     name: "mlflow-db-credentials"

--- a/postgres-shared/postgres-cluster.yaml
+++ b/postgres-shared/postgres-cluster.yaml
@@ -13,10 +13,12 @@ spec:
     openwebui: []
     langfuse: []
     keycloak: []
+    mlflow: []
   databases:
     openwebui: openwebui
     langfuse: langfuse
     keycloak: keycloak
+    mlflow: mlflow
   postgresql:
     version: "17"
   resources:


### PR DESCRIPTION
## Summary
- Deploy MLflow tracking server (community-charts/mlflow v1.8.1, MLflow 3.7.0) via ArgoCD
- Backend store on shared PostgreSQL cluster with credentials synced via External Secrets Operator
- 50Gi artifact storage on Longhorn HDD PVC
- Internal-only ingress at mlflow.k.shion1305.com (no additional auth — network-level restriction via nginx-internal is sufficient)
- RBAC for ESO to read PostgreSQL credentials from `postgres-operator-deployment` namespace
- Incident report documenting postgres-operator user provisioning failure root cause
- Update CLAUDE.md with Renovate docs, single-source app pattern, and app archival pattern

## Files changed
- `apps/mlflow-app.yaml` — ArgoCD Application (multi-source Helm pattern)
- `mlflow/` — values.yaml, ingress, PVC, db-secret-store, external-secret, kustomization
- `postgres-shared/postgres-cluster.yaml` — add mlflow user and database
- `external-secrets/rbac-db-reader.yaml` — RBAC Role/RoleBinding for MLflow ESO db access
- `postgres-operator/README.md` — incident report for user provisioning failure
- `CLAUDE.md` — documentation improvements

## Test plan
- [x] ArgoCD picks up `mlflow` Application and syncs
- [x] PostgreSQL operator creates `mlflow` user and database on `postgres-shared`
- [x] ESO syncs DB credentials into `mlflow` namespace
- [x] MLflow pod starts successfully with DB migration
- [x] MLflow UI accessible at https://mlflow.k.shion1305.com