### PR TITLE
fix: add MLFLOW_ALLOWED_HOSTS to allow ingress domain

### DIFF
--- a/mlflow/values.yaml
+++ b/mlflow/values.yaml
@@ -24,6 +24,9 @@ extraVolumeMounts:
   - name: mlflow-artifacts
     mountPath: /mlflow/artifacts
 
+extraEnvVars:
+  MLFLOW_ALLOWED_HOSTS: "mlflow.k.shion1305.com"
+
 ingress:
   enabled: false
 


### PR DESCRIPTION
## Summary
- Add `MLFLOW_ALLOWED_HOSTS=mlflow.k.shion1305.com` to MLflow env vars
- MLflow 2.16+ validates Host headers to prevent DNS rebinding attacks, rejecting requests from unrecognized hosts

## Test plan
- [ ] Access https://mlflow.k.shion1305.com — should load MLflow UI without "Invalid Host header" error