### PR TITLE
fix: add SampleStrategy to freqtrade config

### DIFF
--- a/freqtrade/configmap.yaml
+++ b/freqtrade/configmap.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   config.json: |
     {
+      "strategy": "SampleStrategy",
       "trading_mode": "spot",
       "margin_mode": "",
       "max_open_trades": 5,


### PR DESCRIPTION
## Summary
- Add `"strategy": "SampleStrategy"` to freqtrade config to fix `No strategy set` startup error
- SampleStrategy is the built-in strategy that ships with the freqtrade Docker image

## Test plan
- [ ] Verify freqtrade pod starts without strategy error