### PR TITLE
refactor(zot): switch to bearer-only OIDC + Envoy Gateway SecurityPolicy

### DIFF
--- a/.github/workflows/demo-push-to-zot.yaml
+++ b/.github/workflows/demo-push-to-zot.yaml
@@ -22,17 +22,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # Use the `docker` driver (host daemon) instead of the default
-      # `docker-container` driver. The container driver runs buildkit in a
-      # sidecar that does not see the runner's ~/.docker/config.json, so the
-      # bearer credentials we write below would be ignored at push time.
       - uses: docker/setup-buildx-action@v3
-        with:
-          driver: docker
 
-      # Mint a fresh OIDC token immediately before login. GHA OIDC tokens
-      # expire in ~10 min; fetching here keeps the full TTL available for
-      # the buildx push that follows.
+      # We don't use docker/login-action / docker push: zot v2.1.16's bearer-
+      # OIDC middleware does not issue a WWW-Authenticate challenge when
+      # unauthenticated, so docker (CLI / daemon / buildkit) never attaches
+      # the bearer token to its retry. crane sends Authorization: Bearer
+      # pre-emptively based on ~/.docker/config.json and works against the
+      # registry without needing the challenge.
+      - name: Install crane
+        uses: imjasonh/setup-crane@v0.4
+
+      # Mint a fresh OIDC token immediately before push. GHA OIDC tokens
+      # expire in ~10 min.
       - name: Get GitHub OIDC token
         id: oidc
         run: |
@@ -45,15 +47,7 @@ jobs:
           echo "::add-mask::$token"
           echo "token=$token" >> "$GITHUB_OUTPUT"
 
-      # Write docker auth config directly. We don't use docker/login-action
-      # because it does GET /v2/ first and expects `WWW-Authenticate: Bearer`
-      # in the 401 response. zot v2.1.16's bearer-OIDC middleware does NOT
-      # issue that challenge (see pkg/api/authn.go bearerAuthHandler — when
-      # only `Bearer.OIDC[]` is configured, an unauthenticated request gets a
-      # plain 401 with no WWW-Authenticate header). Pre-populating
-      # ~/.docker/config.json makes buildx send the bearer pre-emptively, which
-      # zot's OIDC authorizer then validates against GitHub JWKS.
-      - name: Configure docker auth
+      - name: Configure crane auth
         env:
           OIDC_TOKEN: ${{ steps.oidc.outputs.token }}
         run: |
@@ -63,11 +57,21 @@ jobs:
           jq -n --arg auth "$auth" '{auths: {"registry.shion1305.com": {auth: $auth}}}' \
             > ~/.docker/config.json
 
-      - uses: docker/build-push-action@v5
-        with:
-          context: ./zot/demo
-          platforms: linux/amd64
-          push: true
-          tags: |
+      # Build to OCI layout and push with crane. buildx --output=type=oci
+      # writes a tarball; crane push uploads it via direct bearer.
+      - name: Build OCI image
+        run: |
+          set -euo pipefail
+          docker buildx build \
+            --platform linux/amd64 \
+            --output type=oci,dest=/tmp/image.tar \
+            ./zot/demo
+
+      - name: Push with crane
+        run: |
+          set -euo pipefail
+          crane push /tmp/image.tar \
             registry.shion1305.com/shion1305/demo:${{ github.sha }}
-            registry.shion1305.com/shion1305/demo:latest
+          crane tag \
+            registry.shion1305.com/shion1305/demo:${{ github.sha }} \
+            latest

--- a/.github/workflows/demo-push-to-zot.yaml
+++ b/.github/workflows/demo-push-to-zot.yaml
@@ -61,21 +61,26 @@ jobs:
             '{auths: {"registry.shion1305.com": {registrytoken: $t}}}' \
             > ~/.docker/config.json
 
-      # Build to docker-archive format. crane push expects a tarball with
-      # manifest.json at the root (docker save format).
-      - name: Build image (docker tarball)
+      # Build to OCI layout (extracted dir). crane push supports OCI-layout
+      # tarballs/dirs and pushes manifests with the OCI media type, which zot
+      # accepts. (The docker-archive format pushes
+      # application/vnd.docker.distribution.manifest.v2+json which zot rejects
+      # with 415 / MANIFEST_INVALID.)
+      - name: Build OCI image
         run: |
           set -euo pipefail
           docker buildx build \
             --platform linux/amd64 \
-            --tag registry.shion1305.com/shion1305/demo:${{ github.sha }} \
-            --output type=docker,dest=/tmp/image.tar \
+            --output type=oci,dest=/tmp/image.tar \
             ./zot/demo
 
       - name: Push with crane
         run: |
           set -euo pipefail
