### PR TITLE
fix: use correct env var MLFLOW_SERVER_ALLOWED_HOSTS

### DIFF
--- a/mlflow/values.yaml
+++ b/mlflow/values.yaml
@@ -25,7 +25,7 @@ extraVolumeMounts:
     mountPath: /mlflow/artifacts
 
 extraEnvVars:
-  MLFLOW_ALLOWED_HOSTS: "mlflow.k.shion1305.com"
+  MLFLOW_SERVER_ALLOWED_HOSTS: "mlflow.k.shion1305.com"
 
 ingress:
   enabled: false


### PR DESCRIPTION
## Summary
- Fix env var name: `MLFLOW_ALLOWED_HOSTS` → `MLFLOW_SERVER_ALLOWED_HOSTS`
- MLflow 3.7.0 reads `MLFLOW_SERVER_ALLOWED_HOSTS` for DNS rebinding protection

## Test plan
- [ ] Access https://mlflow.k.shion1305.com — should load without "Invalid Host header" error