### PR TITLE
fix(cloudflare-exporter): disable chart-bundled ServiceMonitor

### DIFF
--- a/cloudflare-exporter/values.yaml
+++ b/cloudflare-exporter/values.yaml
@@ -31,12 +31,8 @@ resources:
     memory: 128Mi
 # Monitoring configuration
 serviceMonitor:
-  enabled: true
-  namespace: monitoring
-  interval: 60s
-  scrapeTimeout: 30s
-  labels:
-    release: kube-prometheus-stack
+  # We use the standalone ServiceMonitor in servicemonitor.yaml instead — chart-rendered SM has wrong selector.
+  enabled: false
 # Security context
 securityContext:
   runAsNonRoot: true


### PR DESCRIPTION
## Summary

- The `cloudflare-exporter` Helm chart's `serviceMonitor.enabled: true` was rendering a `ServiceMonitor` with the same name/namespace as our standalone `cloudflare-exporter/servicemonitor.yaml`, causing a `RepeatedResourceWarning` and putting the `cloudflare-monitoring` ArgoCD Application in **Degraded** state.
- Disable the chart-rendered ServiceMonitor (`serviceMonitor.enabled: false`) and drop its now-unused sub-fields, keeping only the standalone `servicemonitor.yaml` which uses the correct `app.kubernetes.io/name=cloudflare-exporter` selector that actually matches the exporter Pod.
- Standalone `servicemonitor.yaml` is unchanged; it is already wired into `cloudflare-exporter/kustomization.yaml`.

## Test plan

- [ ] ArgoCD syncs the `cloudflare-monitoring` Application cleanly (no `RepeatedResourceWarning`, status returns to Healthy).
- [ ] `kubectl get servicemonitor -n monitoring cloudflare-exporter` returns exactly one ServiceMonitor.
- [ ] Prometheus targets page (or `kubectl port-forward -n grafana svc/kube-prometheus-stack-prometheus 9090:9090`) shows `cloudflare-exporter` as an UP scrape target.
- [ ] Cloudflare dashboard panels in Grafana continue to render data.