### PR TITLE
feat(envoy-gateway): introduce Envoy Gateway PoC alongside ingress-nginx

### DIFF
--- a/apps/cert-manager-app.yaml
+++ b/apps/cert-manager-app.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+  namespace: argocd
+spec:
+  project: default
+  sources:
+    - repoURL: https://charts.jetstack.io
+      chart: cert-manager
+      targetRevision: v1.16.2
+      helm:
+        valueFiles:
+          - $values/cert-manager/values.yaml
+    - repoURL: https://github.com/Shion1305/k8s-GitOps.git
+      targetRevision: HEAD
+      ref: values
+    - repoURL: https://github.com/Shion1305/k8s-GitOps.git
+      targetRevision: HEAD
+      path: cert-manager
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/apps/envoy-gateway-app.yaml
+++ b/apps/envoy-gateway-app.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: envoy-gateway
+  namespace: argocd
+spec:
+  project: default
+  sources:
+    - repoURL: oci://docker.io/envoyproxy
+      chart: gateway-helm
+      targetRevision: v1.2.4
+      helm:
+        releaseName: envoy-gateway
+        valueFiles:
+          - $values/envoy-gateway/values.yaml
+    - repoURL: https://github.com/Shion1305/k8s-GitOps.git
+      targetRevision: HEAD
+      ref: values
+    - repoURL: https://github.com/Shion1305/k8s-GitOps.git
+      targetRevision: HEAD
+      path: envoy-gateway
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: envoy-gateway-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/apps/gateway-api-crds-app.yaml
+++ b/apps/gateway-api-crds-app.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gateway-api-crds
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/kubernetes-sigs/gateway-api.git
+    targetRevision: v1.2.1
+    path: config/crd/standard
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
+      - Replace=true

--- a/cert-manager/cluster-issuer.yaml
+++ b/cert-manager/cluster-issuer.yaml
@@ -1,0 +1,33 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: shion1305@gmail.com
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+    solvers:
+      - dns01:
+          cloudflare:
+            apiTokenSecretRef:
+              name: cloudflare-api-token
+              key: api-token
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: shion1305@gmail.com
+    privateKeySecretRef:
+      name: letsencrypt-staging-account-key
+    solvers:
+      - dns01:
+          cloudflare:
+            apiTokenSecretRef:
+              name: cloudflare-api-token
+              key: api-token

--- a/cert-manager/external-secret.yaml
+++ b/cert-manager/external-secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cloudflare-api-token
+  namespace: cert-manager
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-system
+    kind: SecretStore
+  target:
+    name: cloudflare-api-token
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+  data:
+    - secretKey: api-token
+      remoteRef:
+        key: cert-manager
+        property: CF_API_TOKEN

--- a/cert-manager/kustomization.yaml
+++ b/cert-manager/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - serviceaccount-eso.yaml
+  - secret-store.yaml
+  - external-secret.yaml
+  - cluster-issuer.yaml

--- a/cert-manager/namespace.yaml
+++ b/cert-manager/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager

--- a/cert-manager/secret-store.yaml
+++ b/cert-manager/secret-store.yaml
@@ -1,0 +1,19 @@
+# Namespace-scoped SecretStore for the Vault `system/` KV mount.
+# Backed by the `eso-cert-manager` role bound to the `eso` SA in this namespace.
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: vault-system
+  namespace: cert-manager
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "system"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "eso-cert-manager"
+          serviceAccountRef:
+            name: eso

--- a/cert-manager/serviceaccount-eso.yaml
+++ b/cert-manager/serviceaccount-eso.yaml
@@ -1,0 +1,7 @@
+# Service account used by ExternalSecrets to authenticate against the
+# Vault role `eso-cert-manager`, which permits read on `system/cert-manager` only.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso
+  namespace: cert-manager

--- a/cert-manager/values.yaml
+++ b/cert-manager/values.yaml
@@ -1,0 +1,36 @@
+crds:
+  enabled: true
+  keep: true
+
+replicaCount: 1
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+
+webhook:
+  resources:
+    requests:
+      cpu: 20m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+
+cainjector:
+  resources:
+    requests:
+      cpu: 20m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 256Mi
+
+prometheus:
+  enabled: true
+  servicemonitor:
+    enabled: true

--- a/envoy-gateway/certificates.yaml
+++ b/envoy-gateway/certificates.yaml
@@ -1,0 +1,31 @@
+# Wildcard certificates issued via Let's Encrypt DNS-01 (Cloudflare).
+# Stored in the envoy-gateway-system namespace so Gateway resources can reference them.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-i-shion1305-com
+  namespace: envoy-gateway-system
+spec:
+  secretName: wildcard-i-shion1305-com-tls
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  commonName: "*.i.shion1305.com"
+  dnsNames:
+    - "*.i.shion1305.com"
+    - "i.shion1305.com"
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-shion1305-com
+  namespace: envoy-gateway-system
+spec:
+  secretName: wildcard-shion1305-com-tls
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  commonName: "*.shion1305.com"
+  dnsNames:
+    - "*.shion1305.com"
+    - "shion1305.com"

