### PR TITLE
feat(atc): deploy MinIO for historical source storage

### DIFF
--- a/apps/atc-app.yaml
+++ b/apps/atc-app.yaml
@@ -11,7 +11,7 @@ spec:
     path: atc
   destination:
     server: https://kubernetes.default.svc
-    namespace: postgres-operator-deployment
+    namespace: atc
   syncPolicy:
     automated:
       prune: true

--- a/atc/kustomization.yaml
+++ b/atc/kustomization.yaml
@@ -15,3 +15,7 @@ resources:
   - vault-secret-store.yaml
   - external-secret.yaml
   - deployment-gmocoin-exec-alert.yaml
+  - minio-external-secret.yaml
+  - minio-statefulset.yaml
+  - minio-service.yaml
+  - minio-ingress.yaml

--- a/atc/minio-external-secret.yaml
+++ b/atc/minio-external-secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: minio-historical-source-credentials
+  namespace: atc
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  target:
+    name: minio-historical-source-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+  data:
+    - secretKey: MINIO_PASSWORD
+      remoteRef:
+        key: minio-historical-source
+        property: MINIO_PASSWORD

--- a/atc/minio-ingress.yaml
+++ b/atc/minio-ingress.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minio-historical-source-console
+  namespace: atc
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    # MinIO Console requires WebSocket support
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+spec:
+  ingressClassName: nginx-internal
+  tls:
+    - hosts:
+        - atc-historical-source.k.shion1305.com
+  rules:
+    - host: atc-historical-source.k.shion1305.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: minio-historical-source
+                port:
+                  number: 9090

--- a/atc/minio-service.yaml
+++ b/atc/minio-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-historical-source
+  namespace: atc
+  labels:
+    app: minio-historical-source
+spec:
+  type: ClusterIP
+  selector:
+    app: minio-historical-source
+  ports:
+    - name: api
+      port: 9000
+      targetPort: 9000
+    - name: console
+      port: 9090
+      targetPort: 9090

--- a/atc/minio-statefulset.yaml
+++ b/atc/minio-statefulset.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: minio-historical-source
+  namespace: atc
+  labels:
+    app: minio-historical-source
+spec:
+  serviceName: minio-historical-source
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio-historical-source
+  template:
+    metadata:
+      labels:
+        app: minio-historical-source
+    spec:
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsNonRoot: true
+      containers:
+        - name: minio
+          image: minio/minio:RELEASE.2026-04-14T21-32-45Z
+          command:
+            - minio
+            - server
+            - /data
+            - --console-address
+            - ":9090"
+          env:
+            - name: MINIO_ROOT_USER
+              value: minio
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: minio-historical-source-credentials
+                  key: MINIO_PASSWORD
+          ports:
+            - name: api
+              containerPort: 9000
+            - name: console
+              containerPort: 9090
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: 9000
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /minio/health/ready
+              port: 9000
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            failureThreshold: 3
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: longhorn-hdd
+        resources:
+          requests:
+            storage: 500Gi

--- a/atc/minio-statefulset.yaml
+++ b/atc/minio-statefulset.yaml
@@ -13,6 +13,8 @@ spec:
       app: minio-historical-source
   template:
     metadata:
+      annotations:
+        reloader.stakater.com/auto: "true"
       labels:
         app: minio-historical-source
     spec:


### PR DESCRIPTION
- Add MinIO StatefulSet with 500Gi longhorn-hdd PVC
- Add MinIO Service exposing API (9000) and console (9090)
- Add Ingress for console at atc-historical-source.k.shion1305.com
- Add ExternalSecret pulling credentials from Vault (atc/minio-historical-source)
- Update atc-app.yaml destination namespace to atc
- Update atc kustomization to include MinIO resources


## Overview

Deploy MinIO object storage in the `atc` namespace as raw Kubernetes manifests,
accessible at `atc-historical-source.k.shion1305.com` (nginx-internal).

## Changes

| File | Description |
|------|-------------|
| `apps/atc-app.yaml` | Update destination namespace from `postgres-operator-deployment` to `atc` |
| `atc/kustomization.yaml` | Add MinIO resources |
| `atc/minio-statefulset.yaml` | MinIO StatefulSet, image `minio/minio:RELEASE.2026-04-14T21-32-45Z`, 500Gi `longhorn-hdd` PVC |
| `atc/minio-service.yaml` | ClusterIP service (API `:9000`, console `:9090`) |
| `atc/minio-external-secret.yaml` | ExternalSecret: Vault `atc/minio-historical-source` → `MINIO_ROOT_PASSWORD` |
| `atc/minio-ingress.yaml` | nginx

