### PR TITLE
fix(grafana): unblock operator auth, route to operator service, drop NodePort

### DIFF
--- a/grafana/grafana.yaml
+++ b/grafana/grafana.yaml
@@ -53,11 +53,10 @@ spec:
   service:
     metadata: {}
     spec:
-      type: NodePort
+      type: ClusterIP
       ports:
         - port: 3000
           targetPort: 3000
-          nodePort: 30080
   persistentVolumeClaim:
     spec:
       accessModes:

--- a/grafana/grafana.yaml
+++ b/grafana/grafana.yaml
@@ -12,8 +12,10 @@ spec:
       serve_from_sub_path: "true"
     auth.anonymous:
       enabled: "false"
-    auth.basic:
-      enabled: "false"
+    # auth.basic must remain enabled (the default) so grafana-operator can
+    # authenticate to /api via the admin credentials it manages. The login
+    # form is hidden via auth.disable_login_form below — interactive users
+    # still go through GitHub OAuth.
     auth:
       disable_login_form: "true"
       disable_signout_menu: "false"

--- a/grafana/httproute-external.yaml
+++ b/grafana/httproute-external.yaml
@@ -12,5 +12,5 @@ spec:
     - o11y.shion1305.com
   rules:
     - backendRefs:
-        - name: kube-prometheus-stack-grafana
-          port: 80
+        - name: main-grafana-service
+          port: 3000


### PR DESCRIPTION
## Summary
With grafana-operator now syncing (#243), the kube-prometheus-stack sync exposed three follow-on issues:

1. **Operator can't authenticate to Grafana.** The `Grafana` CR sets `auth.basic.enabled: \"false\"`, which makes Grafana's `/api/*` reject the basic-auth admin credentials the operator manages. The reconciler fails at stage `complete` with *failed to authenticate with grafana*, the Grafana instance is marked not-ready, and every `GrafanaDashboard`/`GrafanaDatasource`/`GrafanaFolder` then errors out with *no matching instances*. Reproduced the 401 directly with `curl -u admin:$pass /api/login/ping`. Fix: drop the override so basic-auth falls back to Grafana's default (enabled). The login form stays hidden via `auth.disable_login_form: \"true\"`, so interactive users still go through GitHub OAuth.
2. **HTTPRoute pointed at a non-existent Service.** `kube-prometheus-stack-grafana:80` was the Helm-bundled service; that disappears once `grafana.enabled: false` takes effect and the operator-managed `Grafana` becomes the real instance. Switch the route to `main-grafana-service:3000` (the Service the operator creates from the `Grafana` CR's `spec.service`).
3. **Drop NodePort 30080 from the operator's Service.** Now that all external traffic goes through the Envoy Gateway → HTTPRoute → ClusterIP path, there's no reason for Grafana's Service to be reachable on a node port. The NodePort was a holdover from the legacy nginx-ssl ingress setup. Switch to `type: ClusterIP`.

After this lands, expected progression:
- `Grafana/main-grafana` reaches `stage=complete success`.
- `GrafanaDatasource/prometheus`, `GrafanaFolder/*`, `GrafanaDashboard/*` reconcile cleanly.
- HTTPRoute `grafana-external` becomes `ResolvedRefs=True` and `o11y.shion1305.com` serves the operator-managed Grafana via the external Envoy Gateway.
- Node port 30080 is freed (anything previously hitting `<node-ip>:30080` will need to use `https://o11y.shion1305.com` instead — repo docs in `CLAUDE.md` reference this and will need updating).

## Test plan
- [ ] `kubectl -n grafana get grafana.grafana.integreatly.org main-grafana -o jsonpath='{.status.stage} {.status.stageStatus}'` → `complete success`.
- [ ] `kubectl -n grafana get svc main-grafana-service` → `TYPE=ClusterIP`, no `NodePort` column.
- [ ] `kubectl -n grafana get grafanadashboard,grafanadatasource,grafanafolder` shows no errors.
- [ ] `kubectl -n grafana describe httproute grafana-external` → `Accepted=True`, `ResolvedRefs=True`.
- [ ] `https://o11y.shion1305.com/grafana/` loads Grafana and GitHub OAuth login completes.
- [ ] `kube-prometheus-stack` Application returns to `Synced/Healthy`.

## Notes
There's also a separate failure on `Grafana/cloudflare-grafana` (`monitoring` namespace) — `dial tcp ...: operation not permitted` from the operator pod to that Service. Likely a NetworkPolicy / CNI egress block, unrelated to this change. Tracking it as a follow-up.