### PR TITLE
feat(zot): rename zot-ui client + cluster-wide pull automation

### DIFF
--- a/apps/zot-pull-app.yaml
+++ b/apps/zot-pull-app.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: zot-pull
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Shion1305/k8s-GitOps.git
+    targetRevision: HEAD
+    path: zot-pull
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: external-secrets
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/docs/zot-registry-deployment-plan.md
+++ b/docs/zot-registry-deployment-plan.md
@@ -354,7 +354,7 @@ Update the realm table to include `cluster-puller` and rename
 
 ## 6. Rollout sequence
 
-1. **PR #278 (the bigger one)** — everything except realm rename + cluster-puller client:
+1. **PR #278** — everything except realm rename + cluster-puller client:
    - `zot/values.yaml` switches to bearer-only
    - `zot/httproute-*.yaml` split
    - `zot/securitypolicy.yaml` new
@@ -363,7 +363,7 @@ Update the realm table to include `cluster-puller` and rename
    - `zot/kustomization.yaml` updated
    - `zot/README.md` new
    - Updated docs
-   - GHA demo workflow rewrite (already on the branch)
+   - GHA demo workflow rewrite
 
    Result after merge:
    - Browser UI login still works because the existing `oauth2-proxy`
@@ -375,17 +375,32 @@ Update the realm table to include `cluster-puller` and rename
    - Cluster pull does NOT yet work; namespaces still need to use external
      pull paths if they pull from this registry.
 
-2. **PR (next) — realm rename + cluster-puller client + zot-pull/ + Vault role**:
+2. **PR (this one) — realm rename + cluster-puller client + zot-pull/ + Vault role**.
+   Stacked on PR #278's branch (`fix/demo-push-error-handling`) until #278
+   merges, then rebased on `main`.
    - `keycloak-operator/zot-realm.yaml` renames `oauth2-proxy` → `zot-ui`,
      adds `cluster-puller`.
    - `zot/external-secret.yaml` updates `client-id: oauth2-proxy` →
      `client-id: zot-ui`.
-   - `zot-pull/` directory + `apps/zot-pull-app.yaml`.
+   - `zot-pull/` directory (5 files: ClusterSecretStore, credentials
+     ExternalSecret, ClusterGenerator, ClusterExternalSecret, kustomization)
+     + `apps/zot-pull-app.yaml`.
    - `vault/scripts/setup-eso-policies.sh` adds eso-cluster-puller policy + role.
-   - Manual realm recreate after merge.
-   - Manual Vault writes for new secrets.
+   - Manual steps required AFTER merge (realm recreate is destructive):
+     a. `kubectl delete keycloakrealmimport zot -n keycloak`
+     b. Admin UI: realm `zot` → Realm Settings → Action → Delete (drops
+        federated-identity links — small impact, user count is small)
+     c. ArgoCD recreates the import CR; operator reimports the realm.
+     d. Admin UI: pull generated secrets for `zot-ui` and `cluster-puller`.
+     e. `vault kv put zot/keycloak-client clientsecret=<zot-ui-secret>`
+     f. `vault kv put zot/cluster-puller client_id=cluster-puller client_secret=<cluster-puller-secret>`
+     g. Run `bash vault/scripts/setup-eso-policies.sh` to apply the new
+        Vault policy + role.
+     h. Re-broker passkey users on first login.
+     i. Re-assign group memberships (`zot-admin`, `pusher-shion1305`,
+        `pusher-shion1305dev`) to the appropriate users.
 
-   Result after merge:
+   Result after merge + manual steps:
    - All four trust paths in §2.2 are live.
    - Existing namespaces opt in by labeling and adding `imagePullSecrets`.
 

--- a/keycloak-operator/zot-realm.yaml
+++ b/keycloak-operator/zot-realm.yaml
@@ -4,19 +4,21 @@
 #
 # This file is reconciled by the Keycloak Operator (KeycloakRealmImport CRD).
 # It declares the `zot` realm used to authenticate human users to the zot
-# registry Web UI:
+# registry Web UI and to mint pull tokens for in-cluster workloads:
 #   - Browser login flow runs through Envoy Gateway's `SecurityPolicy.oidc`
 #     (zot/securitypolicy.yaml), which performs the Authorization Code flow
