### PR TITLE
fix(envoy-gateway): bind 80/443 directly via useListenerPortAsContainerPort

### DIFF
--- a/envoy-gateway/envoyproxy.yaml
+++ b/envoy-gateway/envoyproxy.yaml
@@ -11,6 +11,12 @@
 # --base-id 1 is required because Cilium runs its own Envoy (cilium-envoy) on
 # the same node in the host network namespace. Both default to base-id=0 and
 # fight over the shared-memory domain socket (errno=98 EADDRINUSE on bind).
+#
+# useListenerPortAsContainerPort: true makes Envoy bind the Gateway's listener
+# ports directly (80/443) instead of the default 10000-offset ports
+# (10080/10443). Required for hostNetwork because there is no Service in front
+# to remap ports. NET_BIND_SERVICE (set in the patch below) lets the unprivileged
+# envoy user bind ports <1024.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyProxy
 metadata:
@@ -18,6 +24,7 @@ metadata:
   namespace: envoy-gateway-system
 spec:
   mergeGateways: true
+  useListenerPortAsContainerPort: true
   extraArgs:
     - --base-id
     - "1"


### PR DESCRIPTION
## Summary
- Set `useListenerPortAsContainerPort: true` on the EnvoyProxy CR so the data plane binds the Gateway's listener ports (80/443) directly instead of the +10000-offset defaults (10080/10443).

## Why
After PR #232 the data plane Pod runs Running 2/2 with `hostNetwork: true` on `instance-k8s-proxy`, both wildcard certs are issued, and both Gateways report `Programmed=True`. But external traffic to `https://test-external.shion1305.com/` (141.147.189.36:443) is rejected with `Connection refused`.

`ss -tlnp` on the node shows what envoy is actually listening on:

```
LISTEN  0.0.0.0:10080  ← Gateway port 80 + 10000 offset
LISTEN  0.0.0.0:10443  ← Gateway port 443 + 10000 offset
LISTEN  0.0.0.0:19001  ← readiness probe
LISTEN  127.0.0.1:19000 ← admin
```

Envoy Gateway applies a +10000 offset by default so the unprivileged envoy user can bind without `NET_BIND_SERVICE`, then puts a Service in front that remaps `80 -> 10080` and `443 -> 10443`. Under `hostNetwork: true` there is no Service in the request path — clients hit the node's IP directly — so `:80` / `:443` have no listener and the kernel returns RST.

`useListenerPortAsContainerPort: true` disables the offset. `NET_BIND_SERVICE` was already granted via the StrategicMerge patch in PR #231, so envoy can bind the privileged ports as a non-root user.

## Test plan
- [ ] Merge and let ArgoCD reconcile
- [ ] On `instance-k8s-proxy`: `sudo ss -tlnp | grep -E ':(80|443) '` shows envoy listening on both
- [ ] `curl https://test-external.shion1305.com/` from outside returns guestbook (no `Connection refused`)
- [ ] `curl --resolve guestbook.i.shion1305.com:443:10.130.5.21 https://guestbook.i.shion1305.com/` from inside the cluster returns guestbook
- [ ] `curl http://test-external.shion1305.com/` returns guestbook (or a 301 if we add a redirect later)