### PR TITLE
feat: load freqtrade strategy from Vault

### DIFF
--- a/freqtrade/configmap.yaml
+++ b/freqtrade/configmap.yaml
@@ -6,7 +6,6 @@ metadata:
 data:
   config.json: |
     {
-      "strategy": "SampleStrategy",
       "trading_mode": "spot",
       "margin_mode": "",
       "max_open_trades": 5,

--- a/freqtrade/deployment.yaml
+++ b/freqtrade/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       initContainers:
       - name: copy-strategy
         image: busybox:1.37
-        command: ["sh", "-c", "mkdir -p /user-data/strategies && cp /strategy/*.py /user-data/strategies/"]
+        command: ["sh", "-c", "mkdir -p /user-data/strategies && cp /strategy/*.py /user-data/strategies/ || echo 'WARN: no strategy files found'"]
         volumeMounts:
         - name: user-data
           mountPath: /user-data

--- a/freqtrade/deployment.yaml
+++ b/freqtrade/deployment.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         app: freqtrade
+      annotations:
+        reloader.stakater.com/auto: "true"
     spec:
       initContainers:
       - name: copy-strategy

--- a/freqtrade/deployment.yaml
+++ b/freqtrade/deployment.yaml
@@ -15,6 +15,15 @@ spec:
       labels:
         app: freqtrade
     spec:
+      initContainers:
+      - name: copy-strategy
+        image: busybox:1.37
+        command: ["sh", "-c", "mkdir -p /user-data/strategies && cp /strategy/*.py /user-data/strategies/"]
+        volumeMounts:
+        - name: user-data
+          mountPath: /user-data
+        - name: strategy
+          mountPath: /strategy
       containers:
       - name: freqtrade
         image: freqtradeorg/freqtrade:stable
@@ -23,6 +32,11 @@ spec:
           - --config
           - /freqtrade/user_data/config.json
         env:
+        - name: FREQTRADE__STRATEGY
+          valueFrom:
+            secretKeyRef:
+              name: freqtrade-secrets
+              key: STRATEGY
         - name: FREQTRADE__API_SERVER__JWT_SECRET_KEY
           valueFrom:
             secretKeyRef:
@@ -74,3 +88,6 @@ spec:
       - name: config
         configMap:
           name: freqtrade-config
+      - name: strategy
+        secret:
+          secretName: freqtrade-strategy

--- a/freqtrade/external-secret-strategy.yaml
+++ b/freqtrade/external-secret-strategy.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: freqtrade-strategy
+  namespace: freqtrade
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  target:
+    name: freqtrade-strategy
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+  dataFrom:
+    - extract:
+        key: strategy

--- a/freqtrade/kustomization.yaml
+++ b/freqtrade/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: freqtrade
 resources:
   - vault-secret-store.yaml
   - external-secret.yaml
+  - external-secret-strategy.yaml
   - configmap.yaml
   - pvc.yaml
   - deployment.yaml


### PR DESCRIPTION
## Summary
- Load strategy Python file from Vault secret (`freqtrade/strategy`) instead of relying on built-in strategies
- Strategy class name also loaded from Vault (`freqtrade/config` → `STRATEGY` key) via env var
- Init container copies strategy `.py` files from secret volume into PVC's `strategies/` directory
- Removed hardcoded `SampleStrategy` from configmap

## Vault setup required

**`freqtrade/config`** — add key:
| Key | Value |
|---|---|
| `STRATEGY` | Your strategy class name (e.g. `SampleStrategy`) |

**`freqtrade/strategy`** — new secret with key:
| Key | Value |
|---|---|
| `strategy.py` | Full Python source of your strategy file |

## Test plan
- [ ] Verify init container copies strategy file to `/freqtrade/user_data/strategies/`
- [ ] Verify freqtrade starts and loads the strategy without errors