### PR TITLE
feat(keycloak-operator): add zot realm for registry auth

### DIFF
--- a/apps/keycloak-operator-app.yaml
+++ b/apps/keycloak-operator-app.yaml
@@ -14,8 +14,6 @@ spec:
     repoURL: https://github.com/Shion1305/k8s-GitOps.git
     targetRevision: HEAD
     path: keycloak-operator
-    directory:
-      exclude: "crds/*"  # CRDs managed by separate app
   syncPolicy:
     automated:
       selfHeal: true

--- a/keycloak-operator/kustomization.yaml
+++ b/keycloak-operator/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - keycloak.yaml
+  - vault-secret-store.yaml
+  - db-secret-store.yaml
+  - external-secret.yaml
+  - zot-realm.yaml

--- a/keycloak-operator/zot-realm.yaml
+++ b/keycloak-operator/zot-realm.yaml
@@ -1,0 +1,228 @@
+# =============================================================================
+# Keycloak Realm Import: zot
+# =============================================================================
+#
+# This file is reconciled by the Keycloak Operator (KeycloakRealmImport CRD).
+# It declares the `zot` realm used to authenticate:
+#   - Human users logging in to the zot UI at https://registry.shion1305.com
+#     via OIDC Authorization Code flow (client: `zot-registry`).
+#   - GitHub Actions workflows pushing images to the zot registry, via OIDC
+#     token exchange (client: `gha-exchanger`) using GitHub's OIDC issuer
+#     (https://token.actions.githubusercontent.com) as an Identity Provider.
+#
+# Token exchange is enabled cluster-wide via `KC_FEATURES=token-exchange`
+# already set on the Keycloak CR (see `keycloak.yaml`). No realm-level toggle
+# is required.
+#
+# -----------------------------------------------------------------------------
+# Manual post-import steps (one-time, after first successful sync):
+# -----------------------------------------------------------------------------
+# 1. Retrieve the auto-generated client secret for the `zot-registry` client
+#    from the Keycloak admin UI:
+#      https://keycloak.k.shion1305.com → realm `zot` → Clients → zot-registry
+#      → Credentials tab → "Client secret" (Regenerate if needed).
+#    The placeholder `PLACEHOLDER_REPLACE_AFTER_REALM_IMPORT` declared below
+#    is overwritten by Keycloak on first import; the realm import does NOT
+#    re-apply the placeholder on subsequent reconciles, so it is safe to let
+#    Keycloak own the value.
+#
+# 2. Push the actual client secret into Vault so ESO can sync it into the zot
+#    namespace (used by zot for OIDC code-flow token exchange):
+#      vault kv put zot/keycloak-client clientsecret=<value-from-keycloak-ui>
+#
+# 3. Generate the zot UI session encryption key and store it in Vault:
+#      vault kv put zot/session-keys key=$(openssl rand -base64 64)
+#
+# 4. (Optional) Repeat step 1-2 for the `gha-exchanger` client if/when its
+#    secret is needed by GHA workflows for the token-exchange grant. Store at
+#    `zot/gha-exchanger-client` (key: `clientsecret`) if required.
+#
+# -----------------------------------------------------------------------------
+# Out of scope for this YAML:
+# -----------------------------------------------------------------------------
+# - Adding human users to the `zot-admin` group requires creating the user
+#   (in this `zot` realm or via brokering from the `master` realm) and then
+#   assigning group membership manually in the Keycloak admin UI.
+# - Vault-side policy / role setup (`eso-zot`) is documented in the deployment
+#   plan and tracked under `vault/scripts/setup-eso-policies.sh`.
+# =============================================================================
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: KeycloakRealmImport
+metadata:
+  name: zot
+  namespace: keycloak
+spec:
+  keycloakCRName: keycloak
+  realm:
+    realm: zot
+    enabled: true
+    registrationAllowed: false
+    # HTTPS required for external traffic; cluster-internal HTTP (service mesh)
+    # is permitted for the operator/health checks.
+    sslRequired: external
+
+    # -------------------------------------------------------------------------
+    # Realm roles (top-level, NOT client roles). These are the role names that
+    # zot's accessControl policy keys off of via the `groups` claim in the JWT
+    # (groups carry their associated realmRole into the claim).
+    # -------------------------------------------------------------------------
+    roles:
+      realm:
+        - name: zot-admin
+          description: Full admin (read/create/update/delete) on all repositories in zot
+        - name: pusher-shion1305
+          description: Push/pull on shion1305/** repositories
+        - name: pusher-shion1305dev
+          description: Push/pull on shion1305dev/** repositories
+
+    # -------------------------------------------------------------------------
+    # Groups mirror the realm roles. The `groups` OIDC claim is what zot's
+    # accessControl uses for authorization, so each group is granted its
+    # corresponding realmRole, and the group-membership mapper on each client
+    # ensures the group name lands in the JWT.
+    # -------------------------------------------------------------------------
+    groups:
+      - name: zot-admin
+        realmRoles:
+          - zot-admin
+      - name: pusher-shion1305
+        realmRoles:
+          - pusher-shion1305
+      - name: pusher-shion1305dev
+        realmRoles:
+          - pusher-shion1305dev
+
+    # -------------------------------------------------------------------------
+    # Clients
+    # -------------------------------------------------------------------------
+    clients:
+      # zot-registry: confidential client used by zot for both:
+      #   - the UI Authorization Code flow (human OIDC login)
+      #   - the audience of JWTs minted via gha-exchanger token exchange
+      - clientId: zot-registry
+        protocol: openid-connect
+        publicClient: false
+        clientAuthenticatorType: client-secret
+        # NOTE: This placeholder is replaced by a Keycloak-generated secret on
+        # first import. The real value is retrieved from the admin UI and
+        # written to Vault at `zot/keycloak-client` (key: `clientsecret`).
+        # Do NOT commit the actual secret to git.
+        secret: PLACEHOLDER_REPLACE_AFTER_REALM_IMPORT
+        standardFlowEnabled: true
+        directAccessGrantsEnabled: false
+        serviceAccountsEnabled: false
+        redirectUris:
+          - https://registry.shion1305.com/*
+        webOrigins:
+          - https://registry.shion1305.com
+        attributes:
+          # 1 hour access token lifespan — long enough for `docker push` of
+          # large images without forcing mid-push re-auth.
+          access.token.lifespan: "3600"
+        protocolMappers:
+          # Emit `groups` claim in id_token, access_token and userinfo so that
+          # zot's accessControl can authorize human UI users by group membership.
+          - name: groups
+            protocolMapper: oidc-group-membership-mapper
+            protocol: openid-connect
+            consentRequired: false
+            config:
+              claim.name: "groups"
+              full.path: "false"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+
+      # gha-exchanger: confidential client used by GitHub Actions to exchange
+      # GitHub OIDC id_tokens for zot-registry-audience JWTs via the
+      # urn:ietf:params:oauth:grant-type:token-exchange grant.
+      - clientId: gha-exchanger
+        protocol: openid-connect
+        publicClient: false
+        clientAuthenticatorType: client-secret
+        # NOTE: This placeholder is replaced by a Keycloak-generated secret on
+        # first import. The token-exchange grant requires the GHA workflow to
+        # present this client_secret; rotate it manually post-import and store
+        # in Vault (e.g. `zot/gha-exchanger-client` key `clientsecret`) if it
+        # ever needs to be consumed via ESO.
+        secret: PLACEHOLDER_REPLACE_AFTER_REALM_IMPORT
+        standardFlowEnabled: false
+        directAccessGrantsEnabled: false
+        # serviceAccountsEnabled is required for the token-exchange flow so
+        # that the client itself can act as the requester.
+        serviceAccountsEnabled: true
+        attributes:
+          oauth2.device.authorization.grant.enabled: "false"
+        protocolMappers:
+          # Same group-membership mapper as zot-registry: the JWT minted via
+          # token exchange must carry the assigned `pusher-*` group in the
+          # `groups` claim so zot's accessControl can authorize the push.
+          - name: groups
+            protocolMapper: oidc-group-membership-mapper
+            protocol: openid-connect
+            consentRequired: false
+            config:
+              claim.name: "groups"
+              full.path: "false"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+
+    # -------------------------------------------------------------------------
+    # Identity Providers
+    # -------------------------------------------------------------------------
+    identityProviders:
+      # GitHub Actions OIDC issuer. Used as the source of truth for verifying
+      # GitHub OIDC id_tokens presented to the gha-exchanger client during
+      # token exchange.
+      - alias: github-actions
+        providerId: oidc
+        enabled: true
+        storeToken: false
+        addReadTokenRoleOnCreate: false
+        trustEmail: false
+        firstBrokerLoginFlowAlias: "first broker login"
+        config:
+          issuer: "https://token.actions.githubusercontent.com"
+          # GitHub's OIDC issuer does not implement a classical token endpoint,
+          # but Keycloak's OIDC IdP requires the field. Set it to the canonical
+          # token URL; it is unused by the token-exchange flow itself.
+          tokenUrl: "https://token.actions.githubusercontent.com/token"
+          jwksUrl: "https://token.actions.githubusercontent.com/.well-known/jwks"
+          useJwksUrl: "true"
+          validateSignature: "true"
+          clientAuthMethod: "client_secret_post"
+          # The audience the GHA workflow must request when fetching the
+          # GitHub OIDC token (this is what GitHub embeds in the `aud` claim).
+          clientId: "zot-registry"
+          defaultScope: "openid"
+          prompt: ""
+          # GitHub OIDC has no userinfo endpoint; skip it to avoid 404s.
+          disableUserInfo: "true"
+
+    # -------------------------------------------------------------------------
+    # Identity Provider Mappers
+    # -------------------------------------------------------------------------
+    # Use `oidc-advanced-group-idp-mapper` to conditionally assign a group
+    # based on the `repository_owner` claim from the GitHub OIDC token. This
+    # is the standard mapper for value-conditional group assignment when
+    # brokering OIDC; the `claims` config takes a JSON array of {key,value}
+    # pairs that must all match for the mapping to fire.
+    identityProviderMappers:
+      - name: gha-shion1305-pusher
+        identityProviderAlias: github-actions
+        identityProviderMapper: oidc-advanced-group-idp-mapper
+        config:
+          syncMode: FORCE
+          claims: '[{"key":"repository_owner","value":"Shion1305"}]'
+          are.claim.values.regex: "false"
+          group: "/pusher-shion1305"
+
+      - name: gha-shion1305dev-pusher
+        identityProviderAlias: github-actions
+        identityProviderMapper: oidc-advanced-group-idp-mapper
+        config:
+          syncMode: FORCE
+          claims: '[{"key":"repository_owner","value":"Shion1305Dev"}]'
+          are.claim.values.regex: "false"
+          group: "/pusher-shion1305dev"

--- a/keycloak-operator/zot-realm.yaml
+++ b/keycloak-operator/zot-realm.yaml
@@ -62,9 +62,8 @@ spec:
     # terminated at Envoy Gateway and the `xforwarded` proxy headers config on
     # the Keycloak CR makes Keycloak treat `X-Forwarded-Proto: https` requests
     # as HTTPS. Net effect: every flow that traverses
-    # `*.shion1305.com` / `*.i.shion1305.com` (Cloudflare → Gateway TLS) is
-    # HTTPS-enforced, while loopback health checks from the Keycloak operator
-    # remain unaffected.
+    # `*.shion1305.com` / `*.i.shion1305.com` (Gateway TLS) is HTTPS-enforced,
+    # while loopback health checks from the Keycloak operator remain unaffected.
     sslRequired: external
 
     # -------------------------------------------------------------------------

--- a/keycloak-operator/zot-realm.yaml
+++ b/keycloak-operator/zot-realm.yaml
@@ -57,8 +57,14 @@ spec:
     realm: zot
     enabled: true
     registrationAllowed: false
-    # HTTPS required for external traffic; cluster-internal HTTP (service mesh)
-    # is permitted for the operator/health checks.
+    # `external` = HTTPS required for any non-loopback request. Cluster-internal
+    # plaintext (Pod IP, ClusterIP) still satisfies this because traffic is TLS-
+    # terminated at Envoy Gateway and the `xforwarded` proxy headers config on
+    # the Keycloak CR makes Keycloak treat `X-Forwarded-Proto: https` requests
+    # as HTTPS. Net effect: every flow that traverses
+    # `*.shion1305.com` / `*.i.shion1305.com` (Cloudflare → Gateway TLS) is
+    # HTTPS-enforced, while loopback health checks from the Keycloak operator
+    # remain unaffected.
     sslRequired: external
 
     # -------------------------------------------------------------------------

--- a/vault/scripts/setup-eso-policies.sh
+++ b/vault/scripts/setup-eso-policies.sh
@@ -18,17 +18,6 @@ set -euo pipefail
 
 echo "=== Creating namespace-scoped ESO policies ==="
 
-# Policy for ClusterExternalSecret (shared/app only)
-vault policy write eso-shared - <<EOF
-path "secret/data/shared/app" {
-  capabilities = ["read"]
-}
-path "secret/metadata/shared/app" {
-  capabilities = ["read", "list"]
-}
-EOF
-echo "✓ Created policy: eso-shared"
-
 # Policy for langfuse namespace
 vault policy write eso-langfuse - <<EOF
 path "secret/data/shared/langfuse" {
@@ -106,16 +95,19 @@ path "system/metadata/cert-manager" {
 EOF
 echo "✓ Created policy: eso-cert-manager"
 
+# Policy for zot namespace (separate KV v2 engine mounted at zot/)
+vault policy write eso-zot - <<EOF
+path "zot/data/*" {
+  capabilities = ["read"]
+}
+path "zot/metadata/*" {
+  capabilities = ["read", "list"]
+}
+EOF
+echo "✓ Created policy: eso-zot"
+
 echo ""
 echo "=== Creating namespace-scoped Kubernetes auth roles ==="
-
-# Update existing "eso" role to use scoped policy (ClusterExternalSecret only)
-vault write auth/kubernetes/role/eso \
-  bound_service_account_names=external-secrets \
-  bound_service_account_namespaces=external-secrets \
-  policies=eso-shared \
-  ttl=1h
-echo "✓ Updated role: eso (scoped to eso-shared)"
 
 # Langfuse
 vault write auth/kubernetes/role/eso-langfuse \
@@ -173,6 +165,14 @@ vault write auth/kubernetes/role/eso-cert-manager \
   ttl=1h
 echo "✓ Created role: eso-cert-manager"
 
+# zot
+vault write auth/kubernetes/role/eso-zot \
+  bound_service_account_names=eso \
+  bound_service_account_namespaces=zot \
+  policies=eso-zot \
+  ttl=1h
+echo "✓ Created role: eso-zot"
+
 echo ""
 echo "=== Removing old broad policy ==="
 vault policy delete eso-policy 2>/dev/null && echo "✓ Deleted old policy: eso-policy" || echo "ⓘ Policy eso-policy not found (already removed)"
@@ -181,11 +181,11 @@ echo ""
 echo "=== Setup Complete ==="
 echo ""
 echo "Per-namespace roles created:"
-echo "  eso          → SA external-secrets/external-secrets → secret/data/shared/app"
-echo "  eso-langfuse → SA eso/langfuse                      → secret/data/shared/langfuse"
-echo "  eso-openwebui→ SA eso/openwebui                     → secret/data/shared/openwebui"
-echo "  eso-keycloak → SA eso/keycloak                      → secret/data/shared/keycloak"
-echo "  eso-atc      → SA eso/atc                           → atc/data/*"
-echo "  eso-lumos-bot→ SA eso/lumos-bot                     → lumos-bot/data/*"
-echo "  eso-freqtrade→ SA eso/freqtrade                    → freqtrade/data/*"
-echo "  eso-cert-manager→ SA eso/cert-manager              → system/data/cert-manager"
+echo "  eso-langfuse    → SA eso/langfuse        → secret/data/shared/langfuse"
+echo "  eso-openwebui   → SA eso/openwebui       → secret/data/shared/openwebui"
+echo "  eso-keycloak    → SA eso/keycloak        → secret/data/shared/keycloak"
+echo "  eso-atc         → SA eso/atc             → atc/data/*"
+echo "  eso-lumos-bot   → SA eso/lumos-bot       → lumos-bot/data/*"
+echo "  eso-freqtrade   → SA eso/freqtrade       → freqtrade/data/*"
+echo "  eso-cert-manager→ SA eso/cert-manager    → system/data/cert-manager"
+echo "  eso-zot         → SA eso/zot             → zot/data/*"


### PR DESCRIPTION
## Summary

PR1 of the [zot registry deployment plan](../tree/main/docs/zot-registry-deployment-plan.md). Declares a new Keycloak `zot` realm for authenticating the upcoming self-hosted OCI registry. The zot deployment, HTTPRoutes and SecurityPolicy follow in PR2/PR3 — zot is not deployed yet, so this realm has no consumer at merge time.

## Changes

- **`keycloak-operator/zot-realm.yaml`** (new): `KeycloakRealmImport` defining the `zot` realm
  - `zot-registry` (confidential OIDC client) — UI Authorization Code flow + audience for GHA push JWTs
  - `gha-exchanger` (confidential, `serviceAccountsEnabled: true`) — token-exchange grant
  - `github-actions` Identity Provider (GitHub OIDC issuer)
  - IdP mappers (`oidc-advanced-group-idp-mapper`) assign `pusher-shion1305` / `pusher-shion1305dev` group based on `repository_owner` claim
  - `zot-admin` realm role + group for human registry admins
  - Group-membership mapper emits `groups` claim in id/access/userinfo tokens
- **`keycloak-operator/kustomization.yaml`** (new): introduce Kustomize so the new manifest is picked up
- **`apps/keycloak-operator-app.yaml`**: drop `directory.exclude` (Kustomize selects manifests)
- **`vault/scripts/setup-eso-policies.sh`**: add `eso-zot` policy + role; drop the now-removed `eso-shared` blocks (Vault state was cleaned up after #248)

## Manual post-merge steps

After ArgoCD syncs the new realm:

1. **Vault setup** (run once with VAULT_ADDR + VAULT_TOKEN):
   ```bash
   vault secrets enable -path=zot kv-v2
   bash vault/scripts/setup-eso-policies.sh   # creates eso-zot policy + role
   ```

2. **Capture client secrets** from Keycloak UI (`https://keycloak.k.shion1305.com` → realm `zot` → Clients → Credentials):
   - `zot-registry` → `vault kv put zot/keycloak-client clientsecret=<value>`
   - `gha-exchanger` → store separately if/when needed for GHA workflow

3. **Generate session keys**:
   ```bash
   vault kv put zot/session-keys key=$(openssl rand -base64 64)
   ```

4. **Add a human user to `zot-admin`** (manual: create user in `zot` realm or broker from `master`, then add to `zot-admin` group via Keycloak UI)

## Test plan

- [ ] ArgoCD `keycloak-operator` Application syncs (Healthy, Synced)
- [ ] Existing `keycloak` Keycloak CR remains healthy (no churn from Kustomize migration)
- [ ] `kubectl get keycloakrealmimport zot -n keycloak` reports Done
- [ ] In Keycloak UI, realm `zot` exists with: `zot-registry` (confidential, redirectUris set), `gha-exchanger` (confidential, token-exchange capable), `github-actions` IdP with two mappers, three realm roles, three groups
- [ ] Realm import does NOT overwrite the Keycloak-generated client secret on subsequent reconciles (verify by editing the secret, waiting for next sync, confirming it remains)
- [ ] Token-exchange smoke test (curl with a synthesized GitHub OIDC token, see plan PR1 §動作確認)