-#     against this realm using the `oauth2-proxy` confidential client below
-#     and forwards the Keycloak access token upstream as `Authorization:
+#     against this realm using the `zot-ui` confidential client below and
+#     forwards the Keycloak access token upstream as `Authorization:
 #     Bearer ...` (forwardAccessToken: true).
-#   - zot's `http.auth.bearer.oidc[]` validates that token (issuer =
-#     this realm, audience = `zot-registry`) and authorizes via the `groups`
-#     claim.
-#
-# A planned follow-up PR renames the `oauth2-proxy` client to `zot-ui` and
-# adds a `cluster-puller` service-account client for kubelet pulls. See
-# docs/zot-registry-deployment-plan.md.
+#   - In-cluster image pulls (kubelet imagePullSecrets) and manual
+#     `docker login` from WireGuard hosts use the `cluster-puller`
+#     service-account client below (grant_type=client_credentials). ESO's
+#     ClusterGenerator (zot-pull/cluster-generator.yaml) calls Keycloak's
+#     token endpoint and templates a dockerconfigjson Secret named
+#     `zot-pull` into every namespace labelled `zot-pull/enabled=true`.
+#   - zot's `http.auth.bearer.oidc[]` validates the access tokens issued by
+#     this realm (audience = `zot-registry`) and authorizes via the
+#     `groups` claim.
 #
 # GitHub Actions does NOT pass through Keycloak. CI/CD workflows present
 # their own GitHub OIDC token directly to zot at `registry.shion1305.com`,
@@ -35,12 +37,13 @@
 #    overwritten by Keycloak on first import; subsequent reconciles do not
 #    re-apply the placeholder.
 #
-# 2. Repeat for `oauth2-proxy` and persist both into Vault:
-#      vault kv put zot/keycloak-client clientsecret=<zot-registry-secret>
-#      vault kv put oauth2-proxy/keycloak \
-#        client-id=oauth2-proxy \
-#        client-secret=<oauth2-proxy-secret> \
-#        cookie-secret=$(openssl rand -base64 32 | tr -- '+/' '-_' | head -c 32)
+# 2. Repeat for `zot-ui` and `cluster-puller`, then persist all three into
+#    Vault (the zot/cluster-puller path is read by ESO via the
+#    `eso-cluster-puller` Vault role; see vault/scripts/setup-eso-policies.sh):
+#      vault kv put zot/keycloak-client clientsecret=<zot-ui-secret>
+#      vault kv put zot/cluster-puller \
+#        client_id=cluster-puller \
+#        client_secret=<cluster-puller-secret>
 #
 # 3. Bind the Browser authentication flow to "Identity Provider Redirector"
 #    pinned to alias `user`, so human web logins skip the choice screen and go
@@ -321,10 +324,10 @@ spec:
     # -------------------------------------------------------------------------
     clients:
       # zot-registry: confidential client. Its sole purpose now is to be the
-      # `aud` audience that oauth2-proxy stamps onto the access_token (via the
-      # audience mapper below). zot's `bearer.oidc[].audiences=[zot-registry]`
-      # validates against this. The client is NOT used directly for any
-      # interactive login flow; oauth2-proxy is.
+      # `aud` audience that the `zot-ui` and `cluster-puller` clients stamp
+      # onto their access_tokens (via the audience mappers below). zot's
+      # `bearer.oidc[].audiences=[zot-registry]` validates against this.
+      # The client is NOT used directly for any interactive login flow.
       - clientId: zot-registry
         protocol: openid-connect
         publicClient: false
@@ -338,11 +341,12 @@ spec:
         attributes:
           access.token.lifespan: "3600"
 
