### PR TITLE
feat(postgres-shared): provision nc-press-chotatsu-data and expose via internal Gateway

### DIFF
--- a/envoy-gateway/gateway-internal.yaml
+++ b/envoy-gateway/gateway-internal.yaml
@@ -27,3 +27,16 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+    # TLS passthrough listener for raw TCP services (e.g. Postgres) that
+    # multiplex on SNI. Envoy does not terminate TLS — the backend handles
+    # the certificate. Routing decisions are made on the SNI hostname only.
+    - name: tls-passthrough
+      port: 5432
+      protocol: TLS
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: All
+        kinds:
+          - kind: TLSRoute

--- a/postgres-shared/kustomization.yaml
+++ b/postgres-shared/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
   - postgres-cluster.yaml
+  - tlsroute-internal.yaml

--- a/postgres-shared/postgres-cluster.yaml
+++ b/postgres-shared/postgres-cluster.yaml
@@ -14,11 +14,13 @@ spec:
     langfuse: []
     keycloak: []
     mlflow: []
+    nc_press_chotatsu_data: []
   databases:
     openwebui: openwebui
     langfuse: langfuse
     keycloak: keycloak
     mlflow: mlflow
+    nc-press-chotatsu-data: nc_press_chotatsu_data
   postgresql:
     version: "17"
   resources:

--- a/postgres-shared/tlsroute-internal.yaml
+++ b/postgres-shared/tlsroute-internal.yaml
@@ -1,0 +1,20 @@
+# Routes TLS connections with SNI=postgres-shared.i.shion1305.com on the
+# internal Gateway's port 5432 listener to the postgres-shared master Service.
+# Envoy does not terminate TLS — Spilo presents its self-signed cert and the
+# client must connect with sslmode=require (or distribute the CA for verify-full).
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: postgres-shared
+  namespace: postgres-operator-deployment
+spec:
+  parentRefs:
+    - name: internal
+      namespace: envoy-gateway-system
+      sectionName: tls-passthrough
+  hostnames:
+    - postgres-shared.i.shion1305.com
+  rules:
+    - backendRefs:
+        - name: postgres-shared
+          port: 5432


### PR DESCRIPTION
## Summary
- Provisions a new \`nc-press-chotatsu-data\` database with owner \`nc_press_chotatsu_data\` on the shared Spilo cluster (user name uses underscores since hyphens require quoting in psql).
- Adds a port 5432 \`TLS Passthrough\` listener on the **internal** Gateway and a \`TLSRoute\` that matches SNI \`postgres-shared.i.shion1305.com\` and forwards to the \`postgres-shared\` master Service.
- Envoy does not terminate TLS — Spilo's self-signed cert is presented directly to the client. Connect with \`sslmode=require\` (or distribute the CA for \`verify-full\`).

## Test plan
- [ ] After merge: \`kubectl get postgresql postgres-shared -n postgres-operator-deployment -o jsonpath='{.status.PostgresClusterStatus}'\` returns \`Running\`.
- [ ] \`kubectl get secret nc-press-chotatsu-data.postgres-shared.credentials.postgresql.acid.zalan.do -n postgres-operator-deployment\` exists.
- [ ] \`kubectl get gateway internal -n envoy-gateway-system -o jsonpath='{.status.listeners[?(@.name=="tls-passthrough")].conditions}'\` shows \`Programmed=True\`.
- [ ] \`kubectl get tlsroute postgres-shared -n postgres-operator-deployment\` shows \`Accepted=True\` and \`ResolvedRefs=True\`.
- [ ] DNS \`postgres-shared.i.shion1305.com\` resolves to \`10.130.5.21\` (instance-k8s-proxy).
- [ ] From a client on the WireGuard network: \`PGSSLMODE=require psql 'host=postgres-shared.i.shion1305.com port=5432 dbname=nc-press-chotatsu-data user=nc_press_chotatsu_data password=<secret>'\` succeeds and \`SELECT 1\` works.