### PR TITLE
fix(envoy-gateway): apply hostNetwork via StrategicMerge patch

### DIFF
--- a/envoy-gateway/envoyproxy.yaml
+++ b/envoy-gateway/envoyproxy.yaml
@@ -1,7 +1,12 @@
 # Data plane configuration for the Envoy Gateway controller.
-# Pins the Envoy proxy DaemonSet to instance-k8s-proxy and binds 80/443 via hostNetwork
+# Pins the Envoy proxy Pod to instance-k8s-proxy and binds 80/443 via hostNetwork
 # so that *.i.shion1305.com (10.130.5.21) and test-external.shion1305.com (141.147.189.36)
 # resolve directly to this node.
+#
+# hostNetwork / dnsPolicy are not native EnvoyProxy CRD fields (removed in v1.0.0,
+# tracking issue: envoyproxy/gateway#1928). The official escape hatch is the
+# StrategicMerge patch on envoyDeployment. NET_BIND_SERVICE is required because
+# the data plane binds privileged ports (<1024).
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyProxy
 metadata:
@@ -21,8 +26,6 @@ spec:
             - key: node-role.kubernetes.io/control-plane
               operator: Exists
               effect: NoSchedule
-          hostNetwork: true
-          dnsPolicy: ClusterFirstWithHostNet
         container:
           resources:
             requests:
@@ -31,6 +34,20 @@ spec:
             limits:
               cpu: 1000m
               memory: 512Mi
+        patch:
+          type: StrategicMerge
+          value:
+            spec:
+              template:
+                spec:
+                  hostNetwork: true
+                  dnsPolicy: ClusterFirstWithHostNet
+                  containers:
+                    - name: envoy
+                      securityContext:
+                        capabilities:
+                          add:
+                            - NET_BIND_SERVICE
       envoyService:
         # Pod uses hostNetwork so the Service is informational only.
         type: ClusterIP


### PR DESCRIPTION
## Summary
- Switch `EnvoyProxy/instance-k8s-proxy` to inject `hostNetwork`, `dnsPolicy`, and `NET_BIND_SERVICE` via the StrategicMerge patch escape hatch.

## Why
PR #229 set `spec.provider.kubernetes.envoyDeployment.pod.hostNetwork` and `dnsPolicy` directly on the EnvoyProxy CR. ArgoCD rejected the resource because those fields aren't in the EnvoyProxy v1alpha1 schema:

```
EnvoyProxy/instance-k8s-proxy: failed to create typed patch object
(envoy-gateway-system/instance-k8s-proxy; gateway.envoyproxy.io/v1alpha1, Kind=EnvoyProxy):
.spec.provider.kubernetes.envoyDeployment.pod.hostNetwork: field not declared in schema
```

Native `hostNetwork` support was removed in Envoy Gateway v1.0.0 (tracking issue: envoyproxy/gateway#1928) and never reinstated through v1.7.x. The official workaround is the StrategicMerge `patch` field on `envoyDeployment`, which lets us inject arbitrary Pod-spec fields. We also need `NET_BIND_SERVICE` on the envoy container so it can bind ports 80/443 (<1024) under hostNetwork.

## Cascading effects this unblocks
With the EnvoyProxy CR rejected:
- GatewayClass `envoy-default` shows `Accepted=False` (`InvalidParameters: envoyproxy referenced by gatewayclass is not found`).
- Gateways `internal` and `external` stay `Programmed=Unknown` (`Waiting for controller`).
- No envoy data plane Pod is created, so HTTPRoutes have no listener.

After this fix, ArgoCD should apply the EnvoyProxy CR, the controller will reconcile the GatewayClass, and the data plane Deployment will roll out on `instance-k8s-proxy`.

## Test plan
- [ ] Merge and let ArgoCD reconcile
- [ ] `kubectl get envoyproxy -A` lists `instance-k8s-proxy`
- [ ] `kubectl get gatewayclass envoy-default` shows `Accepted=True`
- [ ] `kubectl get gateway -A` shows both gateways with `Programmed=True`
- [ ] `kubectl get pods -n envoy-gateway-system -l gateway.envoyproxy.io/owning-gateway-namespace=envoy-gateway-system` shows the envoy data plane on `instance-k8s-proxy` with `hostNetwork: true`
- [ ] `curl -k https://guestbook.i.shion1305.com/` from inside WireGuard returns guestbook
- [ ] `curl https://test-external.shion1305.com/` from outside returns guestbook