### PR TITLE
fix(keycloak): declare built-in OIDC client scopes in zot realm

### DIFF
--- a/keycloak-operator/zot-realm.yaml
+++ b/keycloak-operator/zot-realm.yaml
@@ -108,13 +108,211 @@ spec:
     # -------------------------------------------------------------------------
     # Client scopes
     # -------------------------------------------------------------------------
-    # `groups` is not a built-in OIDC scope; Keycloak rejects auth requests
-    # with `scope=openid email groups` ("invalid_scope") unless `groups` is
-    # registered as a realm client scope. The actual `groups` claim is still
-    # produced by the per-client `oidc-group-membership-mapper` declared on
-    # `zot-registry` and `gha-exchanger` below — this scope only registers
-    # the name so it can appear in the auth request.
+    # When a realm is imported with a non-empty `clientScopes` list, Keycloak
+    # uses it as the COMPLETE set of scopes for the realm and skips the
+    # auto-seeded built-ins. So we have to declare every scope we want — both
+    # the OIDC built-ins (`profile`, `email`, `roles`, `web-origins`, `acr`,
+    # `basic`) and our custom `groups` — otherwise Keycloak rejects login
+    # requests carrying any of them as `invalid_scope`.
+    #
+    # Source for the built-in mapper configs: Keycloak 26.x
+    # `OIDCLoginProtocolFactory.addBuiltinMappers()` and the per-scope wiring
+    # in the same file. We mirror Keycloak's defaults so behavior matches a
+    # vanilla realm. Optional scopes (`offline_access`, `address`, `phone`,
+    # `microprofile-jwt`) are intentionally omitted — not used by zot.
+    defaultDefaultClientScopes:
+      - basic
+      - profile
+      - email
+      - roles
+      - web-origins
+      - acr
+      - groups
+    defaultOptionalClientScopes: []
     clientScopes:
