### PR TITLE
fix(zot): strip newlines from Vault values in ExternalSecret template

### DIFF
--- a/zot/external-secret.yaml
+++ b/zot/external-secret.yaml
@@ -19,10 +19,12 @@ spec:
       data:
         # zot uses Viper to parse these files and infers format from the
         # extension — keys must end in .json/.yaml/etc., not bare names.
+        # `openssl rand -base64 64` wraps lines at 76 chars; strip newlines
+        # so the rendered JSON is valid.
         keycloak-credentials.json: |
-          {"clientid": "zot-registry", "clientsecret": "{{ .clientsecret }}"}
+          {"clientid": "zot-registry", "clientsecret": "{{ .clientsecret | trim | replace "\n" "" }}"}
         session-keys.json: |
-          {"hashKey": "{{ .sessionHashKey }}"}
+          {"hashKey": "{{ .sessionHashKey | trim | replace "\n" "" }}"}
   data:
     - secretKey: clientsecret
       remoteRef:


### PR DESCRIPTION
## Summary
- Follow-up to #261. After mounting `session-keys.json` with the Vault-sourced hashKey, zot still crashed with `While parsing config: invalid character '\n' in string`.
- Root cause: `openssl rand -base64 64` (the command used to seed the hashKey in Vault) wraps its output at 76 chars with a literal newline, and our template rendered that newline straight into the JSON string body.
- Pipe both templated values through `trim | replace "\n" ""` so the rendered JSON is well-formed regardless of trailing whitespace or wrapped base64 in Vault.

## Test plan
- [ ] After merge + ESO refresh: `kubectl get secret -n zot zot-oidc -o jsonpath='{.data.session-keys\.json}' | base64 -d | jq .` parses cleanly with no embedded newline
- [ ] `kubectl get pods -n zot` shows `zot-0` Running (not CrashLoopBackOff)
- [ ] `kubectl logs -n zot zot-0` no longer reports `invalid character '\n' in string`