### PR TITLE
fix(envoy-gateway): run envoy data plane as root to bind 80/443

### DIFF
--- a/envoy-gateway/envoyproxy.yaml
+++ b/envoy-gateway/envoyproxy.yaml
@@ -58,13 +58,17 @@ spec:
                   dnsPolicy: ClusterFirstWithHostNet
                   containers:
                     - name: envoy
+                      # Run envoy as root (UID 0) so it can bind privileged
+                      # ports 80/443 under hostNetwork. The distroless envoy
+                      # binary has no file capabilities (`setcap`) baked in,
+                      # so passing NET_BIND_SERVICE via capabilities.add is a
+                      # no-op for non-root users — the kernel clears
+                      # permitted/effective sets on exec. capabilities.drop
+                      # ALL keeps the privilege surface narrow even as root.
                       securityContext:
-                        # allowPrivilegeEscalation must be true so the
-                        # NET_BIND_SERVICE capability can be promoted into the
-                        # process's effective set; without it, the kernel keeps
-                        # the cap in permitted-only and bind(80/443) fails with
-                        # EACCES under runAsNonRoot.
-                        allowPrivilegeEscalation: true
+                        runAsUser: 0
+                        runAsGroup: 0
+                        runAsNonRoot: false
                         capabilities:
                           add:
                             - NET_BIND_SERVICE


### PR DESCRIPTION
## Summary
- Override the envoy container's securityContext to run as UID 0 (root) so the data plane can bind privileged ports 80/443 under hostNetwork.

## Why
PR #235 set `allowPrivilegeEscalation: true` on the envoy container, but envoy still failed to bind:

```
cannot bind '0.0.0.0:80': Permission denied
cannot bind '0.0.0.0:443': Permission denied
```

The actual blocker is the distroless image. `envoyproxy/envoy:distroless-v1.32.2` ships `/usr/local/bin/envoy` **without any file capabilities** (`setcap` was never applied during image build). When a non-root UID `execve()`s a binary that has no file caps, the Linux kernel clears the *permitted* and *effective* capability sets entirely — `capabilities.add` only adds NET_BIND_SERVICE to the *bounding* set, which is not sufficient to actually use the capability at runtime. `allowPrivilegeEscalation: true` doesn't help either, because there is no SUID or file-cap binary to escalate from.

This is a [well-documented limitation](https://seankhliao.com/blog/12021-02-29-k8s-non-root-capabilities/) of Linux capabilities + non-root containers. Workarounds:

| Option | Tradeoff |
|---|---|
| **Run as root** (this PR) | Simplest, no image rebuild |
| Bake `setcap` into a custom envoy image | Keeps non-root, but requires maintaining a fork on every envoy version bump |
| Use unprivileged ports + Service in front | Conflicts with the `*.i.shion1305.com → 10.130.5.21:443` DNS design |

The override is scoped to the envoy container only via the StrategicMerge patch — the envoy-gateway controller and shutdown-manager keep their default non-root contexts. With `capabilities.drop: [ALL]` and `add: [NET_BIND_SERVICE]`, even as root the practical privilege surface stays narrow: envoy cannot do `CAP_SYS_ADMIN`, `CAP_NET_RAW`, `CAP_DAC_OVERRIDE`, etc.

## Test plan
- [ ] Merge and let ArgoCD reconcile (delete the old envoy pod manually because hostNetwork ports prevent rolling-update overlap)
- [ ] On `instance-k8s-proxy`: `sudo ss -tlnp | grep envoy` shows `0.0.0.0:80` and `0.0.0.0:443`
- [ ] envoy container logs no longer contain `Permission denied` bind errors
- [ ] `curl https://test-external.shion1305.com/` from outside returns guestbook
- [ ] `curl --resolve guestbook.i.shion1305.com:443:10.130.5.21 https://guestbook.i.shion1305.com/` from inside the cluster returns guestbook