### PR TITLE
feat: deploy freqtrade trading bot

### DIFF
--- a/apps/freqtrade-app.yaml
+++ b/apps/freqtrade-app.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: freqtrade
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Shion1305/k8s-GitOps.git
+    targetRevision: HEAD
+    path: freqtrade
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: freqtrade
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/freqtrade/configmap.yaml
+++ b/freqtrade/configmap.yaml
@@ -25,7 +25,6 @@ data:
         "listen_ip_address": "0.0.0.0",
         "listen_port": 8080,
         "verbosity": "error",
-        "enable_openapi": true,
         "CORS_origins": []
       },
       "bot_name": "freqtrade",

--- a/freqtrade/configmap.yaml
+++ b/freqtrade/configmap.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: freqtrade-config
+  namespace: freqtrade
+data:
+  config.json: |
+    {
+      "trading_mode": "spot",
+      "margin_mode": "",
+      "max_open_trades": 5,
+      "stake_currency": "USDT",
+      "stake_amount": "unlimited",
+      "tradable_balance_ratio": 0.99,
+      "dry_run": true,
+      "dry_run_wallet": 1000,
+      "cancel_open_orders_on_exit": false,
+      "exchange": {
+        "name": "binance",
+        "key": "",
+        "secret": "",
+        "ccxt_sync_config": {},
+        "ccxt_async_config": {}
+      },
+      "api_server": {
+        "enabled": true,
+        "listen_ip_address": "0.0.0.0",
+        "listen_port": 8080,
+        "verbosity": "error",
+        "enable_openapi": true,
+        "jwt_secret_key": "change-me-to-a-random-string",
+        "CORS_origins": [],
+        "username": "freqtrader",
+        "password": "freqtrader"
+      },
+      "bot_name": "freqtrade",
+      "initial_state": "running",
+      "internals": {
+        "process_throttle_secs": 5
+      }
+    }

--- a/freqtrade/configmap.yaml
+++ b/freqtrade/configmap.yaml
@@ -17,8 +17,6 @@ data:
       "cancel_open_orders_on_exit": false,
       "exchange": {
         "name": "binance",
-        "key": "",
-        "secret": "",
         "ccxt_sync_config": {},
         "ccxt_async_config": {}
       },
@@ -28,10 +26,7 @@ data:
         "listen_port": 8080,
         "verbosity": "error",
         "enable_openapi": true,
-        "jwt_secret_key": "change-me-to-a-random-string",
-        "CORS_origins": [],
-        "username": "freqtrader",
-        "password": "freqtrader"
+        "CORS_origins": []
       },
       "bot_name": "freqtrade",
       "initial_state": "running",

--- a/freqtrade/deployment.yaml
+++ b/freqtrade/deployment.yaml
@@ -22,6 +22,32 @@ spec:
           - trade
           - --config
           - /freqtrade/user_data/config.json
+        env:
+        - name: FREQTRADE__EXCHANGE__KEY
+          valueFrom:
+            secretKeyRef:
+              name: freqtrade-secrets
+              key: EXCHANGE_KEY
+        - name: FREQTRADE__EXCHANGE__SECRET
+          valueFrom:
+            secretKeyRef:
+              name: freqtrade-secrets
+              key: EXCHANGE_SECRET
+        - name: FREQTRADE__API_SERVER__JWT_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: freqtrade-secrets
+              key: JWT_SECRET_KEY
+        - name: FREQTRADE__API_SERVER__USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: freqtrade-secrets
+              key: API_USERNAME
+        - name: FREQTRADE__API_SERVER__PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: freqtrade-secrets
+              key: API_PASSWORD
         ports:
         - containerPort: 8080
           name: http

--- a/freqtrade/deployment.yaml
+++ b/freqtrade/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: freqtrade
+  namespace: freqtrade
+  labels:
+    app: freqtrade
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: freqtrade
+  template:
+    metadata:
+      labels:
+        app: freqtrade
+    spec:
+      containers:
+      - name: freqtrade
+        image: freqtradeorg/freqtrade:2025.3
+        args:
+          - trade
+          - --config
+          - /freqtrade/user_data/config.json
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "50m"
+          limits:
+            memory: "1Gi"
+            cpu: "1"
+        livenessProbe:
+          httpGet:
+            path: /api/v1/ping
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /api/v1/ping
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        volumeMounts:
+        - name: config
+          mountPath: /freqtrade/user_data/config.json
+          subPath: config.json
+        - name: user-data
+          mountPath: /freqtrade/user_data/data
+      volumes:
+      - name: config
+        configMap:
+          name: freqtrade-config
+      - name: user-data
+        persistentVolumeClaim:
+          claimName: freqtrade-data