-      # oauth2-proxy: confidential client used by the oauth2-proxy sidecar
-      # to run the human Authorization Code flow. Its access_token carries
-      # `aud=[oauth2-proxy, zot-registry]` (via the audience mapper) so zot
-      # accepts it under the bearer.oidc[Keycloak] entry.
-      - clientId: oauth2-proxy
+      # zot-ui: confidential client driven by Envoy Gateway's SecurityPolicy
+      # (zot/securitypolicy.yaml) to run the human Authorization Code flow.
+      # Its access_token carries `aud=[zot-ui, zot-registry]` (via the
+      # audience mapper) so zot accepts it under the bearer.oidc[Keycloak]
+      # entry.
+      - clientId: zot-ui
         protocol: openid-connect
         publicClient: false
         clientAuthenticatorType: client-secret
@@ -379,6 +383,52 @@ spec:
               included.client.audience: "zot-registry"
               id.token.claim: "false"
               access.token.claim: "true"
+
+      # cluster-puller: confidential client used by ESO's ClusterGenerator
+      # (zot-pull/cluster-generator.yaml) to mint short-lived access_tokens
+      # via grant_type=client_credentials. The materialized dockerconfigjson
+      # is fanned out to every namespace labelled `zot-pull/enabled=true`,
+      # so kubelet can `imagePullSecrets`-pull from the registry.
+      #
+      # Service-account flow only: no human-facing flow, no interactive
+      # login, no redirectUris. The hardcoded `groups` mapper carries both
+      # pusher group names so the cluster can pull from `shion1305/**` and
+      # `shion1305dev/**` regardless of how `defaultPolicy` evolves on
+      # individual repositories.
+      - clientId: cluster-puller
+        protocol: openid-connect
+        publicClient: false
+        clientAuthenticatorType: client-secret
+        secret: PLACEHOLDER_REPLACE_AFTER_REALM_IMPORT
+        standardFlowEnabled: false
+        directAccessGrantsEnabled: false
+        serviceAccountsEnabled: true
+        attributes:
+          access.token.lifespan: "3600"
+        protocolMappers:
+          # Audience mapper required because Keycloak service-account
+          # access_tokens default to `aud=account`.
+          - name: zot-registry-audience
+            protocolMapper: oidc-audience-mapper
+            protocol: openid-connect
+            config:
+              included.client.audience: "zot-registry"
+              id.token.claim: "false"
+              access.token.claim: "true"
+          # Static `groups` claim so zot's accessControl authorizes the
+          # service account against the pusher repos. Read on
+          # `**` is also permitted by `defaultPolicy: ["read"]`, but the
+          # explicit groups make the intent visible.
+          - name: groups-static
+            protocolMapper: oidc-hardcoded-claim-mapper
+            protocol: openid-connect
+            config:
+              claim.name: "groups"
+              claim.value: '["pusher-shion1305", "pusher-shion1305dev"]'
+              jsonType.label: "JSON"
+              id.token.claim: "false"
+              access.token.claim: "true"
+              userinfo.token.claim: "false"
 
     # -------------------------------------------------------------------------
     # Identity Providers

