### PR TITLE
feat(argocd): add argocd-critical PriorityClass for core components

### DIFF
--- a/argocd/priorityclass.yaml
+++ b/argocd/priorityclass.yaml
@@ -1,0 +1,8 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: argocd-critical
+value: 1000000
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: "Priority class for critical ArgoCD components (controller, repo-server, server, redis). Ensures GitOps engine stays scheduled under node pressure."

--- a/argocd/values.yaml
+++ b/argocd/values.yaml
@@ -134,17 +134,20 @@ server:
     timeoutSeconds: 5
   readinessProbe:
     timeoutSeconds: 5
+  priorityClassName: argocd-critical
 # Dex configuration
 dex:
   enabled: true
 # Redis
 redis:
   enabled: true
+  priorityClassName: argocd-critical
 # Application controller
 controller:
   replicas: 1
   readinessProbe:
     timeoutSeconds: 5
+  priorityClassName: argocd-critical
 # Repo server
 repoServer:
   replicas: 1
@@ -152,6 +155,7 @@ repoServer:
     timeoutSeconds: 5
   readinessProbe:
     timeoutSeconds: 5
+  priorityClassName: argocd-critical
 # ApplicationSet controller
 applicationSet:
   replicas: 1


### PR DESCRIPTION
## Summary
- Define a new `argocd-critical` PriorityClass (value `1000000`, matching the existing `postgres-operator-pod` tier — below Longhorn and system tiers).
- Assign it to the four critical ArgoCD components: `controller`, `repoServer`, `server`, and `redis`. Auxiliary components (`dex`, `applicationSet`, `notifications`) are intentionally left at default priority.
- Goal: keep the GitOps engine scheduled under node pressure so apps can continue to self-heal.

## Test plan
- [ ] ArgoCD syncs itself: PriorityClass `argocd-critical` is created.
- [ ] `kubectl get pods -n argocd -o custom-columns=NAME:.metadata.name,PRIORITY:.spec.priorityClassName` shows `argocd-critical` on `argocd-server`, `argocd-application-controller`, `argocd-repo-server`, `argocd-redis`.
- [ ] `argocd-dex-server`, `argocd-applicationset-controller`, `argocd-notifications-controller` remain at `<none>`.
- [ ] ArgoCD UI remains reachable post-rollout.