### PR TITLE
fix(cloudflare-monitoring): restore grafana-operator auth + add Keycloak OIDC

### DIFF
--- a/cloudflare-exporter/external-secret.yaml
+++ b/cloudflare-exporter/external-secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cloudflare-grafana-oauth
+  namespace: monitoring
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  target:
+    name: cloudflare-grafana-oauth
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+  data:
+    - secretKey: clientsecret
+      remoteRef:
+        key: keycloak-client
+        property: clientsecret

--- a/cloudflare-exporter/grafana.yaml
+++ b/cloudflare-exporter/grafana.yaml
@@ -12,24 +12,30 @@ spec:
       serve_from_sub_path: "false"
     auth.anonymous:
       enabled: "false"
-    auth.basic:
-      enabled: "false"
+    # auth.basic must remain enabled (the default) so grafana-operator can
+    # authenticate to /api via the admin credentials it manages. The login
+    # form is hidden via auth.disable_login_form below — interactive users
+    # still go through Keycloak OIDC.
     auth:
       disable_login_form: "true"
       disable_signout_menu: "false"
       oauth_auto_login: "true"
-    auth.github:
+    auth.generic_oauth:
       enabled: "true"
+      name: Keycloak
       allow_sign_up: "true"
-      client_id: ${dex.github.clientID}
-      client_secret: ${dex.github.clientSecret}
-      scopes: user:email,read:org
-      auth_url: https://github.com/login/oauth/authorize
-      token_url: https://github.com/login/oauth/access_token
-      api_url: https://api.github.com/user
-      allowed_organizations: Shion1305Dev
-      allow_assign_grafana_admin: "true"
-      role_attribute_path: contains(groups[*], '@Shion1305Dev/k-shion1305-com-admin') && 'Admin' || 'Viewer'
+      client_id: cloudflare-grafana
+      # File-based to avoid leaking the client secret through the Pod env.
+      # The Secret is produced by ESO from Vault (cloudflare-grafana/keycloak-client)
+      # and mounted at /etc/grafana/secrets via the deployment override below.
+      client_secret: $__file{/etc/grafana/secrets/clientsecret}
+      scopes: openid email profile groups
+      # NOTE: Depends on PR3 introducing the keycloak.shion1305.com hostname.
+      # Until PR3 merges, OIDC login will fail; the auth.basic fix is independent.
+      auth_url: https://keycloak.shion1305.com/realms/grafana/protocol/openid-connect/auth
+      token_url: https://keycloak.shion1305.com/realms/grafana/protocol/openid-connect/token
+      api_url: https://keycloak.shion1305.com/realms/grafana/protocol/openid-connect/userinfo
+      role_attribute_path: contains(groups[*], 'grafana-admin') && 'Admin' || contains(groups[*], 'grafana-editor') && 'Editor' || 'Viewer'
     security:
       admin_user: admin
   deployment:
@@ -38,9 +44,6 @@ spec:
         spec:
           containers:
             - name: grafana
-              envFrom:
-                - secretRef:
-                    name: grafana-github-oauth-secret
               resources:
                 limits:
                   cpu: 500m
@@ -48,6 +51,14 @@ spec:
                 requests:
                   cpu: 250m
                   memory: 256Mi
+              volumeMounts:
+                - name: oauth-client-secret
+                  mountPath: /etc/grafana/secrets
+                  readOnly: true
+          volumes:
+            - name: oauth-client-secret
+              secret:
+                secretName: cloudflare-grafana-oauth
   service:
     metadata: {}
     spec:

--- a/cloudflare-exporter/kustomization.yaml
+++ b/cloudflare-exporter/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
   - grafana-datasource.yaml
   - grafana-folder.yaml
   - grafana-dashboards.yaml
+  - vault-secret-store.yaml
+  - external-secret.yaml

--- a/cloudflare-exporter/vault-secret-store.yaml
+++ b/cloudflare-exporter/vault-secret-store.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso
+  namespace: monitoring
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: vault
+  namespace: monitoring
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "cloudflare-grafana"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "eso-cloudflare-grafana"
+          serviceAccountRef:
+            name: "eso"

