### PR TITLE
fix(envoy-gateway): drop oci:// prefix from repoURL

### DIFF
--- a/apps/envoy-gateway-app.yaml
+++ b/apps/envoy-gateway-app.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: default
   sources:
-    - repoURL: oci://docker.io/envoyproxy
+    - repoURL: docker.io/envoyproxy
       chart: gateway-helm
       targetRevision: v1.2.4
       helm:


### PR DESCRIPTION
## Summary
- Remove the explicit `oci://` scheme from the `envoy-gateway` ArgoCD Application's Helm source.

## Why
PR #229 introduced this app with `repoURL: oci://docker.io/envoyproxy` + `chart: gateway-helm`. ArgoCD adds the `oci://` scheme implicitly when constructing the OCI manifest URL from `<repoURL>/<chart>`. With the prefix already present, ArgoCD parsed the URL incorrectly and requested:

```
HEAD https://registry-1.docker.io/v2/envoyproxy/manifests/v1.2.4
```

Docker Hub returned `403 Forbidden` because the path is missing the `gateway-helm` segment. The chart actually lives at `oci://docker.io/envoyproxy/gateway-helm` per the official install docs (https://gateway.envoyproxy.io/v1.2/install/install-helm/).

After this fix, ArgoCD will request the correct path:
```
HEAD https://registry-1.docker.io/v2/envoyproxy/gateway-helm/manifests/v1.2.4
```

## Impact
Currently the `envoy-gateway` Application is in `ComparisonError` state with no pods running, so the Gateways from PR #229 have no data plane and the guestbook HTTPRoutes can't serve traffic. This unblocks the PoC.

## Test plan
- [ ] Merge and let ArgoCD reconcile
- [ ] `kubectl get app envoy-gateway -n argocd` reports Synced + Healthy
- [ ] `kubectl get pods -n envoy-gateway-system` shows controller + envoy data plane running
- [ ] `kubectl get gateway -A` shows both gateways with Programmed=True
- [ ] `curl -k https://guestbook.i.shion1305.com/` from inside the WireGuard network returns guestbook
- [ ] `curl https://test-external.shion1305.com/` from outside returns guestbook