### PR TITLE
feat(envoy-gateway): add wildcard cert + listener for *.k.shion1305.com

### DIFF
--- a/envoy-gateway/certificates.yaml
+++ b/envoy-gateway/certificates.yaml
@@ -29,3 +29,21 @@ spec:
   dnsNames:
     - "*.shion1305.com"
     - "shion1305.com"
+---
+# Issued for the legacy *.k.shion1305.com hostname space so envoy-gateway can
+# serve 308 redirects from old URLs (e.g. keycloak.k.shion1305.com →
+# keycloak.shion1305.com) during the ingress-nginx → Gateway migration.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-k-shion1305-com
+  namespace: envoy-gateway-system
+spec:
+  secretName: wildcard-k-shion1305-com-tls
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  commonName: "*.k.shion1305.com"
+  dnsNames:
+    - "*.k.shion1305.com"
+    - "k.shion1305.com"

--- a/envoy-gateway/gateway-external.yaml
+++ b/envoy-gateway/gateway-external.yaml
@@ -23,3 +23,19 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+    # Legacy *.k.shion1305.com listener — exists solely to terminate TLS for
+    # 308-redirect HTTPRoutes that move old URLs to their *.shion1305.com
+    # equivalents during the ingress-nginx → Gateway migration. Once all
+    # consumers are migrated and the legacy ingress-nginx subdomain is
+    # decommissioned, this listener (and the matching cert) can be removed.
+    - name: https-legacy-k
+      port: 443
+      protocol: HTTPS
+      hostname: "*.k.shion1305.com"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: wildcard-k-shion1305-com-tls
+      allowedRoutes:
+        namespaces:
+          from: All


### PR DESCRIPTION
## Summary

- Add `wildcard-k-shion1305-com` Certificate (cert-manager / Let's Encrypt DNS-01) so envoy-gateway can terminate TLS for the legacy `*.k.shion1305.com` hostname space.
- Add a dedicated `https-legacy-k` listener on the external Gateway scoped to `*.k.shion1305.com`.

## Why land this first

The next PR (keycloak hostname migration) attaches a 308-redirect HTTPRoute (`keycloak.k.shion1305.com` → `keycloak.shion1305.com`) to this listener. cert-manager DNS-01 takes a few minutes to issue the wildcard. By landing the cert + listener separately, the Gateway listener reaches \`Ready\` before any HTTPRoute starts depending on it, avoiding a brief window where the redirect would 503.

This listener is only meant for the migration window — once all `*.k.shion1305.com` consumers have moved (initially: keycloak), the listener and cert can be removed.

## Scope

- No HTTPRoutes attached yet — just cert issuance and listener provisioning.
- DNS for `*.k.shion1305.com` is currently pointed at the ingress-nginx LB; this PR does **not** change DNS, so existing `*.k.shion1305.com` traffic continues hitting ingress-nginx as before.

## Test plan

- [ ] After merge, ArgoCD syncs `envoy-gateway` Application
- [ ] `kubectl get certificate -n envoy-gateway-system wildcard-k-shion1305-com` reaches `READY=True`
- [ ] Secret `wildcard-k-shion1305-com-tls` exists in `envoy-gateway-system`
- [ ] `kubectl get gateway -n envoy-gateway-system external -o yaml` shows new listener `https-legacy-k` with `Programmed=True` and `ResolvedRefs=True`
- [ ] No regressions on existing `https` listener for `*.shion1305.com`