--- a/envoy-gateway/envoyproxy.yaml
+++ b/envoy-gateway/envoyproxy.yaml
@@ -1,0 +1,36 @@
+# Data plane configuration for the Envoy Gateway controller.
+# Pins the Envoy proxy DaemonSet to instance-k8s-proxy and binds 80/443 via hostNetwork
+# so that *.i.shion1305.com (10.130.5.21) and test-external.shion1305.com (141.147.189.36)
+# resolve directly to this node.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: instance-k8s-proxy
+  namespace: envoy-gateway-system
+spec:
+  mergeGateways: true
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        replicas: 1
+        pod:
+          nodeSelector:
+            kubernetes.io/hostname: instance-k8s-proxy
+          tolerations:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+              effect: NoSchedule
+          hostNetwork: true
+          dnsPolicy: ClusterFirstWithHostNet
+        container:
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+      envoyService:
+        # Pod uses hostNetwork so the Service is informational only.
+        type: ClusterIP

--- a/envoy-gateway/gateway-external.yaml
+++ b/envoy-gateway/gateway-external.yaml
@@ -1,0 +1,25 @@
+# External Gateway: publicly reachable via 141.147.189.36 (instance-k8s-proxy).
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: external
+  namespace: envoy-gateway-system
+spec:
+  gatewayClassName: envoy-default
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: wildcard-shion1305-com-tls
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/envoy-gateway/gateway-internal.yaml
+++ b/envoy-gateway/gateway-internal.yaml
@@ -1,0 +1,29 @@
+# Internal Gateway: serves *.i.shion1305.com (resolves to 10.130.5.21).
+# IP-level access control is provided by the network topology — the WireGuard CIDR
+# is the only path to 10.130.5.21 — so no SecurityPolicy allowlist is attached here.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: internal
+  namespace: envoy-gateway-system
+spec:
+  gatewayClassName: envoy-default
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      hostname: "*.i.shion1305.com"
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https
+      port: 443
+      protocol: HTTPS
+      hostname: "*.i.shion1305.com"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: wildcard-i-shion1305-com-tls
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/envoy-gateway/gatewayclass.yaml
+++ b/envoy-gateway/gatewayclass.yaml
@@ -1,0 +1,11 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: envoy-default
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: instance-k8s-proxy
+    namespace: envoy-gateway-system

--- a/envoy-gateway/kustomization.yaml
+++ b/envoy-gateway/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - envoyproxy.yaml
+  - gatewayclass.yaml
+  - certificates.yaml
+  - gateway-internal.yaml
+  - gateway-external.yaml

--- a/envoy-gateway/values.yaml
+++ b/envoy-gateway/values.yaml
@@ -1,0 +1,19 @@
+deployment:
+  envoyGateway:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+
+config:
+  envoyGateway:
+    logging:
+      level:
+        default: info
+    provider:
+      type: Kubernetes
+    gateway:
+      controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/guestbook/httproute-external.yaml
+++ b/guestbook/httproute-external.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: guestbook-external
+  namespace: guestbook
+spec:
+  parentRefs:
+    - name: external
+      namespace: envoy-gateway-system
+      sectionName: https
+  hostnames:
+    - test-external.shion1305.com
+  rules:
+    - backendRefs:
+        - name: guestbook-ui
+          port: 80

--- a/guestbook/httproute-internal.yaml
+++ b/guestbook/httproute-internal.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: guestbook-internal
+  namespace: guestbook
+spec:
+  parentRefs:
+    - name: internal
+      namespace: envoy-gateway-system
+      sectionName: https
+  hostnames:
+    - guestbook.i.shion1305.com
+  rules:
+    - backendRefs:
+        - name: guestbook-ui
+          port: 80

--- a/guestbook/kustomization.yaml
+++ b/guestbook/kustomization.yaml
@@ -5,3 +5,6 @@ resources:
   - redis-master-service.yaml
   - guestbook-ui-deployment.yaml
   - guestbook-ui-svc.yaml
+  - reference-grant.yaml
+  - httproute-internal.yaml
+  - httproute-external.yaml

--- a/guestbook/reference-grant.yaml
+++ b/guestbook/reference-grant.yaml
@@ -1,0 +1,14 @@
+# Allows Gateways in envoy-gateway-system to attach HTTPRoutes living in the guestbook namespace.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-envoy-gateway
+  namespace: guestbook
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: envoy-gateway-system
+  to:
+    - group: ""
+      kind: Service

