### PR TITLE
fix(envoy-gateway): allow NET_BIND_SERVICE to take effect on envoy container

### DIFF
--- a/envoy-gateway/envoyproxy.yaml
+++ b/envoy-gateway/envoyproxy.yaml
@@ -59,6 +59,12 @@ spec:
                   containers:
                     - name: envoy
                       securityContext:
+                        # allowPrivilegeEscalation must be true so the
+                        # NET_BIND_SERVICE capability can be promoted into the
+                        # process's effective set; without it, the kernel keeps
+                        # the cap in permitted-only and bind(80/443) fails with
+                        # EACCES under runAsNonRoot.
+                        allowPrivilegeEscalation: true
                         capabilities:
                           add:
                             - NET_BIND_SERVICE


### PR DESCRIPTION
## Summary
- Set `allowPrivilegeEscalation: true` on the envoy container's securityContext so the previously granted `NET_BIND_SERVICE` capability actually takes effect.

## Why
After PR #234 the EnvoyProxy CR is accepted and `useListenerPortAsContainerPort: true` makes envoy attempt to bind 80/443 directly. But the data plane still cannot serve traffic — `ss -tlnp` shows nothing on 80/443, and the envoy container logs:

```
cannot bind '0.0.0.0:80': Permission denied
cannot bind '0.0.0.0:443': Permission denied
```

The pod runs as UID 65532 with `allowPrivilegeEscalation: false`, which is what the Envoy Gateway Helm chart sets by default. Under that flag the Linux kernel applies `SECBIT_NO_NEW_PRIVS`, which zeroes out the bounding set after exec. As a result a capability granted via `capabilities.add: [NET_BIND_SERVICE]` ends up in the *permitted* set but never gets promoted to the *effective* set the process actually uses. So envoy "has" NET_BIND_SERVICE on paper but cannot use it to bind a privileged port.

This patch flips `allowPrivilegeEscalation` to `true` for the envoy container only. With the existing `capabilities.drop: [ALL]` and the narrow `add: [NET_BIND_SERVICE]`, the practical privilege surface stays small — the container still cannot escalate to root or gain other capabilities — but the kernel will now promote the granted cap into the effective set so `bind(0.0.0.0:80)` succeeds.

## Test plan
- [ ] Merge and let ArgoCD reconcile (may need to delete the old envoy pod manually because hostNetwork ports prevent rolling-update overlap)
- [ ] On `instance-k8s-proxy`: `sudo ss -tlnp | grep envoy` shows envoy listening on 0.0.0.0:80 and 0.0.0.0:443
- [ ] envoy container logs no longer contain `Permission denied` bind errors
- [ ] `curl https://test-external.shion1305.com/` from outside returns guestbook
- [ ] `curl --resolve guestbook.i.shion1305.com:443:10.130.5.21 https://guestbook.i.shion1305.com/` from inside the cluster returns guestbook