### PR TITLE
fix(postgres-shared): rename nc-press-chotatsu-data DB to underscore form

### DIFF
--- a/postgres-shared/postgres-cluster.yaml
+++ b/postgres-shared/postgres-cluster.yaml
@@ -20,7 +20,7 @@ spec:
     langfuse: langfuse
     keycloak: keycloak
     mlflow: mlflow
-    nc-press-chotatsu-data: nc_press_chotatsu_data
+    nc_press_chotatsu_data: nc_press_chotatsu_data
   postgresql:
     version: "17"
   resources:


### PR DESCRIPTION
## Summary
- Zalando postgres-operator's database-name validator rejects hyphens (\`database "nc-press-chotatsu-data" has invalid name\`), so the DB from #237 was never created — only the role was.
- Rename DB to \`nc_press_chotatsu_data\` to match the role name and pass validation.

## Test plan
- [ ] After merge: \`kubectl exec -n postgres-operator-deployment postgres-shared-0 -c postgres -- psql -U postgres -c '\l' | grep nc_press_chotatsu_data\` returns the new DB.
- [ ] Connect from a WireGuard client: \`PGPASSWORD=<secret> psql 'host=postgres-shared.i.shion1305.com port=5432 dbname=nc_press_chotatsu_data user=nc_press_chotatsu_data sslmode=require sslnegotiation=direct'\` and run \`SELECT current_database();\`.