### PR TITLE
fix(zot): use 'oidc' as the OpenID provider name

### DIFF
--- a/zot/values.yaml
+++ b/zot/values.yaml
@@ -38,8 +38,8 @@ configFiles:
         "auth": {
           "openid": {
             "providers": {
-              "keycloak": {
-                "name": "keycloak",
+              "oidc": {
+                "name": "oidc",
                 "issuer": "https://keycloak.shion1305.com/realms/zot",
                 "credentialsFile": "/etc/zot/secrets/keycloak-credentials.json",
                 "scopes": ["openid", "email", "groups"]


### PR DESCRIPTION
## Summary
- After the JSON / `.json`-extension fixes (#261, #262), zot now starts up far enough to validate the OIDC provider config and crashes with `unsupported openid/oauth2 provider`.
- zot v2 only accepts four provider `name` strings — `google`, `gitlab`, `oidc`, `github` — defined in `pkg/api/config/config.go` (`openIDSupportedProviders` / `oauth2SupportedProviders`).
- We had `name: keycloak`, which is not on the list. Switch to the generic `oidc` handler. Keycloak's `/.well-known/openid-configuration` discovery makes this work transparently for any Keycloak realm issuer.

## Test plan
- [ ] `kubectl get pods -n zot` shows `zot-0` Running
- [ ] `kubectl logs -n zot zot-0` no longer reports `unsupported openid/oauth2 provider`
- [ ] `https://docker.shion1305.com` UI loads, OIDC code-flow login via Keycloak succeeds