### PR TITLE
fix(envoy-gateway): move useListenerPortAsContainerPort under provider.kubernetes

### DIFF
--- a/envoy-gateway/envoyproxy.yaml
+++ b/envoy-gateway/envoyproxy.yaml
@@ -24,13 +24,13 @@ metadata:
   namespace: envoy-gateway-system
 spec:
   mergeGateways: true
-  useListenerPortAsContainerPort: true
   extraArgs:
     - --base-id
     - "1"
   provider:
     type: Kubernetes
     kubernetes:
+      useListenerPortAsContainerPort: true
       envoyDeployment:
         replicas: 1
         pod:


### PR DESCRIPTION
## Summary
- Move `useListenerPortAsContainerPort: true` from `spec` directly to its correct position at `spec.provider.kubernetes`.

## Why
PR #233 placed the field at `spec.useListenerPortAsContainerPort`, but the EnvoyProxy v1alpha1 CRD declares it under `spec.provider.kubernetes`. ArgoCD rejected the resource:

```
failed to calculate diff: error calculating structured merge diff:
error building typed value from config resource:
.spec.useListenerPortAsContainerPort: field not declared in schema
```

Verified with:
```sh
kubectl get crd envoyproxies.gateway.envoyproxy.io -o json | python3 -c "
import json, sys
schema = json.load(sys.stdin)['spec']['versions'][0]['schema']['openAPIV3Schema']
def find(o, p=''):
  if isinstance(o, dict):
    for k, v in o.items():
      if k == 'useListenerPortAsContainerPort': print(p + '.' + k)
      find(v, p + '.' + k)
find(schema)"
# .properties.spec.properties.provider.properties.kubernetes.properties.useListenerPortAsContainerPort
```

## Test plan
- [ ] Merge and let ArgoCD reconcile (or `argocd app sync envoy-gateway` / `kubectl annotate app envoy-gateway argocd.argoproj.io/refresh=hard`)
- [ ] `kubectl get app envoy-gateway -n argocd` reports Synced
- [ ] On `instance-k8s-proxy`: `sudo ss -tlnp | grep -E ':(80|443) '` shows envoy listening on both
- [ ] `curl https://test-external.shion1305.com/` from outside returns guestbook
- [ ] `curl --resolve guestbook.i.shion1305.com:443:10.130.5.21 https://guestbook.i.shion1305.com/` returns guestbook