-          crane push /tmp/image.tar \
+          # Extract OCI tarball so crane can read it as an OCI layout dir.
+          mkdir -p /tmp/oci
+          tar -xf /tmp/image.tar -C /tmp/oci
+          crane push /tmp/oci \
             registry.shion1305.com/shion1305/demo:${{ github.sha }}
           crane tag \
             registry.shion1305.com/shion1305/demo:${{ github.sha }} \

--- a/.github/workflows/demo-push-to-zot.yaml
+++ b/.github/workflows/demo-push-to-zot.yaml
@@ -47,14 +47,18 @@ jobs:
           echo "::add-mask::$token"
           echo "token=$token" >> "$GITHUB_OUTPUT"
 
+      # Use the `registrytoken` field so crane sends `Authorization: Bearer
+      # <token>` directly. The `auth` field would be sent as `Basic
+      # <base64(oidc:JWT)>`, which zot's bearer-OIDC regex (case-insensitive
+      # `bearer (.*)`) rejects with ErrInvalidBearerToken.
       - name: Configure crane auth
         env:
           OIDC_TOKEN: ${{ steps.oidc.outputs.token }}
         run: |
           set -euo pipefail
           mkdir -p ~/.docker
-          auth=$(printf 'oidc:%s' "$OIDC_TOKEN" | base64 -w0)
-          jq -n --arg auth "$auth" '{auths: {"registry.shion1305.com": {auth: $auth}}}' \
+          jq -n --arg t "$OIDC_TOKEN" \
+            '{auths: {"registry.shion1305.com": {registrytoken: $t}}}' \
             > ~/.docker/config.json
 
       # Build to docker-archive format. crane push expects a tarball with

--- a/.github/workflows/demo-push-to-zot.yaml
+++ b/.github/workflows/demo-push-to-zot.yaml
@@ -57,14 +57,15 @@ jobs:
           jq -n --arg auth "$auth" '{auths: {"registry.shion1305.com": {auth: $auth}}}' \
             > ~/.docker/config.json
 
-      # Build to OCI layout and push with crane. buildx --output=type=oci
-      # writes a tarball; crane push uploads it via direct bearer.
-      - name: Build OCI image
+      # Build to docker-archive format. crane push expects a tarball with
+      # manifest.json at the root (docker save format).
+      - name: Build image (docker tarball)
         run: |
           set -euo pipefail
           docker buildx build \
             --platform linux/amd64 \
-            --output type=oci,dest=/tmp/image.tar \
+            --tag registry.shion1305.com/shion1305/demo:${{ github.sha }} \
+            --output type=docker,dest=/tmp/image.tar \
             ./zot/demo
 
       - name: Push with crane

--- a/.github/workflows/demo-push-to-zot.yaml
+++ b/.github/workflows/demo-push-to-zot.yaml
@@ -6,6 +6,10 @@ on:
     paths:
       - "zot/demo/**"
       - ".github/workflows/demo-push-to-zot.yaml"
+  pull_request:
+    paths:
+      - "zot/demo/**"
+      - ".github/workflows/demo-push-to-zot.yaml"
   workflow_dispatch:
 
 permissions:
@@ -18,48 +22,35 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Get GitHub OIDC token (audience=zot-registry)
-        id: gh-oidc
+      - uses: docker/setup-buildx-action@v3
+
+      # Mint a fresh OIDC token immediately before login. GHA OIDC tokens
+      # expire in ~10 min; fetching here keeps the full TTL available for
+      # the buildx push that follows.
+      - name: Get GitHub OIDC token
+        id: oidc
         run: |