--- a/freqtrade/deployment.yaml
+++ b/freqtrade/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: freqtrade
-        image: freqtradeorg/freqtrade:2025.3
+        image: freqtradeorg/freqtrade:stable
         args:
           - trade
           - --config
@@ -72,15 +72,15 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 5
         volumeMounts:
+        - name: user-data
+          mountPath: /freqtrade/user_data
         - name: config
           mountPath: /freqtrade/user_data/config.json
           subPath: config.json
-        - name: user-data
-          mountPath: /freqtrade/user_data/data
       volumes:
-      - name: config
-        configMap:
-          name: freqtrade-config
       - name: user-data
         persistentVolumeClaim:
           claimName: freqtrade-data
+      - name: config
+        configMap:
+          name: freqtrade-config

--- a/freqtrade/deployment.yaml
+++ b/freqtrade/deployment.yaml
@@ -23,16 +23,6 @@ spec:
           - --config
           - /freqtrade/user_data/config.json
         env:
-        - name: FREQTRADE__EXCHANGE__KEY
-          valueFrom:
-            secretKeyRef:
-              name: freqtrade-secrets
-              key: EXCHANGE_KEY
-        - name: FREQTRADE__EXCHANGE__SECRET
-          valueFrom:
-            secretKeyRef:
-              name: freqtrade-secrets
-              key: EXCHANGE_SECRET
         - name: FREQTRADE__API_SERVER__JWT_SECRET_KEY
           valueFrom:
             secretKeyRef:

--- a/freqtrade/external-secret.yaml
+++ b/freqtrade/external-secret.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: freqtrade-secrets
+  namespace: freqtrade
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  target:
+    name: freqtrade-secrets
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+  dataFrom:
+    - extract:
+        key: config

--- a/freqtrade/external-secret.yaml
+++ b/freqtrade/external-secret.yaml
@@ -18,4 +18,4 @@ spec:
           managed-by: external-secrets
   dataFrom:
     - extract:
-        key: config
+        key: shared/freqtrade

--- a/freqtrade/external-secret.yaml
+++ b/freqtrade/external-secret.yaml
@@ -18,4 +18,4 @@ spec:
           managed-by: external-secrets
   dataFrom:
     - extract:
-        key: shared/freqtrade
+        key: config

--- a/freqtrade/ingress.yaml
+++ b/freqtrade/ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: freqtrade
+  namespace: freqtrade
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  ingressClassName: nginx-internal
+  tls:
+    - hosts:
+        - freqtrade.k.shion1305.com
+  rules:
+    - host: freqtrade.k.shion1305.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: freqtrade
+                port:
+                  number: 8080

--- a/freqtrade/kustomization.yaml
+++ b/freqtrade/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: freqtrade
+
+resources:
+  - configmap.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/freqtrade/kustomization.yaml
+++ b/freqtrade/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 namespace: freqtrade
 
 resources:
+  - vault-secret-store.yaml
+  - external-secret.yaml
   - configmap.yaml
   - pvc.yaml
   - deployment.yaml

--- a/freqtrade/pvc.yaml
+++ b/freqtrade/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: freqtrade-data
+  namespace: freqtrade
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 5Gi

--- a/freqtrade/pvc.yaml
+++ b/freqtrade/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   storageClassName: longhorn
   resources:
     requests:
-      storage: 5Gi
+      storage: 50Gi

--- a/freqtrade/service.yaml
+++ b/freqtrade/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: freqtrade
+  namespace: freqtrade
+  labels:
+    app: freqtrade
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: freqtrade

--- a/freqtrade/vault-secret-store.yaml
+++ b/freqtrade/vault-secret-store.yaml
@@ -13,7 +13,7 @@ spec:
   provider:
     vault:
       server: "http://vault.vault.svc.cluster.local:8200"
-      path: "freqtrade"
+      path: "secret"
       version: "v2"
       auth:
         kubernetes:

--- a/freqtrade/vault-secret-store.yaml
+++ b/freqtrade/vault-secret-store.yaml
@@ -13,7 +13,7 @@ spec:
   provider:
     vault:
       server: "http://vault.vault.svc.cluster.local:8200"