+      - name: basic
+        description: "OpenID Connect scope for add all basic claims to the token"
+        protocol: openid-connect
+        attributes:
+          include.in.token.scope: "false"
+          display.on.consent.screen: "false"
+        protocolMappers:
+          - name: sub
+            protocol: openid-connect
+            protocolMapper: oidc-sub-mapper
+            config:
+              access.token.claim: "true"
+              introspection.token.claim: "true"
+          - name: auth_time
+            protocol: openid-connect
+            protocolMapper: oidc-usersessionmodel-note-mapper
+            config:
+              user.session.note: "AUTH_TIME"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              introspection.token.claim: "true"
+              claim.name: "auth_time"
+              jsonType.label: "long"
+
+      - name: profile
+        description: "OpenID Connect built-in scope: profile"
+        protocol: openid-connect
+        attributes:
+          include.in.token.scope: "true"
+          display.on.consent.screen: "true"
+          consent.screen.text: "${profileScopeConsentText}"
+        protocolMappers:
+          - name: full name
+            protocol: openid-connect
+            protocolMapper: oidc-full-name-mapper
+            config:
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+              introspection.token.claim: "true"
+          - name: family name
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            config:
+              user.attribute: "lastName"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+              introspection.token.claim: "true"
+              claim.name: "family_name"
+              jsonType.label: "String"
+          - name: given name
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            config:
+              user.attribute: "firstName"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+              introspection.token.claim: "true"
+              claim.name: "given_name"
+              jsonType.label: "String"
+          - name: username
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            config:
+              user.attribute: "username"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+              introspection.token.claim: "true"
+              claim.name: "preferred_username"
+              jsonType.label: "String"
+          - name: locale
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            config:
+              user.attribute: "locale"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+              introspection.token.claim: "true"
+              claim.name: "locale"
+              jsonType.label: "String"
+
+      - name: email
+        description: "OpenID Connect built-in scope: email"
+        protocol: openid-connect
+        attributes:
+          include.in.token.scope: "true"
+          display.on.consent.screen: "true"
+          consent.screen.text: "${emailScopeConsentText}"
+        protocolMappers:
+          - name: email
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            config:
+              user.attribute: "email"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+              introspection.token.claim: "true"
+              claim.name: "email"
+              jsonType.label: "String"
+          - name: email verified
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-property-mapper
+            config:
+              user.attribute: "emailVerified"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+              introspection.token.claim: "true"
+              claim.name: "email_verified"
+              jsonType.label: "boolean"
+
+      - name: roles
+        description: "OpenID Connect scope for add user roles to the access token"
+        protocol: openid-connect
+        attributes:
+          include.in.token.scope: "false"
+          display.on.consent.screen: "true"
+          consent.screen.text: "${rolesScopeConsentText}"
+        protocolMappers:
+          - name: realm roles
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-realm-role-mapper
+            config:
+              multivalued: "true"
+              access.token.claim: "true"
+              introspection.token.claim: "true"
+              claim.name: "realm_access.roles"
+              jsonType.label: "String"
+          - name: client roles
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-client-role-mapper
+            config:
+              multivalued: "true"
+              access.token.claim: "true"
+              introspection.token.claim: "true"
+              claim.name: "resource_access.${client_id}.roles"
+              jsonType.label: "String"
+          - name: audience resolve
+            protocol: openid-connect
+            protocolMapper: oidc-audience-resolve-mapper
+            config:
+              access.token.claim: "true"
+              introspection.token.claim: "true"
+
+      - name: web-origins
+        description: "OpenID Connect scope for add allowed web origins to the access token"
+        protocol: openid-connect
+        attributes:
+          include.in.token.scope: "false"
+          display.on.consent.screen: "false"
+          consent.screen.text: ""
+        protocolMappers:
+          - name: allowed web origins
+            protocol: openid-connect
+            protocolMapper: oidc-allowed-origins-mapper
+            config:
+              access.token.claim: "true"
+              introspection.token.claim: "true"
+
+      - name: acr
+        description: "OpenID Connect scope for add acr (authentication context class reference) to the token"
+        protocol: openid-connect
+        attributes:
+          include.in.token.scope: "false"
+          display.on.consent.screen: "false"
+        protocolMappers:
+          - name: acr loa level
+            protocol: openid-connect
+            protocolMapper: oidc-acr-mapper
+            config:
+              id.token.claim: "true"
+              access.token.claim: "true"
+              introspection.token.claim: "true"
+
+      # `groups` is custom to this realm — used by zot's accessControl. The
+      # actual claim is produced by the per-client mapper on `zot-registry`
+      # and `gha-exchanger`; this scope just registers the name so it can be
+      # listed in the auth request.
       - name: groups
         description: Group memberships claim
         protocol: openid-connect


### PR DESCRIPTION
## Summary
Restore the OIDC built-in client scopes (`profile`, `email`, `roles`, `web-origins`, `acr`, `basic`) that PR #267 silently dropped.

## Problem
PR #267 added a `clientScopes:` block with only `groups`. Keycloak's import behavior: when `clientScopes` is non-empty, the realm uses **only** that list — the built-in OIDC scopes that Keycloak normally auto-seeds are skipped. Result: the realm now has `groups` + `offline_access`, and any login request including `email`/`profile` gets `invalid_scope`.

## Fix
Declare all needed built-ins inline (configs mirrored from Keycloak 26's `OIDCLoginProtocolFactory`), keep `groups`, and add `defaultDefaultClientScopes` so clients automatically receive them on import.

Optional scopes (`offline_access`, `address`, `phone`, `microprofile-jwt`) are deliberately omitted — not needed for zot.

## Apply steps (manual, after merge)
The Keycloak operator import skips when the realm already exists:
1. Admin UI → realm `zot` → Action → Delete realm
2. \`kubectl delete job -n keycloak zot\`
3. \`kubectl annotate keycloakrealmimport zot -n keycloak force-reconcile=\"\$(date +%s)\" --overwrite\`
4. Wait for fresh job to complete; rotate `zot-registry` client secret in Vault.

## Test plan
- [ ] After re-import, https://keycloak.shion1305.com/admin → realm `zot` → Client scopes shows: basic, profile, email, roles, web-origins, acr, groups (+ offline_access).
- [ ] zot login at https://registry.shion1305.com no longer returns `invalid_scope`.
- [ ] JWT carries `groups` claim with the user's group memberships.