--- a/keycloak-operator/grafana-realm.yaml
+++ b/keycloak-operator/grafana-realm.yaml
@@ -1,0 +1,126 @@
+# =============================================================================
+# Keycloak Realm Import: grafana
+# =============================================================================
+#
+# This file is reconciled by the Keycloak Operator (KeycloakRealmImport CRD).
+# It declares the `grafana` realm used to authenticate human users logging in
+# to Grafana instances via OIDC Authorization Code flow. Today this is consumed
+# by `cloudflare-grafana` (in the `monitoring` namespace); additional Grafana
+# clients can be added below as new instances onboard.
+#
+# Role-to-Grafana-role mapping is performed inside Grafana via
+# `auth.generic_oauth.role_attribute_path`, keying off the `groups` claim
+# emitted by the group-membership protocol mapper attached to each client.
+#
+# -----------------------------------------------------------------------------
+# Manual post-import steps (one-time, after first successful sync):
+# -----------------------------------------------------------------------------
+# 1. Retrieve the auto-generated client secret for the `cloudflare-grafana`
+#    client from the Keycloak admin UI:
+#      https://keycloak.k.shion1305.com → realm `grafana` → Clients →
+#      cloudflare-grafana → Credentials tab → "Client secret".
+#    The placeholder `PLACEHOLDER_REPLACE_AFTER_REALM_IMPORT` declared below
+#    is overwritten by Keycloak on first import; the realm import does NOT
+#    re-apply the placeholder on subsequent reconciles, so it is safe to let
+#    Keycloak own the value.
+#
+# 2. Push the actual client secret into Vault so ESO can sync it into the
+#    `monitoring` namespace as the `cloudflare-grafana-oauth` Secret consumed
+#    by the Grafana CR via /etc/grafana/secrets/clientsecret:
+#      vault secrets enable -path=cloudflare-grafana kv-v2   # one-time
+#      vault kv put cloudflare-grafana/keycloak-client clientsecret=<value>
+#
+# 3. Assign human users to the `grafana-admin`, `grafana-editor`, or
+#    `grafana-viewer` group in the Keycloak admin UI. Group membership is the
+#    sole authorization signal: users without any of these groups still log
+#    in and receive `Viewer` (default fallback in role_attribute_path).
+#
+# -----------------------------------------------------------------------------
+# Out of scope for this YAML:
+# -----------------------------------------------------------------------------
+# - Vault-side policy / role setup (`eso-cloudflare-grafana`) is tracked in
+#   `vault/scripts/setup-eso-policies.sh`.
+# - User provisioning: this realm has no IdP brokering yet; users must be
+#   created locally in the `grafana` realm (or brokered later if needed).
+# =============================================================================
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: KeycloakRealmImport
+metadata:
+  name: grafana
+  namespace: keycloak
+spec:
+  keycloakCRName: keycloak
+  realm:
+    realm: grafana
+    enabled: true
+    registrationAllowed: false
+    # `external` = HTTPS required for any non-loopback request. Cluster-internal
+    # plaintext (Pod IP, ClusterIP) still satisfies this because traffic is TLS-
+    # terminated at the ingress and the `xforwarded` proxy headers config on
+    # the Keycloak CR makes Keycloak treat `X-Forwarded-Proto: https` requests
+    # as HTTPS.
+    sslRequired: external
+
+    # -------------------------------------------------------------------------
+    # Realm roles. Mirrored 1:1 by groups below; the group-membership mapper
+    # on each client carries the group name into the `groups` claim, which
+    # Grafana's role_attribute_path consumes.
+    # -------------------------------------------------------------------------
+    roles:
+      realm:
+        - name: grafana-admin
+          description: Grafana Admin role (full instance admin)
+        - name: grafana-editor
+          description: Grafana Editor role (create/edit dashboards)
+        - name: grafana-viewer
+          description: Grafana Viewer role (read-only, default fallback)
+
+    groups:
+      - name: grafana-admin
+        realmRoles:
+          - grafana-admin
+      - name: grafana-editor
+        realmRoles:
+          - grafana-editor
+      - name: grafana-viewer
+        realmRoles:
+          - grafana-viewer
+
+    # -------------------------------------------------------------------------
+    # Clients
+    # -------------------------------------------------------------------------
+    clients:
+      # cloudflare-grafana: confidential client used by the cloudflare-grafana
+      # instance (monitoring namespace) for the Authorization Code flow.
+      - clientId: cloudflare-grafana
+        protocol: openid-connect
+        publicClient: false
+        clientAuthenticatorType: client-secret
+        # NOTE: This placeholder is replaced by a Keycloak-generated secret on
+        # first import. The real value is retrieved from the admin UI and
+        # written to Vault at `cloudflare-grafana/keycloak-client`
+        # (key: `clientsecret`). Do NOT commit the actual secret to git.
+        secret: PLACEHOLDER_REPLACE_AFTER_REALM_IMPORT
+        standardFlowEnabled: true
+        directAccessGrantsEnabled: false
+        serviceAccountsEnabled: false
+        # TODO: migrate hostname to envoy-gateway-fronted (e.g.
+        # cloudflare-grafana.shion1305.com) once the HTTPRoute is added; until
+        # then the production hostname is the existing nginx-ssl ingress.
+        redirectUris:
+          - https://ynufes-cf.k.shion1305.com/*
+        webOrigins:
+          - https://ynufes-cf.k.shion1305.com
+        protocolMappers:
+          # Emit `groups` claim in id_token, access_token and userinfo so
+          # Grafana's role_attribute_path can map group → org role.
+          - name: groups
+            protocolMapper: oidc-group-membership-mapper
+            protocol: openid-connect
+            consentRequired: false
+            config:
+              claim.name: "groups"
+              full.path: "false"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"

