### PR TITLE
fix: add required pairlists config for freqtrade

### DIFF
--- a/freqtrade/configmap.yaml
+++ b/freqtrade/configmap.yaml
@@ -52,6 +52,11 @@ data:
         "30": 0.02,
         "0": 0.04
       },
+      "pairlists": [
+        {
+          "method": "StaticPairList"
+        }
+      ],
       "stoploss": -0.10,
       "api_server": {
         "enabled": true,


### PR DESCRIPTION
## Summary
- Add `pairlists` with `StaticPairList` method to freqtrade config
- Fixes `'pairlists' is a required property` startup error
- Validated against official freqtrade Binance example config — all required fields now present

## Test plan
- [ ] Verify freqtrade pod starts without configuration errors
- [ ] Confirm API server responds at `/api/v1/ping`