### PR TITLE
fix(envoy-gateway): pass --base-id 1 to avoid clash with cilium-envoy

### DIFF
--- a/envoy-gateway/envoyproxy.yaml
+++ b/envoy-gateway/envoyproxy.yaml
@@ -7,6 +7,10 @@
 # tracking issue: envoyproxy/gateway#1928). The official escape hatch is the
 # StrategicMerge patch on envoyDeployment. NET_BIND_SERVICE is required because
 # the data plane binds privileged ports (<1024).
+#
+# --base-id 1 is required because Cilium runs its own Envoy (cilium-envoy) on
+# the same node in the host network namespace. Both default to base-id=0 and
+# fight over the shared-memory domain socket (errno=98 EADDRINUSE on bind).
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyProxy
 metadata:
@@ -14,6 +18,9 @@ metadata:
   namespace: envoy-gateway-system
 spec:
   mergeGateways: true
+  extraArgs:
+    - --base-id
+    - "1"
   provider:
     type: Kubernetes
     kubernetes:


### PR DESCRIPTION
## Summary
- Add `extraArgs: [--base-id, \"1\"]` to the EnvoyProxy CR so the data plane can coexist with cilium-envoy on the same host.

## Why
After PR #231 the EnvoyProxy CR applied successfully and the data plane Pod was scheduled on `instance-k8s-proxy` with `hostNetwork: true`. The container then crash-looped (5 restarts) with:

```
unable to bind domain socket with base_id=0, id=0, errno=98 (see --base-id option)
```

`errno=98` is `EADDRINUSE`. The cause is that Cilium runs its own Envoy (`kube-system/cilium-envoy-72hhq`) on every node, also in the host network namespace, for L7 policy enforcement. Both Envoy processes default to `base-id=0` and contend for the same Unix domain socket used for inter-process shared memory.

[Envoy's `--base-id` option](https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-base-id) was designed exactly for this case: it scopes the shared-memory region per Envoy instance, allowing multiple Envoy processes to coexist on the same host. Setting our data plane to `base-id=1` (cilium-envoy stays at the default 0) eliminates the collision.

The EnvoyProxy CRD's `spec.extraArgs` is passed straight to the envoy container's command line.

## Test plan
- [ ] Merge and let ArgoCD reconcile
- [ ] `kubectl get pods -n envoy-gateway-system -l gateway.envoyproxy.io/owning-gateway-namespace=envoy-gateway-system` shows the envoy data plane Running 2/2 (no restarts)
- [ ] `kubectl logs ...` shows no `errno=98` lines
- [ ] `kubectl get gateway -A` shows both gateways with `Programmed=True`
- [ ] `curl -k https://guestbook.i.shion1305.com/` from inside WireGuard returns guestbook
- [ ] `curl https://test-external.shion1305.com/` from outside returns guestbook