### PR TITLE
feat(ingress): allow 192.168.40.0/24 on nginx-internal whitelist

### DIFF
--- a/ingress/nginx-internal-controller.yaml
+++ b/ingress/nginx-internal-controller.yaml
@@ -90,7 +90,7 @@ metadata:
 data:
   # IP whitelist for internal network
   # External users will be blocked even if they somehow reach this controller
-  whitelist-source-range: "10.130.5.0/24"
+  whitelist-source-range: "10.130.5.0/24,192.168.40.0/24"
   # Allow snippet annotations for custom configurations
   allow-snippet-annotations: "true"
   annotations-risk-level: "Critical"


### PR DESCRIPTION
## Summary
- Extend `nginx-internal` controller's `whitelist-source-range` from `10.130.5.0/24` to `10.130.5.0/24,192.168.40.0/24` so clients on the LAN subnet can reach internal-only services.
- Unblocks access to `atc-historical-source.k.shion1305.com` (SeaweedFS filer UI) and any other `nginx-internal` ingress from LAN hosts — previously returning 403 at the controller.

## Test plan
- [ ] ArgoCD syncs the `ingress` app cleanly
- [ ] `ingress-nginx-internal-controller` ConfigMap shows the updated whitelist
- [ ] From a 192.168.40.0/24 host, `https://atc-historical-source.k.shion1305.com` loads the SeaweedFS filer UI
- [ ] From a 10.130.5.0/24 host, existing internal services still work