--- a/keycloak-operator/kustomization.yaml
+++ b/keycloak-operator/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - db-secret-store.yaml
   - external-secret.yaml
   - zot-realm.yaml
+  - grafana-realm.yaml

--- a/vault/scripts/setup-eso-policies.sh
+++ b/vault/scripts/setup-eso-policies.sh
@@ -117,6 +117,18 @@ path "github-app-shared/metadata/*" {
 EOF
 echo "✓ Created policy: eso-github-app"
 
+# Policy for cloudflare-grafana OIDC client credentials (separate KV v2 engine mounted at cloudflare-grafana/)
+# The Grafana CR lives in the shared `monitoring` namespace; the role binds to SA `eso/monitoring`.
+vault policy write eso-cloudflare-grafana - <<EOF
+path "cloudflare-grafana/data/*" {
+  capabilities = ["read"]
+}
+path "cloudflare-grafana/metadata/*" {
+  capabilities = ["read", "list"]
+}
+EOF
+echo "✓ Created policy: eso-cloudflare-grafana"
+
 echo ""
 echo "=== Creating namespace-scoped Kubernetes auth roles ==="
 
@@ -192,6 +204,14 @@ vault write auth/kubernetes/role/eso-github-app \
   ttl=1h
 echo "✓ Created role: eso-github-app"
 
+# cloudflare-grafana (per-namespace pattern; SA `eso` lives in the shared `monitoring` namespace)
+vault write auth/kubernetes/role/eso-cloudflare-grafana \
+  bound_service_account_names=eso \
+  bound_service_account_namespaces=monitoring \
+  policies=eso-cloudflare-grafana \
+  ttl=1h
+echo "✓ Created role: eso-cloudflare-grafana"
+
 echo ""
 echo "=== Removing old broad policy ==="
 vault policy delete eso-policy 2>/dev/null && echo "✓ Deleted old policy: eso-policy" || echo "ⓘ Policy eso-policy not found (already removed)"
@@ -209,3 +229,4 @@ echo "  eso-freqtrade   → SA eso/freqtrade       → freqtrade/data/*"
 echo "  eso-cert-manager→ SA eso/cert-manager    → system/data/cert-manager"
 echo "  eso-zot         → SA eso/zot             → zot/data/*"
 echo "  eso-github-app  → SA external-secrets/external-secrets → github-app-shared/data/*"
+echo "  eso-cloudflare-grafana → SA eso/monitoring     → cloudflare-grafana/data/*"


### PR DESCRIPTION
## Summary

- **Fix Degraded state** of the `cloudflare-monitoring` Application: drop the `auth.basic.enabled: false` override so grafana-operator can authenticate to the Pod's REST API and finish reconcile.
- **Wire cloudflare-grafana to Keycloak OIDC** against a new dedicated `grafana` realm (groups → Admin/Editor/Viewer via `role_attribute_path`). Client secret flows Vault → ESO → mounted file at `/etc/grafana/secrets/clientsecret` (no Pod env exposure).
- **Add KeycloakRealmImport** for the `grafana` realm with the `cloudflare-grafana` client; reproducible Vault role/policy added to `setup-eso-policies.sh`.

## Why this fixes Degraded

grafana-operator authenticates to each managed Grafana instance's REST API using HTTP basic auth with the admin credentials it generates and stores in a Secret. With `auth.basic.enabled: false` the Pod returns `401` for every operator request, the operator can't verify Grafana state, and the Application shows Degraded with reconcile errors. Removing the override (default is `enabled: true`) re-enables the operator path while `auth.disable_login_form: true` keeps the username/password UI form hidden — the same pattern documented in `grafana/grafana.yaml` lines 15-18.

## What changed

| File | Change |
|---|---|
| `cloudflare-exporter/grafana.yaml` | Drop `auth.basic` override; add `auth.generic_oauth` (Keycloak); replace `envFrom` GitHub-OAuth secret with a file-mounted OIDC client secret |
| `cloudflare-exporter/vault-secret-store.yaml` (new) | Per-namespace SA `eso` + SecretStore `vault` (path `cloudflare-grafana`) in `monitoring` |
| `cloudflare-exporter/external-secret.yaml` (new) | ExternalSecret producing `cloudflare-grafana-oauth` Secret with key `clientsecret` |
| `cloudflare-exporter/kustomization.yaml` | Register the two new resources |
| `keycloak-operator/grafana-realm.yaml` (new) | KeycloakRealmImport for `grafana` realm: roles + groups (admin/editor/viewer), single `cloudflare-grafana` confidential client, group-membership protocol mapper |
| `keycloak-operator/kustomization.yaml` | Register `grafana-realm.yaml` |
| `vault/scripts/setup-eso-policies.sh` | Add `eso-cloudflare-grafana` policy + role (binds SA `eso/monitoring` to mount `cloudflare-grafana/`) |

## Manual post-merge steps

> The Degraded fix lands as soon as ArgoCD syncs. Steps 1-4 are required to make OIDC login actually work.

1. Enable the Vault KV v2 mount:
   ```bash
   vault secrets enable -path=cloudflare-grafana kv-v2
   ```
2. Provision the Vault policy + role (replays idempotently):
   ```bash
   bash vault/scripts/setup-eso-policies.sh
   ```
3. After the `KeycloakRealmImport` reconciles, retrieve the auto-generated client secret from the Keycloak admin UI: realm `grafana` → Clients → `cloudflare-grafana` → Credentials.
4. Push it to Vault:
   ```bash
   vault kv put cloudflare-grafana/keycloak-client clientsecret=<value-from-keycloak>
   ```
5. Create users in the `grafana` realm and assign them to one of `grafana-admin`, `grafana-editor`, `grafana-viewer` (Keycloak admin UI). Users without any of these groups still log in but get `Viewer` (default fallback in `role_attribute_path`).

## Dependencies

This PR's OIDC URLs reference `keycloak.shion1305.com`, the new hostname being introduced in the parallel PR3. Until PR3 merges, the OIDC login flow will fail (DNS won't resolve / no TLS cert). The Degraded fix portion (auth.basic) is independent and will work immediately on merge — the cloudflare-grafana Pod will become Healthy and the operator will reconcile dashboards/datasources successfully. OIDC simply won't work for end users until PR3.

## Test plan

- [ ] ArgoCD `cloudflare-monitoring` Application transitions Degraded → Healthy after sync
- [ ] grafana-operator logs no longer show 401s against the cloudflare-grafana Pod
- [ ] `GrafanaDashboard`/`GrafanaDatasource`/`GrafanaFolder` resources show `applied=true` in their status
- [ ] After post-merge step 1+2: `kubectl describe externalsecret cloudflare-grafana-oauth -n monitoring` shows `SecretSynced=False` (expected until step 4) without auth errors
- [ ] After post-merge step 3+4: `cloudflare-grafana-oauth` Secret exists in `monitoring` with key `clientsecret`
- [ ] After PR3 + step 5: end-to-end OIDC login at https://ynufes-cf.k.shion1305.com works; group `grafana-admin` member sees Admin role; group `grafana-viewer` member sees Viewer role
- [ ] `keycloak.k.shion1305.com` admin UI shows the new `grafana` realm with one client `cloudflare-grafana` and three groups