### PR TITLE
docs(keycloak): document FGAP token-exchange manual step + realm import operating model

### DIFF
--- a/keycloak-operator/README.md
+++ b/keycloak-operator/README.md
@@ -73,6 +73,69 @@ git commit -m "chore: update Keycloak operator to vX.Y.Z"
 
 ArgoCD will sync the changes automatically. The operator will then handle rolling updates of Keycloak pods.
 
+## Realm Configuration (KeycloakRealmImport)
+
+Realms are declared as `KeycloakRealmImport` CRs in this directory:
+
+| File | Realm | Purpose |
+|---|---|---|
+| `user-realm.yaml` | `user` | Central human-user pool (passkey-only); brokered into other realms |
+| `zot-realm.yaml` | `zot` | Docker registry auth (zot UI + GHA token-exchange) |
+| `ynufes-tech-realm.yaml` | `ynufes-tech` | GitHub-OAuth realm for the cloudflare-grafana audience |
+
+### Important: One-shot reconcile model
+
+The Keycloak Operator's `KeycloakRealmImport` is **NOT continuously reconciled**.
+It runs once when the realm does not exist. Once a realm exists, **subsequent
+edits to the YAML are silently ignored**. This has two practical consequences:
+
+1. **Drift is invisible.** Manual changes in the admin UI will not be flagged
+   by ArgoCD as out-of-sync, because the operator does not compare live state
+   against the YAML.
+
+2. **YAML edits don't take effect** unless the realm is recreated:
+   ```bash
+   # Delete the import CR and the realm itself, then let ArgoCD reapply.
+   # WARNING: this drops every user, federated identity, and group membership
+   # in that realm. Acceptable for `zot` (federated GHA users only) and
+   # `ynufes-tech` (regenerated easily). NEVER do this for `user` without
+   # exporting and re-importing user data first.
+   kubectl delete keycloakrealmimport <realm-name> -n keycloak
+   # Then in admin UI: realm → Realm Settings → Action → Delete
+   # ArgoCD will recreate the import CR; the operator will reimport.
+   ```
+
+### Operating principle
+
+To keep YAML and live state aligned, follow this rule:
+
+> **Any change applied via the admin UI MUST be backported to the YAML in this
+> directory in the same PR.** If a change is impossible to express in the YAML
+> (see "Known declarative limits" below), document it as a manual post-import
+> step in the YAML's header comment.
+
+### Known declarative limits (manual post-import steps required)
+
+These items cannot be expressed in the `KeycloakRealmImport` shape today and
+must be applied by hand after each realm (re)creation. Each is documented in
+the affected realm YAML's header comment:
+
+| Item | Where | Why declarative is impossible |
+|---|---|---|
+| Client secret values | All clients with `clientAuthenticatorType: client-secret` | Keycloak generates the secret on first import; we use the literal placeholder `PLACEHOLDER_REPLACE_AFTER_REALM_IMPORT` and retrieve the real value from the admin UI afterwards. Stored in Vault, synced via ESO. |
+| Browser-flow IdP redirector binding | `zot`, others using brokered login | The "Identity Provider Redirector" execution must be added to the Browser flow and bound as the realm's Browser flow. Not expressible on the v2alpha1 CRD. |
+| FGAP token-exchange permissions | `zot` (`gha-exchanger` ↔ `github-actions` IdP) | Stored under `realm-management.authorizationSettings`, all references are internal UUIDs unknown until import time. See [keycloak#33401](https://github.com/keycloak/keycloak/issues/33401), [keycloak#35790](https://github.com/keycloak/keycloak/issues/35790). |
+
+Each realm YAML's header comment lists the realm-specific manual steps in
+order. Always re-run those after realm recreation.
+
+### Future: continuous reconciliation
+
+Long-term we may move client/IdP/permission configuration to **Crossplane
+provider-keycloak**, which gives true GitOps reconcile + drift correction +
+native CRDs for FGAP token-exchange permissions. The realm shell (groups,
+roles, scopes) would stay in `KeycloakRealmImport`. Tracked but not scheduled.
+
 ## Admin Access
 
 Admin credentials are managed separately (not by the operator). Access the admin console at:

--- a/keycloak-operator/zot-realm.yaml
+++ b/keycloak-operator/zot-realm.yaml
@@ -33,9 +33,13 @@
 # 3. Generate the zot UI session encryption key and store it in Vault:
 #      vault kv put zot/session-keys key=$(openssl rand -base64 64)
 #
-# 4. (Optional) Repeat step 1-2 for the `gha-exchanger` client if/when its
-#    secret is needed by GHA workflows for the token-exchange grant. Store at
-#    `zot/gha-exchanger-client` (key: `clientsecret`) if required.
+# 4. Repeat step 1-2 for the `gha-exchanger` client. The token-exchange
+#    grant requires the GHA workflow to present this client_secret. Store at
+#    `zot/gha-exchanger-client` (key: `clientsecret`) and also set the GitHub
+#    repo / org secret `KEYCLOAK_GHA_EXCHANGER_SECRET` to the same value:
+#      vault kv put zot/gha-exchanger-client clientsecret=<value>
+#      gh secret set KEYCLOAK_GHA_EXCHANGER_SECRET \
+#        --repo Shion1305/k8s-GitOps --body "<value>"
 #
 # 5. Bind the Browser authentication flow to "Identity Provider Redirector"
 #    pinned to alias `user`, so human web logins skip the choice screen and
@@ -44,6 +48,23 @@
 #      execution at the top, Required, with config
 #      `Default Identity Provider = user`. Bind that flow as the realm's
 #      Browser flow. This step is not declarative on the CRD shape used here.
+#
+# 6. Grant the `gha-exchanger` client permission to perform `token-exchange`
+#    against the `github-actions` IdP. Without this, GitHub Actions workflows
+#    receive `HTTP 403: Client not allowed to exchange` from the token
+#    endpoint, even though `serviceAccountsEnabled: true` is set on the
+#    client below. Token-exchange v1 in Keycloak 26 is gated by Fine-Grained
+#    Admin Permissions (FGAP) on the IdP, which references internal UUIDs of
+#    both the IdP and the client and therefore cannot be expressed in a
+#    realm import (see keycloak#33401, keycloak#35790). Configure via UI:
+#      a. Identity Providers -> github-actions -> Permissions tab
+#         -> "Permissions enabled" = ON
+#      b. Click the auto-generated `token-exchange` permission
+#         -> "Policies" -> add a new "Client" policy named e.g.
+#         `gha-exchanger-can-exchange`, Clients=[gha-exchanger],
+#         Logic=Positive -> Save.
+#      c. Back on the permission, attach the new policy -> Save.
+#    Reference: https://www.keycloak.org/securing-apps/token-exchange
 #
 # -----------------------------------------------------------------------------
 # Out of scope for this YAML:


### PR DESCRIPTION
## Summary

- Adds manual post-import step #6 to `zot-realm.yaml` documenting how to grant the `gha-exchanger` client `token-exchange` permission on the `github-actions` IdP via the admin UI. This unblocks GitHub Actions image push (currently failing with `HTTP 403: Client not allowed to exchange`).
- Promotes step #4 (gha-exchanger client_secret retrieval) from optional to required, with the matching `gh secret set KEYCLOAK_GHA_EXCHANGER_SECRET` line.
- Adds a new "Realm Configuration" section to `keycloak-operator/README.md` capturing:
  - The KeycloakRealmImport **one-shot reconcile model** and how to recreate a realm safely.
  - The operating principle that UI changes must be backported to YAML in the same PR.
  - Known declarative limits (client secrets, browser-flow IdP redirector, FGAP token-exchange).
  - Future direction (Crossplane provider-keycloak) for true continuous reconciliation.

## Why no realm recreation

FGAP permissions can be set on an existing realm without recreation; the IdP and client already exist. Only the FGAP policy/permission objects need to be added, which is a UI-only operation due to KeycloakRealmImport's UUID-reference limitation.

## Why not declarative

Researched and confirmed:
- `realm-management.authorizationSettings` references all use Keycloak-internal UUIDs (the IdP's `idp.resource.<uuid>`, client policy `clients: ["<uuid>"]`), unknown until after realm import.
- Even round-tripping a manually configured realm export fails — admin REST returns `authorizationSettings: null` for `realm-management` ([keycloak#35790](https://github.com/keycloak/keycloak/issues/35790)).
- Operator import of `authorizationSettings` is broken ([keycloak#33401](https://github.com/keycloak/keycloak/issues/33401)).
- No production examples of FGAP-in-realm-import exist on GitHub.

The right long-term solution is Crossplane `provider-keycloak`, which has a native `IdentityProviderTokenExchangeScopePermission` CRD. Tracked as future work in the new README section.

## Test plan

- [ ] Merge this PR (docs-only; no live impact).
- [ ] Apply the new step #6 manually in the Keycloak admin UI (5 min).
- [ ] Run step #4: retrieve `gha-exchanger` client secret from UI, store in Vault and GH repo secret.
- [ ] Re-run PR #278 (demo workflow) → should now succeed past the token-exchange step.