### PR TITLE
feat(zot): demo GHA workflow pushing image via Keycloak token-exchange

### DIFF
--- a/.github/workflows/demo-push-to-zot.yaml
+++ b/.github/workflows/demo-push-to-zot.yaml
@@ -1,0 +1,66 @@
+name: demo - build & push to registry.shion1305.com
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "zot/demo/**"
+      - ".github/workflows/demo-push-to-zot.yaml"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Get GitHub OIDC token (audience=zot-registry)
+        id: gh-oidc
+        run: |
+          token=$(curl -fsSL \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=zot-registry" | jq -r '.value')
+          echo "::add-mask::$token"
+          echo "token=$token" >> "$GITHUB_OUTPUT"
+
+      - name: Exchange for Keycloak access token
+        id: kc-exchange
+        run: |
+          response=$(curl -fsSL -X POST \
+            "https://keycloak.shion1305.com/realms/zot/protocol/openid-connect/token" \
+            -d "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
+            -d "subject_token=${{ steps.gh-oidc.outputs.token }}" \
+            -d "subject_token_type=urn:ietf:params:oauth:token-type:id_token" \
+            -d "subject_issuer=github-actions" \
+            -d "audience=zot-registry" \
+            -d "requested_token_type=urn:ietf:params:oauth:token-type:access_token" \
+            -d "client_id=gha-exchanger" \
+            -d "client_secret=${{ secrets.KEYCLOAK_GHA_EXCHANGER_SECRET }}")
+          token=$(echo "$response" | jq -r '.access_token')
+          if [ "$token" = "null" ] || [ -z "$token" ]; then
+            echo "Token exchange failed:"
+            echo "$response"
+            exit 1
+          fi
+          echo "::add-mask::$token"
+          echo "token=$token" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@v3
+        with:
+          registry: registry.shion1305.com
+          username: oidc
+          password: ${{ steps.kc-exchange.outputs.token }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: ./zot/demo
+          push: true
+          tags: |
+            registry.shion1305.com/shion1305/demo:${{ github.sha }}
+            registry.shion1305.com/shion1305/demo:latest

--- a/zot/demo/Dockerfile
+++ b/zot/demo/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:3.20
+RUN echo "hello from zot smoke test" > /msg
+CMD ["cat", "/msg"]


### PR DESCRIPTION
## Summary

- Adds `zot/demo/Dockerfile` (minimal alpine image) as smoke-test payload
- Adds `.github/workflows/demo-push-to-zot.yaml` exercising the full GHA → Keycloak `gha-exchanger` token-exchange → zot bearer auth chain
- Pushes to `registry.shion1305.com/shion1305/demo:${sha}` and `:latest`

## Auth flow

1. `id-token: write` → mint GitHub OIDC JWT (audience=`zot-registry`)
2. Exchange via `urn:ietf:params:oauth:grant-type:token-exchange` at Keycloak's `zot` realm using `gha-exchanger` client
3. Keycloak `gha-shion1305-pusher` IdP mapper assigns `/pusher-shion1305` group based on `repository_owner=Shion1305` claim
4. Returned access_token has `groups: ["pusher-shion1305"]` → zot accessControl on `shion1305/**` allows push

## Prereqs (out-of-band)

- `KEYCLOAK_GHA_EXCHANGER_SECRET` repo secret set to the value retrieved from the Keycloak admin UI (Clients → `gha-exchanger` → Credentials)

## Test plan

- [ ] Set `KEYCLOAK_GHA_EXCHANGER_SECRET` repo secret
- [ ] Merge this PR (triggers workflow on push to main path `zot/demo/**`)
- [ ] Verify GHA logs: each step succeeds, final docker push returns 201
- [ ] Verify in zot UI (https://registry.shion1305.com): `shion1305/demo:<sha>` appears in catalog
- [ ] Verify federated user appeared in Keycloak admin UI (realm `zot` → Users) with assigned `/pusher-shion1305` group