--- a/vault/scripts/setup-eso-policies.sh
+++ b/vault/scripts/setup-eso-policies.sh
@@ -95,6 +95,17 @@ path "freqtrade/metadata/*" {
 EOF
 echo "✓ Created policy: eso-freqtrade"
 
+# Policy for cert-manager namespace (system/ KV v2 mount, cert-manager only)
+vault policy write eso-cert-manager - <<EOF
+path "system/data/cert-manager" {
+  capabilities = ["read"]
+}
+path "system/metadata/cert-manager" {
+  capabilities = ["read", "list"]
+}
+EOF
+echo "✓ Created policy: eso-cert-manager"
+
 echo ""
 echo "=== Creating namespace-scoped Kubernetes auth roles ==="
 
@@ -154,6 +165,14 @@ vault write auth/kubernetes/role/eso-freqtrade \
   ttl=1h
 echo "✓ Created role: eso-freqtrade"
 
+# cert-manager
+vault write auth/kubernetes/role/eso-cert-manager \
+  bound_service_account_names=eso \
+  bound_service_account_namespaces=cert-manager \
+  policies=eso-cert-manager \
+  ttl=1h
+echo "✓ Created role: eso-cert-manager"
+
 echo ""
 echo "=== Removing old broad policy ==="
 vault policy delete eso-policy 2>/dev/null && echo "✓ Deleted old policy: eso-policy" || echo "ⓘ Policy eso-policy not found (already removed)"
@@ -169,3 +188,4 @@ echo "  eso-keycloak → SA eso/keycloak                      → secret/data/sh
 echo "  eso-atc      → SA eso/atc                           → atc/data/*"
 echo "  eso-lumos-bot→ SA eso/lumos-bot                     → lumos-bot/data/*"
 echo "  eso-freqtrade→ SA eso/freqtrade                    → freqtrade/data/*"
+echo "  eso-cert-manager→ SA eso/cert-manager              → system/data/cert-manager"


### PR DESCRIPTION
## Summary
- Stand up cert-manager (Let's Encrypt + Cloudflare DNS-01), Gateway API CRDs, and Envoy Gateway on `instance-k8s-proxy` without touching the existing ingress-nginx controllers.
- Internal traffic (`*.i.shion1305.com` → `10.130.5.21`) and external traffic (`test-external.shion1305.com` → `141.147.189.36`) terminate on the same node via `hostNetwork`, with `mergeGateways: true` letting one Envoy Pod serve both `internal` and `external` Gateway resources.
- Guestbook is exposed through both Gateways as the pilot HTTPRoute (`guestbook.i.shion1305.com` and `test-external.shion1305.com`).

## Architecture
- **cert-manager** (`v1.16.2`) with a `letsencrypt-prod` and `letsencrypt-staging` `ClusterIssuer`, both using Cloudflare DNS-01.
- The Cloudflare API token is fetched from Vault `system/cert-manager` via a namespace-scoped `SecretStore` backed by a new `eso-cert-manager` Vault role/policy (added to `vault/scripts/setup-eso-policies.sh`).
- **Gateway API** standard CRDs at `v1.2.1`.
- **Envoy Gateway** (`v1.2.4`) with a single `GatewayClass` (`envoy-default`) parameterised by an `EnvoyProxy` that pins the data plane to `instance-k8s-proxy` with `hostNetwork`.
- Two Gateways share the Envoy listener via `mergeGateways: true`:
  - `internal` (`*.i.shion1305.com`, wildcard cert via cert-manager). No SecurityPolicy allowlist — only the WireGuard CIDR can reach `10.130.5.21`.
  - `external` (`*.shion1305.com`, wildcard cert via cert-manager). Public-facing.
- ingress-nginx controllers are left untouched and continue to serve everything else.

## Pre-merge prerequisites
1. Cloudflare API token (`Zone.DNS:Edit` for `shion1305.com`) is already stored at Vault `system/cert-manager` (key `CF_API_TOKEN`).
2. New `eso-cert-manager` Vault role/policy applied via `bash vault/scripts/setup-eso-policies.sh`.

## Post-merge bootstrap
ArgoCD does not auto-discover new `Application` manifests, so apply the three new apps once:
```
kubectl apply -f apps/gateway-api-crds-app.yaml
kubectl apply -f apps/cert-manager-app.yaml
kubectl apply -f apps/envoy-gateway-app.yaml
```

## Test plan
- [ ] `kubectl get crd | grep gateway.networking.k8s.io` lists Gateway, HTTPRoute, GatewayClass, ReferenceGrant.
- [ ] `kubectl get clusterissuer letsencrypt-prod` shows `Ready=True`.
- [ ] `kubectl get externalsecret -n cert-manager cloudflare-api-token` shows `SecretSynced=True` and the Secret `cloudflare-api-token` exists.
- [ ] `kubectl get pods -n envoy-gateway-system` shows the controller and one Envoy Pod scheduled on `instance-k8s-proxy`.
- [ ] `kubectl get certificate -n envoy-gateway-system` shows both wildcard certs `Ready=True` (DNS-01 may take a few minutes).
- [ ] `kubectl get gateway -n envoy-gateway-system` shows both Gateways `Programmed=True`.
- [ ] `kubectl get httproute -n guestbook` shows both routes `Accepted=True`.
- [ ] From inside WireGuard: `https://guestbook.i.shion1305.com` returns the hello-kubernetes page with a valid Let's Encrypt cert for `*.i.shion1305.com`.
- [ ] From the public internet: `https://test-external.shion1305.com` returns the hello-kubernetes page with a valid Let's Encrypt cert for `*.shion1305.com`.
- [ ] Existing nginx-served hosts (e.g. `argocd.k.shion1305.com`, `grafana.k.shion1305.com`) continue to work unchanged.