### PR TITLE
refactor(zot): rename to registry.shion1305.com / registry.i.shion1305.com

### DIFF
--- a/keycloak-operator/zot-realm.yaml
+++ b/keycloak-operator/zot-realm.yaml
@@ -4,7 +4,7 @@
 #
 # This file is reconciled by the Keycloak Operator (KeycloakRealmImport CRD).
 # It declares the `zot` realm used to authenticate:
-#   - Human users logging in to the zot UI at https://docker.shion1305.com
+#   - Human users logging in to the zot UI at https://registry.shion1305.com
 #     via OIDC Authorization Code flow (client: `zot-registry`).
 #   - GitHub Actions workflows pushing images to the zot registry, via OIDC
 #     token exchange (client: `gha-exchanger`) using GitHub's OIDC issuer
@@ -125,9 +125,9 @@ spec:
         directAccessGrantsEnabled: false
         serviceAccountsEnabled: false
         redirectUris:
-          - https://docker.shion1305.com/*
+          - https://registry.shion1305.com/*
         webOrigins:
-          - https://docker.shion1305.com
+          - https://registry.shion1305.com
         attributes:
           # 1 hour access token lifespan — long enough for `docker push` of
           # large images without forcing mid-push re-auth.

--- a/zot/httproute-external.yaml
+++ b/zot/httproute-external.yaml
@@ -14,7 +14,7 @@ spec:
       namespace: envoy-gateway-system
       sectionName: https
   hostnames:
-    - docker.shion1305.com
+    - registry.shion1305.com
   rules:
     - backendRefs:
         - name: zot

--- a/zot/httproute-internal.yaml
+++ b/zot/httproute-internal.yaml
@@ -13,7 +13,7 @@ spec:
       namespace: envoy-gateway-system
       sectionName: https
   hostnames:
-    - docker.i.shion1305.com
+    - registry.i.shion1305.com
   rules:
     - backendRefs:
         - name: zot


### PR DESCRIPTION
## Summary
- Rename the public zot hostname `docker.shion1305.com` → `registry.shion1305.com`.
- Rename the WG-internal hostname `docker.i.shion1305.com` → `registry.i.shion1305.com`.
- Touches two `HTTPRoute`s and the `zot-registry` Keycloak client's `redirectUris` / `webOrigins`.

## Out-of-cluster prerequisites
- [ ] DNS: `registry.shion1305.com` (public, Cloudflare-proxied → public ingress)
- [ ] DNS: `registry.i.shion1305.com` (A → WG host `10.130.5.21`)
- [ ] Keycloak admin UI: confirm the imported `zot-registry` client picks up the new redirect URI / web origin. The realm import declares the new values, but the operator does not always overwrite client fields once a realm is imported — add the new URIs manually if needed (and optionally keep the old ones during cutover for rollback).

## Test plan
- [ ] After DNS + Keycloak prereqs land, sync `zot` and `keycloak-operator` apps in ArgoCD.
- [ ] `curl https://registry.shion1305.com/v2/_catalog` returns `{"repositories":[]}` (anonymous read works).
- [ ] OIDC login from `https://registry.shion1305.com/` redirects to Keycloak and back without `redirect_uri` errors.
- [ ] `curl --resolve registry.i.shion1305.com:443:10.130.5.21 https://registry.i.shion1305.com/v2/` returns 200 from a WG-connected host.
- [ ] `docker push registry.shion1305.com/<repo>:<tag>` from GHA succeeds (token-exchange flow unaffected by hostname rename — `gha-exchanger` doesn't carry a redirect URI).