### PR TITLE
fix(zot): mount OIDC secrets with .json extension so Viper parses them

### DIFF
--- a/zot/external-secret.yaml
+++ b/zot/external-secret.yaml
@@ -16,12 +16,19 @@ spec:
       metadata:
         labels:
           managed-by: external-secrets
+      data:
+        # zot uses Viper to parse these files and infers format from the
+        # extension — keys must end in .json/.yaml/etc., not bare names.
+        keycloak-credentials.json: |
+          {"clientid": "zot-registry", "clientsecret": "{{ .clientsecret }}"}
+        session-keys.json: |
+          {"hashKey": "{{ .sessionHashKey }}"}
   data:
     - secretKey: clientsecret
       remoteRef:
         key: keycloak-client
         property: clientsecret
-    - secretKey: session-keys
+    - secretKey: sessionHashKey
       remoteRef:
         key: session-keys
         property: key

--- a/zot/values.yaml
+++ b/zot/values.yaml
@@ -41,13 +41,12 @@ configFiles:
               "keycloak": {
                 "name": "keycloak",
                 "issuer": "https://keycloak.shion1305.com/realms/zot",
-                "clientid": "zot-registry",
-                "clientsecret": "/etc/zot/secrets/clientsecret",
+                "credentialsFile": "/etc/zot/secrets/keycloak-credentials.json",
                 "scopes": ["openid", "email", "groups"]
               }
             }
           },
-          "sessionKeysFile": "/etc/zot/secrets/session-keys"
+          "sessionKeysFile": "/etc/zot/secrets/session-keys.json"
         },
         "accessControl": {
           "repositories": {


### PR DESCRIPTION
## Summary
- zot-0 was crashing with `Unsupported Config Type ""` because `sessionKeysFile` (and the new `credentialsFile`) are loaded via Viper, which derives the parser from the file extension. Mounted paths like `/etc/zot/secrets/session-keys` (no extension) reproduce that exact error.
- Rebuild the `zot-oidc` Secret via ExternalSecret `template.data` so the mounted files become `keycloak-credentials.json` and `session-keys.json` with valid JSON bodies wrapping the Vault-sourced values.
- Migrate the OIDC provider block from the now-deprecated `clientid`/`clientsecret` to `credentialsFile`, which also clears the startup deprecation warning.

## Test plan
- [ ] After merge + ArgoCD sync: `kubectl get pods -n zot` shows `zot-0` Running, no crash loop
- [ ] `kubectl logs -n zot zot-0` no longer reports `failed to read secret file configuration` or the deprecated-`clientid`/`clientsecret` warning
- [ ] `https://docker.shion1305.com` still serves the UI; OIDC code-flow login via Keycloak still works (anonymous read + admin login both validated)