### PR TITLE
fix(grafana): pin job=node-exporter so bundled dashboards populate

### DIFF
--- a/grafana/values.yaml
+++ b/grafana/values.yaml
@@ -116,3 +116,10 @@ prometheus-node-exporter:
         - sourceLabels: [__meta_kubernetes_pod_node_name]
           action: replace
           targetLabel: node
+        # Pin job=node-exporter so the bundled chart dashboards
+        # (which hard-code job="node-exporter") resolve correctly.
+        # The default job name derives from the ServiceMonitor name
+        # (kube-prometheus-stack-prometheus-node-exporter) and does
+        # not match those queries.
+        - replacement: node-exporter
+          targetLabel: job


### PR DESCRIPTION
## Summary

After #246 the bundled kube-prometheus-stack node dashboards still showed no data. Root cause: the dashboards' PromQL queries hard-code `job="node-exporter"`, but the actual job label on scraped metrics resolved to `kube-prometheus-stack-prometheus-node-exporter` (the ServiceMonitor name).

The cause is a misuse of `prometheus.monitor.jobLabel` in the prometheus-node-exporter subchart. That field names a **Service label key whose value should be transferred to `job`** — not a literal job name. Since no Service label `node-exporter=…` exists, Prometheus Operator falls back to using the ServiceMonitor name.

## Fix

Add a final relabel rule that hard-pins `job=node-exporter`:

```yaml
- replacement: node-exporter
  targetLabel: job
```

This sidesteps the `jobLabel` semantics entirely and guarantees the rendered scrape config writes `job="node-exporter"` regardless of upstream label conventions.

## Verification

`helm template ... | yq …spec.endpoints[0].relabelings` confirms the new rule appears at the end of the chain. Once merged and synced, dashboards in the **Node Metrics** folder should populate.

## Test plan

- [ ] After merge, confirm `count(up{job="node-exporter"})` returns 4 in Prometheus.
- [ ] Open Grafana > Node Metrics folder, verify `nodes`, `node-rsrc-use`, `node-cluster-rsrc-use` populate with live data.