-          token=$(curl -fsSL \
+          set -euo pipefail
+          resp=$(curl -fsSL \
             -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=zot-registry" | jq -r '.value')
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=registry.shion1305.com") \
+            || { echo "OIDC token request failed"; exit 1; }
+          token=$(jq -er '.value' <<<"$resp")
           echo "::add-mask::$token"
           echo "token=$token" >> "$GITHUB_OUTPUT"
 
-      - name: Exchange for Keycloak access token
-        id: kc-exchange
-        run: |
-          response=$(curl -fsSL -X POST \
-            "https://keycloak.shion1305.com/realms/zot/protocol/openid-connect/token" \
-            -d "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
-            -d "subject_token=${{ steps.gh-oidc.outputs.token }}" \
-            -d "subject_token_type=urn:ietf:params:oauth:token-type:id_token" \
-            -d "subject_issuer=github-actions" \
-            -d "audience=zot-registry" \
-            -d "requested_token_type=urn:ietf:params:oauth:token-type:access_token" \
-            -d "client_id=gha-exchanger" \
-            -d "client_secret=${{ secrets.KEYCLOAK_GHA_EXCHANGER_SECRET }}")
-          token=$(echo "$response" | jq -r '.access_token')
-          if [ "$token" = "null" ] || [ -z "$token" ]; then
-            echo "Token exchange failed:"
-            echo "$response"
-            exit 1
-          fi
-          echo "::add-mask::$token"
-          echo "token=$token" >> "$GITHUB_OUTPUT"
-
+      # Username is ignored by zot's bearer-OIDC middleware (only the
+      # Authorization header is read) but docker login requires one.
       - uses: docker/login-action@v3
         with:
           registry: registry.shion1305.com
           username: oidc
-          password: ${{ steps.kc-exchange.outputs.token }}
-
-      - uses: docker/setup-buildx-action@v3
+          password: ${{ steps.oidc.outputs.token }}
 
       - uses: docker/build-push-action@v5
         with:
           context: ./zot/demo
+          platforms: linux/amd64
           push: true
           tags: |
             registry.shion1305.com/shion1305/demo:${{ github.sha }}

--- a/.github/workflows/demo-push-to-zot.yaml
+++ b/.github/workflows/demo-push-to-zot.yaml
@@ -22,7 +22,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Use the `docker` driver (host daemon) instead of the default
+      # `docker-container` driver. The container driver runs buildkit in a
+      # sidecar that does not see the runner's ~/.docker/config.json, so the
+      # bearer credentials we write below would be ignored at push time.
       - uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker
 
       # Mint a fresh OIDC token immediately before login. GHA OIDC tokens
       # expire in ~10 min; fetching here keeps the full TTL available for

--- a/.github/workflows/demo-push-to-zot.yaml
+++ b/.github/workflows/demo-push-to-zot.yaml
@@ -39,13 +39,23 @@ jobs:
           echo "::add-mask::$token"
           echo "token=$token" >> "$GITHUB_OUTPUT"
 
-      # Username is ignored by zot's bearer-OIDC middleware (only the
-      # Authorization header is read) but docker login requires one.
-      - uses: docker/login-action@v3
-        with:
-          registry: registry.shion1305.com
-          username: oidc
-          password: ${{ steps.oidc.outputs.token }}
+      # Write docker auth config directly. We don't use docker/login-action
+      # because it does GET /v2/ first and expects `WWW-Authenticate: Bearer`
+      # in the 401 response. zot v2.1.16's bearer-OIDC middleware does NOT
+      # issue that challenge (see pkg/api/authn.go bearerAuthHandler — when
+      # only `Bearer.OIDC[]` is configured, an unauthenticated request gets a
+      # plain 401 with no WWW-Authenticate header). Pre-populating
+      # ~/.docker/config.json makes buildx send the bearer pre-emptively, which
+      # zot's OIDC authorizer then validates against GitHub JWKS.
+      - name: Configure docker auth
+        env:
+          OIDC_TOKEN: ${{ steps.oidc.outputs.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.docker
+          auth=$(printf 'oidc:%s' "$OIDC_TOKEN" | base64 -w0)
+          jq -n --arg auth "$auth" '{auths: {"registry.shion1305.com": {auth: $auth}}}' \
+            > ~/.docker/config.json
 
       - uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/demo-push-to-zot.yaml
+++ b/.github/workflows/demo-push-to-zot.yaml
@@ -30,8 +30,12 @@ jobs:
       # the bearer token to its retry. crane sends Authorization: Bearer
       # pre-emptively based on ~/.docker/config.json and works against the
       # registry without needing the challenge.
-      - name: Install crane
-        uses: imjasonh/setup-crane@v0.4
+      #
+      # crane is installed via aqua so the local toolchain (aqua.yaml) and CI
+      # use the exact same pinned version.
+      - uses: aquaproj/aqua-installer@v4.0.4
+        with:
+          aqua_version: v2.58.0
 
       # Mint a fresh OIDC token immediately before push. GHA OIDC tokens
       # expire in ~10 min.

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -12,3 +12,4 @@ registries:
   ref: v4.479.0 # renovate: depName=aquaproj/aqua-registry
 packages:
 - name: hashicorp/vault@v1.21.4
+- name: google/go-containerregistry@v0.21.5


### PR DESCRIPTION
## Summary

Replace Keycloak token-exchange with a direct GitHub Actions → zot OIDC bearer flow.

- Drop the explicit token-exchange step
- `docker login -u oidc -p $GHA_JWT` against `registry.shion1305.com`
- zot validates the JWT against `https://token.actions.githubusercontent.com` JWKS via `http.auth.bearer.oidc[]`

## Depends on #284

The cluster-side configuration this workflow exercises lives in #284 (bearer-only zot + Envoy SecurityPolicy + split HTTPRoutes). Until #284 is merged and ArgoCD reconciles, the deployed zot still uses `http.auth.openid` and the `build-push` check here will fail with 401.

## Test plan

- [x] Merge #284, wait for zot Application Synced
- [ ] Re-run this workflow; confirm `build-push` passes
- [ ] Confirm pushed image lands at `registry.shion1305.com/shion1305/demo:<sha>`