### PR TITLE
fix(keycloak): use statusCode 301 for legacy redirect HTTPRoute

### DIFF
--- a/keycloak-operator/httproute-legacy-redirect.yaml
+++ b/keycloak-operator/httproute-legacy-redirect.yaml
@@ -1,10 +1,14 @@
 # Backward-compat for the old hostname (keycloak.k.shion1305.com).
-# Issues a 308 Permanent Redirect to keycloak.shion1305.com so existing browser
+# Issues a 301 Permanent Redirect to keycloak.shion1305.com so existing browser
 # bookmarks keep working. Server-to-server OIDC clients should NOT rely on this
 # — they must be migrated to https://keycloak.shion1305.com directly because
 # OIDC discovery at /realms/<realm>/.well-known/openid-configuration returns the
 # canonical issuer URL, and most JWT validators reject mismatched issuers
 # regardless of how the discovery URL was reached.
+#
+# Gateway API spec restricts requestRedirect.statusCode to 301 or 302 — 308 is
+# rejected with a CEL validation error, so we use 301 (the closest semantic
+# match for permanent + method-preserving-by-convention).
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -23,4 +27,4 @@ spec:
           requestRedirect:
             scheme: https
             hostname: keycloak.shion1305.com
-            statusCode: 308
+            statusCode: 301


### PR DESCRIPTION
## Summary

The keycloak-operator Application failed to sync after #255 with:

```
HTTPRoute.gateway.networking.k8s.io "keycloak-legacy-redirect" is invalid:
spec.rules[0].filters[0].requestRedirect.statusCode: Unsupported value: 308:
supported values: "301", "302"
```

Gateway API HTTPRoute spec restricts \`requestRedirect.statusCode\` to **301 or 302** via CEL validation. 308 is rejected outright. Switching to 301 (Permanent Redirect) — the closest semantic match for the permanent host migration. Browsers cache and follow it identically; method preservation on POST (the technical difference between 301 and 308) is not relevant for the interactive Keycloak admin/login surface.

## Test plan

- [ ] After merge, ArgoCD \`keycloak-operator\` Application reaches Synced + Healthy
- [ ] \`kubectl -n keycloak get httproute keycloak-legacy-redirect\` shows \`Accepted=True\`, \`ResolvedRefs=True\`
- [ ] \`curl -I https://keycloak.k.shion1305.com/\` → \`HTTP/2 301\`, \`location: https://keycloak.shion1305.com/\`