### PR TITLE
fix(zot): pin StatefulSet to amd64 nodes

### DIFF
--- a/zot/values.yaml
+++ b/zot/values.yaml
@@ -119,6 +119,15 @@ extraVolumeMounts:
 strategy:
   type: RollingUpdate
 
+# Upstream zot publishes architecture-specific images
+# (`zot-linux-amd64` vs `zot-linux-arm64`) rather than a multi-arch manifest
+# list, and `image.repository` above is hard-pinned to amd64. Constrain
+# scheduling so the StatefulSet doesn't land on an arm64 node and crash with
+# `exec format error`. Switch to a multi-arch image and remove this if/when
+# the upstream chart starts publishing a manifest list.
+nodeSelector:
+  kubernetes.io/arch: amd64
+
 metrics:
   enabled: true
   serviceMonitor:


### PR DESCRIPTION
## Summary

Pin the zot StatefulSet to amd64 nodes via \`nodeSelector: kubernetes.io/arch: amd64\`.

The cluster has mixed amd64/arm64 nodes (3 arm64 + 1 amd64). The upstream zot image \`ghcr.io/project-zot/zot-linux-amd64\` is single-arch, so a Pod scheduled onto an arm64 node crashes immediately with:

\`\`\`
exec /usr/local/bin/zot-linux-amd64: exec format error
\`\`\`

zot publishes \`zot-linux-arm64\` as a separate image but not a multi-arch manifest list, and the chart's \`image.repository\` is a single string — there's no clean way to fan out per-arch images via the chart alone.

\`replicaCount\` is 1 (Longhorn RWO PVC) so the scheduling restriction does not cost any HA properties.

## Follow-up (optional)

Build or import a multi-arch zot image (combining the official \`-amd64\` and \`-arm64\` images via \`docker manifest create\`) and host it where this cluster can pull from, then remove the \`nodeSelector\`.

## Test plan

- [ ] After merge, ArgoCD \`zot\` Application syncs cleanly
- [ ] \`kubectl -n zot get pod -o wide\` shows \`zot-0\` running on \`shion-ubuntu-2505\` (amd64)
- [ ] \`kubectl -n zot logs zot-0\` shows zot booting, no \`exec format error\`
- [ ] \`kubectl -n zot get statefulset zot\` → 1/1 Ready