### PR TITLE
fix(zot): set http.externalUrl and require authentication for pulls

### DIFF
--- a/zot/values.yaml
+++ b/zot/values.yaml
@@ -52,7 +52,7 @@ configFiles:
         "accessControl": {
           "repositories": {
             "**": {
-              "anonymousPolicy": ["read"],
+              "defaultPolicy": ["read"],
               "policies": [
                 {
                   "groups": ["zot-admin"],
@@ -61,6 +61,7 @@ configFiles:
               ]
             },
             "shion1305/**": {
+              "defaultPolicy": ["read"],
               "policies": [
                 {
                   "groups": ["pusher-shion1305"],
@@ -69,6 +70,7 @@ configFiles:
               ]
             },
             "shion1305dev/**": {
+              "defaultPolicy": ["read"],
               "policies": [
                 {
                   "groups": ["pusher-shion1305dev"],

--- a/zot/values.yaml
+++ b/zot/values.yaml
@@ -34,6 +34,7 @@ configFiles:
       "http": {
         "address": "0.0.0.0",
         "port": "5000",
+        "externalUrl": "https://registry.shion1305.com",
         "realm": "zot",
         "auth": {
           "openid": {


### PR DESCRIPTION
## Summary
Two related zot fixes bundled together:

1. **`http.externalUrl`** — zot was constructing `redirect_uri=http://0.0.0.0:5000/zot/auth/callback/oidc` from its bind address, breaking the OIDC code flow on `registry.shion1305.com`. Setting `http.externalUrl` makes zot use the public hostname instead.
2. **Drop anonymous read; require auth for pulls** — replaces `anonymousPolicy: [\"read\"]` on `**` with `defaultPolicy: [\"read\"]` on every repo pattern. Anonymous users now get zero privileges; any authenticated Keycloak user can pull; push remains group-gated.

## Behavior

| Caller | Pull | Push | UI |
|---|---|---|---|
| Anonymous | denied | denied | shell loads, catalog empty |
| Authenticated user | any repo | denied | full |
| `pusher-shion1305` | any repo | `shion1305/*` | full |
| `pusher-shion1305dev` | any repo | `shion1305dev/*` | full |
| `zot-admin` | any repo | any repo | full |

## Refs
- `pkg/api/authn.go` in zot — falls back to `net.JoinHostPort(cfg.HTTP.Address, port)` when `cfg.HTTP.ExternalURL` is empty.
- `pkg/api/authz.go` in zot — most-specific pattern wins with no inheritance; `defaultPolicy` is the per-repo allow-list for any authenticated user.

## Test plan
- [ ] After ArgoCD syncs, browse https://registry.shion1305.com — UI loads, catalog empty.
- [ ] Click \"Login\", complete Keycloak flow; auth URL contains `redirect_uri=https%3A%2F%2Fregistry.shion1305.com%2Fzot%2Fauth%2Fcallback%2Foidc`.
- [ ] After login, catalog populates; pull works.
- [ ] Anonymous `docker pull registry.shion1305.com/foo/bar` returns 401.
- [ ] `docker login` + `docker push` from a `pusher-shion1305` member into `shion1305/*` succeeds.
- [ ] Same push attempt to `shion1305dev/*` from a `pusher-shion1305` member is denied.