### PR TITLE
fix(keycloak): allow internal registry hostname in zot-registry redirectUris

### DIFF
--- a/keycloak-operator/zot-realm.yaml
+++ b/keycloak-operator/zot-realm.yaml
@@ -341,8 +341,10 @@ spec:
         serviceAccountsEnabled: false
         redirectUris:
           - https://registry.shion1305.com/*
+          - https://registry.i.shion1305.com/*
         webOrigins:
           - https://registry.shion1305.com
+          - https://registry.i.shion1305.com
         attributes:
           # 1 hour access token lifespan — long enough for `docker push` of
           # large images without forcing mid-push re-auth.


### PR DESCRIPTION
## Summary
Adds `registry.i.shion1305.com` to the `zot-registry` client's `redirectUris` and `webOrigins` so OIDC code-flow logins initiated through the WireGuard-internal hostname are accepted by Keycloak.

## Caveat
zot's `http.externalUrl` is statically `https://registry.shion1305.com`, so even when a user browses `https://registry.i.shion1305.com` and clicks Login, zot will still construct `redirect_uri=https://registry.shion1305.com/zot/auth/callback/oidc`. The newly-added internal redirect URI will not be exercised by today's UI flow but is needed for any future case where zot is configured to redirect through the internal hostname (or for direct API clients that initiate OIDC flows via the internal endpoint).

## Apply steps
KeycloakRealmImport skips when realm already exists, so:
1. Admin UI → realm `zot` → Action → Delete realm
2. \`kubectl delete job -n keycloak zot\`
3. \`kubectl annotate keycloakrealmimport zot -n keycloak force-reconcile=\"\$(date +%s)\" --overwrite\`
4. Rotate `zot-registry` client secret in Vault.

Or do it manually in the admin UI:
- Realm `zot` → Clients → `zot-registry` → "Valid redirect URIs" → add `https://registry.i.shion1305.com/*`
- Same client → "Web origins" → add `https://registry.i.shion1305.com`

## Test plan
- [ ] After applying, `https://registry.i.shion1305.com` login flow works (won't actually exercise this until zot's externalUrl handling is changed).