### PR TITLE
fix(argocd): bump probe timeouts to tolerate node pressure

### DIFF
--- a/argocd/values.yaml
+++ b/argocd/values.yaml
@@ -129,6 +129,11 @@ server:
   # Keep existing service
   service:
     type: ClusterIP
+  # Increase probe timeouts to tolerate transient node pressure (default 1s caused crashloops)
+  livenessProbe:
+    timeoutSeconds: 5
+  readinessProbe:
+    timeoutSeconds: 5
 # Dex configuration
 dex:
   enabled: true
@@ -138,9 +143,15 @@ redis:
 # Application controller
 controller:
   replicas: 1
+  readinessProbe:
+    timeoutSeconds: 5
 # Repo server
 repoServer:
   replicas: 1
+  livenessProbe:
+    timeoutSeconds: 5
+  readinessProbe:
+    timeoutSeconds: 5
 # ApplicationSet controller
 applicationSet:
   replicas: 1


### PR DESCRIPTION
## Summary
- Set `timeoutSeconds: 5` on liveness/readiness probes for `argocd-server`, `argocd-repo-server`, and `argocd-application-controller` via Helm values.

## Why
The Helm chart default of `timeoutSeconds: 1` caused all three components to crashloop on `shion-ubuntu-2505` while the node was under heavy memory/load pressure (memory exhaustion, load avg >100). Probes timed out before responses returned, kubelet killed and restarted containers, blocking GitOps sync entirely. A manual `kubectl patch` was reverted by ArgoCD selfHeal — this baseline must live in `values.yaml` to be durable.

## Test plan
- [ ] Merge and verify ArgoCD `argocd` Application reconciles
- [ ] Confirm new ReplicaSets/StatefulSet pods come up Ready with 0 restart growth
- [ ] Confirm `kubectl get deployment argocd-server -n argocd -o jsonpath='{.spec.template.spec.containers[0].livenessProbe.timeoutSeconds}'` returns `5`