--- a/vault/scripts/setup-eso-policies.sh
+++ b/vault/scripts/setup-eso-policies.sh
@@ -129,6 +129,20 @@ path "cloudflare-grafana/metadata/*" {
 EOF
 echo "✓ Created policy: eso-cloudflare-grafana"
 
+# Policy for the cluster-wide zot-pull automation. Reads only the Keycloak
+# `cluster-puller` service-account credentials at zot/cluster-puller.
+# Consumed by the ClusterSecretStore `vault-zot-cluster-puller` (zot-pull/),
+# which feeds the ClusterGenerator that mints pull bearer tokens.
+vault policy write eso-cluster-puller - <<EOF
+path "zot/data/cluster-puller" {
+  capabilities = ["read"]
+}
+path "zot/metadata/cluster-puller" {
+  capabilities = ["read", "list"]
+}
+EOF
+echo "✓ Created policy: eso-cluster-puller"
+
 echo ""
 echo "=== Creating namespace-scoped Kubernetes auth roles ==="
 
@@ -212,6 +226,16 @@ vault write auth/kubernetes/role/eso-cloudflare-grafana \
   ttl=1h
 echo "✓ Created role: eso-cloudflare-grafana"
 
+# cluster-puller (cluster-scoped store; binds to the ESO operator SA so the
+# ClusterSecretStore `vault-zot-cluster-puller` can read zot/cluster-puller
+# from any namespace context the controller runs in).
+vault write auth/kubernetes/role/eso-cluster-puller \
+  bound_service_account_names=external-secrets \
+  bound_service_account_namespaces=external-secrets \
+  policies=eso-cluster-puller \
+  ttl=1h
+echo "✓ Created role: eso-cluster-puller"
+
 echo ""
 echo "=== Removing old broad policy ==="
 vault policy delete eso-policy 2>/dev/null && echo "✓ Deleted old policy: eso-policy" || echo "ⓘ Policy eso-policy not found (already removed)"
@@ -230,3 +254,4 @@ echo "  eso-cert-manager→ SA eso/cert-manager    → system/data/cert-manager"
 echo "  eso-zot         → SA eso/zot             → zot/data/*"
 echo "  eso-github-app  → SA external-secrets/external-secrets → github-app-shared/data/*"
 echo "  eso-cloudflare-grafana → SA eso/monitoring     → cloudflare-grafana/data/*"
+echo "  eso-cluster-puller → SA external-secrets/external-secrets → zot/data/cluster-puller"

--- a/zot-pull/cluster-external-secret.yaml
+++ b/zot-pull/cluster-external-secret.yaml
@@ -1,0 +1,63 @@
+# Fans out a Kubernetes dockerconfigjson Secret named `zot-pull` into every
+# namespace labelled `zot-pull/enabled=true`. The Secret carries a fresh
+# Keycloak access_token minted by the ClusterGenerator (Webhook), so kubelet
+# can `imagePullSecrets`-pull from registry.shion1305.com without storing a
+# long-lived password.
+#
+# Refresh cadence:
+#   - refreshTime: 5m   — how often the controller scans for newly labelled
+#                          namespaces and pushes the Secret into them.
+#   - refreshInterval: 15m — how often the templated Secret is re-rendered.
+#                            Keycloak access.token.lifespan is 1h, so 15m
+#                            leaves a comfortable margin for clock skew and
+#                            in-flight pulls.
+#
+# Consuming a namespace:
+#   apiVersion: v1
+#   kind: Namespace
+#   metadata:
+#     name: my-app
+#     labels:
+#       zot-pull/enabled: "true"
+#   ---
+#   spec:
+#     imagePullSecrets:
+#       - name: zot-pull
+apiVersion: external-secrets.io/v1
+kind: ClusterExternalSecret
+metadata:
+  name: zot-pull
+spec:
+  namespaceSelector:
+    matchLabels:
+      zot-pull/enabled: "true"
+  refreshTime: 5m
+  externalSecretSpec:
+    refreshInterval: 15m
+    target:
+      name: zot-pull
+      creationPolicy: Owner
+      deletionPolicy: Retain
+      template:
+        # Standard kubelet pull-secret format. zot ignores the username on
+        # bearer-OIDC; "oidc" is just a non-empty placeholder.
+        type: kubernetes.io/dockerconfigjson
+        engineVersion: v2
+        data:
+          .dockerconfigjson: |
+            {
+              "auths": {
+                "registry.shion1305.com": {
+                  "auth": "{{ printf "oidc:%s" .access_token | b64enc }}"
+                },
+                "registry.i.shion1305.com": {
+                  "auth": "{{ printf "oidc:%s" .access_token | b64enc }}"
+                }
+              }
+            }
+    dataFrom:
+      - sourceRef:
+          generatorRef:
+            apiVersion: generators.external-secrets.io/v1alpha1
+            kind: ClusterGenerator
+            name: keycloak-cluster-puller-token

--- a/zot-pull/cluster-generator.yaml
+++ b/zot-pull/cluster-generator.yaml
@@ -1,0 +1,30 @@
+# ClusterGenerator that performs an OAuth2 client_credentials grant against
+# Keycloak's token endpoint and yields the resulting access_token. The
+# ClusterExternalSecret consumes this generator to template a dockerconfigjson
+# Secret in every opted-in namespace.
+#
+# The Keycloak access_token's lifespan controls the maximum staleness of the
+# materialized Secret. With Keycloak `access.token.lifespan: 3600` (1h) and
+# the ClusterExternalSecret refreshInterval set well below that, kubelet
+# always finds a fresh bearer when it pulls.
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: ClusterGenerator
+metadata:
+  name: keycloak-cluster-puller-token
+spec:
+  kind: Webhook
+  generator:
+    webhookSpec:
+      url: https://keycloak.shion1305.com/realms/zot/protocol/openid-connect/token
+      method: POST
+      timeout: 10s
+      headers:
+        Content-Type: application/x-www-form-urlencoded
+      body: 'grant_type=client_credentials&client_id={{ .creds.client_id }}&client_secret={{ .creds.client_secret }}'
+      result:
+        jsonPath: '$'
+      secrets:
+        - name: creds
+          secretRef:
+            name: zot-cluster-puller-credentials
+            namespace: external-secrets

--- a/zot-pull/cluster-secret-store.yaml
+++ b/zot-pull/cluster-secret-store.yaml
@@ -1,0 +1,22 @@
+# ClusterSecretStore so the ClusterGenerator (Webhook) and ClusterExternalSecret
+# can read the `cluster-puller` Keycloak client credentials from Vault.
+#
+# Bound to the cluster-scoped SA `external-secrets/external-secrets` via a
+# Vault role `eso-cluster-puller` (defined in vault/scripts/setup-eso-policies.sh).
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: vault-zot-cluster-puller
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "zot"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "eso-cluster-puller"
+          serviceAccountRef:
+            name: "external-secrets"
+            namespace: "external-secrets"

--- a/zot-pull/credentials-external-secret.yaml
+++ b/zot-pull/credentials-external-secret.yaml
@@ -1,0 +1,28 @@
+# Materializes the Keycloak `cluster-puller` client credentials from Vault into
+# the external-secrets namespace, where the ClusterGenerator references it to
+# call Keycloak's token endpoint.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: zot-cluster-puller-credentials
+  namespace: external-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-zot-cluster-puller
+    kind: ClusterSecretStore
+  target:
+    name: zot-cluster-puller-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      engineVersion: v2
+  data:
+    - secretKey: client_id
+      remoteRef:
+        key: cluster-puller
+        property: client_id
+    - secretKey: client_secret
+      remoteRef:
+        key: cluster-puller
+        property: client_secret

--- a/zot-pull/kustomization.yaml
+++ b/zot-pull/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster-secret-store.yaml
+  - credentials-external-secret.yaml
+  - cluster-generator.yaml
+  - cluster-external-secret.yaml

--- a/zot/README.md
+++ b/zot/README.md
@@ -49,8 +49,6 @@ flow with zot.
 
 ## Onboarding a namespace to cluster pull
 
-> Available after the second-PR `zot-pull/` rollout lands.
-
 ```yaml
 apiVersion: v1
 kind: Namespace
@@ -124,7 +122,7 @@ ArgoCD recreates the CR and the operator reimports. Then:
   for OIDC discovery errors.
 - Confirm the `zot-ui-oidc-credentials` Secret exists in the `zot` namespace
   and contains non-empty `client-id` and `client-secret` keys.
-- The Keycloak `oauth2-proxy` client (post-rename: `zot-ui`) must list both
+- The Keycloak `zot-ui` client must list both
   `https://registry.shion1305.com/oauth2/callback` and
   `https://registry.i.shion1305.com/oauth2/callback` in `redirectUris`.
 

--- a/zot/external-secret.yaml
+++ b/zot/external-secret.yaml
@@ -6,10 +6,9 @@
 # tokens (forwarded by Envoy as `Authorization: Bearer ...`) directly against
 # the issuer JWKS via `http.auth.bearer.oidc[]` in zot/values.yaml.
 #
-# The Keycloak client is currently `oauth2-proxy` (legacy name kept until the
-# realm-recreate PR renames it to `zot-ui`). The literal client-id below moves
-# in lockstep with the realm; do NOT regenerate this without coordinating both
-# changes (see zot/README.md).
+# The literal client-id below MUST match the Keycloak client name in
+# `keycloak-operator/zot-realm.yaml`. Don't change one without the other; the
+# Vault secret behind `clientsecret` is the secret of that exact client.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -31,7 +30,7 @@ spec:
       # Envoy Gateway's SecurityPolicy.oidc requires fixed keys
       # `client-id` and `client-secret` (see oidc_types.go in v1.7.x).
       data:
-        client-id: "oauth2-proxy"
+        client-id: "zot-ui"
         client-secret: "{{ .clientsecret | trim | replace \"\n\" \"\" }}"
   data:
     - secretKey: clientsecret

--- a/zot/securitypolicy.yaml
+++ b/zot/securitypolicy.yaml
@@ -38,8 +38,8 @@ spec:
     # redirectURL omitted on purpose: Envoy auto-derives it as
     # https://<:authority>/oauth2/callback per request. This lets the same
     # SecurityPolicy serve both registry.shion1305.com and
-    # registry.i.shion1305.com without a second policy. Keycloak's
-    # `oauth2-proxy` (post-rename: `zot-ui`) client must list BOTH
+    # registry.i.shion1305.com without a second policy. Keycloak's `zot-ui`
+    # client must list BOTH
     # `https://registry.shion1305.com/oauth2/callback` and
     # `https://registry.i.shion1305.com/oauth2/callback` in redirectUris —
     # already declared in keycloak-operator/zot-realm.yaml.


### PR DESCRIPTION
## Summary

Second of two PRs landing the bearer-only zot architecture. Stacked on #278; rebase target moves to `main` once #278 merges.

- **Realm**: rename `oauth2-proxy` → `zot-ui`; add `cluster-puller` service-account client (audience mapper + hardcoded `groups` for both org namespaces)
- **`zot-pull/`** (new): ClusterSecretStore + credentials ExternalSecret + ClusterGenerator (Webhook → Keycloak token endpoint) + ClusterExternalSecret fanning out a `kubernetes.io/dockerconfigjson` Secret named `zot-pull` into every namespace labelled `zot-pull/enabled=true`
- **Vault**: new `eso-cluster-puller` policy + auth role (binds to operator SA `external-secrets/external-secrets`)
- **Consumers**: `zot/external-secret.yaml` updates `client-id` to `zot-ui`; comment caveats dropped from `zot/securitypolicy.yaml`, `zot/README.md`

Plan: [`docs/zot-registry-deployment-plan.md`](docs/zot-registry-deployment-plan.md) §6 step 2.

## Manual steps required after merge

> The KeycloakRealmImport CRD only reconciles on first import, so the realm must be deleted and recreated for these changes to take effect. Federated-identity links drop on recreate.

1. `kubectl delete keycloakrealmimport zot -n keycloak`
2. Admin UI: realm `zot` → Realm Settings → Action → Delete
3. ArgoCD recreates the import CR; operator reimports.
4. Admin UI: pull generated client secrets for `zot-ui` and `cluster-puller`.
5. Vault writes:
   - `vault kv put zot/keycloak-client clientsecret=<zot-ui-secret>`
   - `vault kv put zot/cluster-puller client_id=cluster-puller client_secret=<cluster-puller-secret>`
6. `bash vault/scripts/setup-eso-policies.sh` to apply the new policy + role.
7. Re-broker passkey users on first login; re-assign `zot-admin` / `pusher-shion1305` / `pusher-shion1305dev` group memberships.

## Test plan

- [ ] After realm recreate + Vault writes, `kubectl get externalsecret zot-ui-oidc-credentials -n zot` reaches `SecretSynced`
- [ ] `kubectl get clusterexternalsecret zot-pull` shows non-zero `provisionedNamespaces`
- [ ] Label a test namespace: `kubectl label ns test-pull zot-pull/enabled=true`; `kubectl get secret zot-pull -n test-pull` appears within ~5 minutes
- [ ] Pod with `imagePullSecrets: [{name: zot-pull}]` pulling `registry.shion1305.com/shion1305/demo:latest` reaches `Running`
- [ ] Browser login at `https://registry.shion1305.com/` succeeds with the new `zot-ui` client
- [ ] GHA push (no change in this PR) still works
- [ ] Manual `docker login registry.i.shion1305.com -u oidc -p <kc_at>` succeeds (per `zot/README.md`)