### PR TITLE
fix: switch postgres-operator config to ConfigMap to fix user provisioning

### DIFF
--- a/postgres-operator/values.yaml
+++ b/postgres-operator/values.yaml
@@ -3,6 +3,10 @@ image:
   repository: zalando/postgres-operator
   tag: v1.15.1
   pullPolicy: IfNotPresent
+# Use ConfigMap instead of OperatorConfigurationCRD to avoid CRD schema
+# defaults causing ArgoCD to normalize the configuration to {}, which
+# silently drops settings like enable_database_access.
+configTarget: "ConfigMap"
 # Operator configuration
 configGeneral:
   enable_crd_registration: true


### PR DESCRIPTION
## Summary
- The Zalando postgres-operator's `OperatorConfigurationCRD` has OpenAPI schema defaults that cause ArgoCD's client-side apply to normalize the `configuration` field to `{}`, silently dropping all settings including `enable_database_access: true`
- Without `enable_database_access`, the operator creates Kubernetes secrets for new PostgreSQL users but **never creates the actual SQL roles or databases**, causing authentication failures
- This is the root cause of the recurring issue where newly added PostgreSQL users fail to authenticate
- Fix: switch `configTarget` from `OperatorConfigurationCRD` (default) to `ConfigMap`, which doesn't have CRD schema defaulting

## Root cause analysis
1. Helm chart renders full `OperatorConfiguration` with `debug.enable_database_access: true`
2. CRD schema has defaults matching all Helm values
3. ArgoCD compares desired vs live state, sees defaults match, strips them → applies `configuration: {}`
4. Operator reads empty config, `enable_database_access` defaults to `false`
5. Operator skips SQL role/database creation on cluster updates, only creates K8s secrets

## Test plan
- [ ] After merge, verify the operator ConfigMap contains `enable_database_access: "true"`
- [ ] Delete the stale `OperatorConfiguration` CRD: `kubectl delete operatorconfiguration postgres-operator -n postgres-operator`
- [ ] Trigger resync: `kubectl annotate postgresql postgres-shared -n postgres-operator-deployment zalando.org/resync="$(date +%s)" --overwrite`
- [ ] Verify `mlflow` user is created: `kubectl exec -n postgres-operator-deployment postgres-shared-0 -- psql -U postgres -c "SELECT usename FROM pg_shadow WHERE usename = 'mlflow';"`
- [ ] Verify MLflow pod starts successfully