### PR TITLE
fix(keycloak): register `groups` as a realm client scope

### DIFF
--- a/keycloak-operator/zot-realm.yaml
+++ b/keycloak-operator/zot-realm.yaml
@@ -106,6 +106,23 @@ spec:
           - pusher-shion1305dev
 
     # -------------------------------------------------------------------------
+    # Client scopes
+    # -------------------------------------------------------------------------
+    # `groups` is not a built-in OIDC scope; Keycloak rejects auth requests
+    # with `scope=openid email groups` ("invalid_scope") unless `groups` is
+    # registered as a realm client scope. The actual `groups` claim is still
+    # produced by the per-client `oidc-group-membership-mapper` declared on
+    # `zot-registry` and `gha-exchanger` below — this scope only registers
+    # the name so it can appear in the auth request.
+    clientScopes:
+      - name: groups
+        description: Group memberships claim
+        protocol: openid-connect
+        attributes:
+          include.in.token.scope: "true"
+          display.on.consent.screen: "false"
+
+    # -------------------------------------------------------------------------
     # Clients
     # -------------------------------------------------------------------------
     clients:


### PR DESCRIPTION
## Summary
zot's OIDC auth request was being rejected by Keycloak with:
```
invalid_scope: Invalid scopes: openid email groups
```

Cause: `groups` is not a built-in OIDC scope, and it was never declared at the realm level. Keycloak only accepts scope names that are registered as client scopes (built-in or custom).

## Fix
Add a realm-level `clientScopes` block declaring `groups` as a custom OIDC scope.

The `groups` **claim** is still produced by the existing per-client `oidc-group-membership-mapper` on `zot-registry` (line 138-147) and `gha-exchanger` (line 173-182). This change only registers the **scope name** so clients can list it in the auth request without Keycloak rejecting it.

## Test plan
- [ ] After ArgoCD syncs and the realm reconciles, browse https://registry.shion1305.com → click Login.
- [ ] Auth URL contains `scope=openid+email+groups` and Keycloak no longer returns `invalid_scope`.
- [ ] After login, JWT access token contains `groups` claim with the user's group memberships.
- [ ] Group-based authz in zot still works (admin/pusher policies).