-      path: "secret"
+      path: "freqtrade"
       version: "v2"
       auth:
         kubernetes:

--- a/freqtrade/vault-secret-store.yaml
+++ b/freqtrade/vault-secret-store.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso
+  namespace: freqtrade
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: vault
+  namespace: freqtrade
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "freqtrade"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "eso-freqtrade"
+          serviceAccountRef:
+            name: "eso"

--- a/vault/scripts/setup-eso-policies.sh
+++ b/vault/scripts/setup-eso-policies.sh
@@ -84,12 +84,12 @@ path "lumos-bot/metadata/*" {
 EOF
 echo "✓ Created policy: eso-lumos-bot"
 
-# Policy for freqtrade namespace
+# Policy for freqtrade namespace (separate KV v2 engine mounted at freqtrade/)
 vault policy write eso-freqtrade - <<EOF
-path "secret/data/shared/freqtrade" {
+path "freqtrade/data/*" {
   capabilities = ["read"]
 }
-path "secret/metadata/shared/freqtrade" {
+path "freqtrade/metadata/*" {
   capabilities = ["read", "list"]
 }
 EOF
@@ -168,4 +168,4 @@ echo "  eso-openwebui→ SA eso/openwebui                     → secret/data/sh
 echo "  eso-keycloak → SA eso/keycloak                      → secret/data/shared/keycloak"
 echo "  eso-atc      → SA eso/atc                           → atc/data/*"
 echo "  eso-lumos-bot→ SA eso/lumos-bot                     → lumos-bot/data/*"
-echo "  eso-freqtrade→ SA eso/freqtrade                    → secret/data/shared/freqtrade"
+echo "  eso-freqtrade→ SA eso/freqtrade                    → freqtrade/data/*"

--- a/vault/scripts/setup-eso-policies.sh
+++ b/vault/scripts/setup-eso-policies.sh
@@ -84,6 +84,17 @@ path "lumos-bot/metadata/*" {
 EOF
 echo "✓ Created policy: eso-lumos-bot"
 
+# Policy for freqtrade namespace
+vault policy write eso-freqtrade - <<EOF
+path "secret/data/shared/freqtrade" {
+  capabilities = ["read"]
+}
+path "secret/metadata/shared/freqtrade" {
+  capabilities = ["read", "list"]
+}
+EOF
+echo "✓ Created policy: eso-freqtrade"
+
 echo ""
 echo "=== Creating namespace-scoped Kubernetes auth roles ==="
 
@@ -135,6 +146,14 @@ vault write auth/kubernetes/role/eso-lumos-bot \
   ttl=1h
 echo "✓ Created role: eso-lumos-bot"
 
+# Freqtrade
+vault write auth/kubernetes/role/eso-freqtrade \
+  bound_service_account_names=eso \
+  bound_service_account_namespaces=freqtrade \
+  policies=eso-freqtrade \
+  ttl=1h
+echo "✓ Created role: eso-freqtrade"
+
 echo ""
 echo "=== Removing old broad policy ==="
 vault policy delete eso-policy 2>/dev/null && echo "✓ Deleted old policy: eso-policy" || echo "ⓘ Policy eso-policy not found (already removed)"
@@ -149,3 +168,4 @@ echo "  eso-openwebui→ SA eso/openwebui                     → secret/data/sh
 echo "  eso-keycloak → SA eso/keycloak                      → secret/data/shared/keycloak"
 echo "  eso-atc      → SA eso/atc                           → atc/data/*"
 echo "  eso-lumos-bot→ SA eso/lumos-bot                     → lumos-bot/data/*"
+echo "  eso-freqtrade→ SA eso/freqtrade                    → secret/data/shared/freqtrade"


### PR DESCRIPTION
## Summary
- Deploy freqtrade trading bot as a single-source ArgoCD application
- Accessible internally at `freqtrade.k.shion1305.com` via `nginx-internal` ingress
- Starts in dry-run mode with default Binance/USDT config and API server enabled on port 8080
- Uses 5Gi Longhorn PVC for persistent trade data

## Test plan
- [ ] Verify ArgoCD syncs the application successfully
- [ ] Confirm freqtrade pod starts and passes health checks (`/api/v1/ping`)
- [ ] Access `freqtrade.k.shion1305.com` from internal network and verify the FreqUI loads
- [ ] Update configmap with real exchange keys and strategy before enabling live trading