### PR TITLE
fix(grafana-operator): drop oci:// prefix from repoURL

### DIFF
--- a/apps/grafana-operator-app.yaml
+++ b/apps/grafana-operator-app.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: default
   sources:
-    - repoURL: oci://ghcr.io/grafana/helm-charts
+    - repoURL: ghcr.io/grafana/helm-charts
       chart: grafana-operator
       targetRevision: 5.22.2
       helm:


### PR DESCRIPTION
## Summary
- Drop the `oci://` scheme from the grafana-operator chart `repoURL` so ArgoCD v3 appends the chart name correctly when constructing the OCI manifest URL.
- The Application has been failing with `ComparisonError`/403 since April. With `oci://ghcr.io/grafana/helm-charts`, ArgoCD's helm-pull was hitting `ghcr.io/v2/grafana/helm-charts/manifests/<tag>` (chart segment dropped). Without the scheme, the ref resolves to `ghcr.io/grafana/helm-charts/grafana-operator:5.22.2`.
- **Verified live**: temporarily patched the running Application with the new repoURL — manifest resolved, sync moved from `Unknown/ComparisonError` to `OutOfSync/Missing` with the operator's CRDs and Deployment surfaced. Reverted the live patch so the change ships through GitOps.
- Once merged, ArgoCD will install the grafana-operator (currently absent from the cluster — the live `Grafana` CR has been inactive since April, hence the `o11y` ingress has actually been served by the bundled kube-prometheus-stack grafana).

## Test plan
- [ ] PR merges; `grafana-operator` Application transitions from `Unknown` to `Synced`.
- [ ] `kubectl -n grafana get deploy grafana-operator-controller-manager` is `Available`.
- [ ] `kubectl get crd grafanas.grafana.integreatly.org` exists and the existing `Grafana/main-grafana` CR reconciles (or the orphaned-resources warning is investigated).
- [ ] `kube-prometheus-stack-grafana` (Helm bundled) continues serving `o11y.shion1305.com` until the operator-managed Grafana is ready to take over.