### PR TITLE
feat(zot-pull): cluster-wide imagePullSecret automation

### DIFF
--- a/apps/zot-pull-app.yaml
+++ b/apps/zot-pull-app.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: zot-pull
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Shion1305/k8s-GitOps.git
+    targetRevision: HEAD
+    path: zot-pull
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: external-secrets
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/zot-pull/cluster-external-secret.yaml
+++ b/zot-pull/cluster-external-secret.yaml
@@ -1,0 +1,63 @@
+# Fans out a Kubernetes dockerconfigjson Secret named `zot-pull` into every
+# namespace labelled `zot-pull/enabled=true`. The Secret carries a fresh
+# Keycloak access_token minted by the ClusterGenerator (Webhook), so kubelet
+# can `imagePullSecrets`-pull from registry.shion1305.com without storing a
+# long-lived password.
+#
+# Refresh cadence:
+#   - refreshTime: 5m   — how often the controller scans for newly labelled
+#                          namespaces and pushes the Secret into them.
+#   - refreshInterval: 15m — how often the templated Secret is re-rendered.
+#                            Keycloak access.token.lifespan is 1h, so 15m
+#                            leaves a comfortable margin for clock skew and
+#                            in-flight pulls.
+#
+# Consuming a namespace:
+#   apiVersion: v1
+#   kind: Namespace
+#   metadata:
+#     name: my-app
+#     labels:
+#       zot-pull/enabled: "true"
+#   ---
+#   spec:
+#     imagePullSecrets:
+#       - name: zot-pull
+apiVersion: external-secrets.io/v1
+kind: ClusterExternalSecret
+metadata:
+  name: zot-pull
+spec:
+  namespaceSelector:
+    matchLabels:
+      zot-pull/enabled: "true"
+  refreshTime: 5m
+  externalSecretSpec:
+    refreshInterval: 15m
+    target:
+      name: zot-pull
+      creationPolicy: Owner
+      deletionPolicy: Retain
+      template:
+        # Standard kubelet pull-secret format. zot ignores the username on
+        # bearer-OIDC; "oidc" is just a non-empty placeholder.
+        type: kubernetes.io/dockerconfigjson
+        engineVersion: v2
+        data:
+          .dockerconfigjson: |
+            {
+              "auths": {
+                "registry.shion1305.com": {
+                  "auth": "{{ printf "oidc:%s" .access_token | b64enc }}"
+                },
+                "registry.i.shion1305.com": {
+                  "auth": "{{ printf "oidc:%s" .access_token | b64enc }}"
+                }
+              }
+            }
+    dataFrom:
+      - sourceRef:
+          generatorRef:
+            apiVersion: generators.external-secrets.io/v1alpha1
+            kind: ClusterGenerator
+            name: keycloak-cluster-puller-token

--- a/zot-pull/cluster-generator.yaml
+++ b/zot-pull/cluster-generator.yaml
@@ -1,0 +1,30 @@
+# ClusterGenerator that performs an OAuth2 client_credentials grant against
+# Keycloak's token endpoint and yields the resulting access_token. The
+# ClusterExternalSecret consumes this generator to template a dockerconfigjson
+# Secret in every opted-in namespace.
+#
+# The Keycloak access_token's lifespan controls the maximum staleness of the
+# materialized Secret. With Keycloak `access.token.lifespan: 3600` (1h) and
+# the ClusterExternalSecret refreshInterval set well below that, kubelet
+# always finds a fresh bearer when it pulls.
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: ClusterGenerator
+metadata:
+  name: keycloak-cluster-puller-token
+spec:
+  kind: Webhook
+  generator:
+    webhookSpec:
+      url: https://keycloak.shion1305.com/realms/zot/protocol/openid-connect/token
+      method: POST
+      timeout: 10s
+      headers:
+        Content-Type: application/x-www-form-urlencoded
+      body: 'grant_type=client_credentials&client_id={{ .creds.client_id }}&client_secret={{ .creds.client_secret }}'
+      result:
+        jsonPath: '$'
+      secrets:
+        - name: creds
+          secretRef:
+            name: zot-cluster-puller-credentials
+            namespace: external-secrets

--- a/zot-pull/cluster-secret-store.yaml
+++ b/zot-pull/cluster-secret-store.yaml
@@ -1,0 +1,22 @@
+# ClusterSecretStore so the ClusterGenerator (Webhook) and ClusterExternalSecret
+# can read the `cluster-puller` Keycloak client credentials from Vault.
+#
+# Bound to the cluster-scoped SA `external-secrets/external-secrets` via a
+# Vault role `eso-cluster-puller` (defined in vault/scripts/setup-eso-policies.sh).
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: vault-zot-cluster-puller
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "zot"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "eso-cluster-puller"
+          serviceAccountRef:
+            name: "external-secrets"
+            namespace: "external-secrets"

--- a/zot-pull/credentials-external-secret.yaml
+++ b/zot-pull/credentials-external-secret.yaml
@@ -1,0 +1,28 @@
+# Materializes the Keycloak `cluster-puller` client credentials from Vault into
+# the external-secrets namespace, where the ClusterGenerator references it to
+# call Keycloak's token endpoint.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: zot-cluster-puller-credentials
+  namespace: external-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-zot-cluster-puller
+    kind: ClusterSecretStore
+  target:
+    name: zot-cluster-puller-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      engineVersion: v2
+  data:
+    - secretKey: client_id
+      remoteRef:
+        key: cluster-puller
+        property: client_id
+    - secretKey: client_secret
+      remoteRef:
+        key: cluster-puller
+        property: client_secret

--- a/zot-pull/kustomization.yaml
+++ b/zot-pull/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster-secret-store.yaml
+  - credentials-external-secret.yaml
+  - cluster-generator.yaml
+  - cluster-external-secret.yaml


### PR DESCRIPTION
## Summary

Fan out a Kubernetes \`dockerconfigjson\` Secret named \`zot-pull\` into every namespace labelled \`zot-pull/enabled=true\`, carrying a fresh Keycloak access_token so kubelet can \`imagePullSecrets\`-pull from \`registry.shion1305.com\` without storing a long-lived password.

Components (all in \`zot-pull/\`, fronted by \`apps/zot-pull-app.yaml\`):
- **ClusterSecretStore** \`vault-zot-cluster-puller\` — reads Vault KV v2 mount \`zot/\`, role \`eso-cluster-puller\`.
- **ExternalSecret** \`zot-cluster-puller-credentials\` — materializes the Keycloak \`cluster-puller\` client credentials in the \`external-secrets\` namespace.
- **ClusterGenerator** (Webhook) \`keycloak-cluster-puller-token\` — POSTs \`grant_type=client_credentials\` to Keycloak's token endpoint, returns the full token JSON.
- **ClusterExternalSecret** \`zot-pull\` — \`namespaceSelector: { zot-pull/enabled: \"true\" }\`, \`refreshInterval: 15m\` vs 1h token TTL. Templates a \`kubernetes.io/dockerconfigjson\` Secret with \`auth: b64encode(\"oidc:<access_token>\")\` for both registry hostnames.

## Dependency

**Blocked on #282** (\`cluster-puller\` Keycloak client + \`eso-cluster-puller\` Vault policy/role). Until that PR merges, the realm is recreated, and the Vault writes are done, this app will sit in \`OutOfSync\` / \`Degraded\`.

## Consumer onboarding

\`\`\`yaml
apiVersion: v1
kind: Namespace
metadata:
  name: my-app
  labels:
    zot-pull/enabled: \"true\"
---
spec:
  imagePullSecrets:
    - name: zot-pull
\`\`\`

See [\`zot/README.md\`](zot/README.md) for the full operator guide.

## Test plan

- [ ] After #282 merges + realm recreate + Vault writes done: \`kubectl get clusterexternalsecret zot-pull\` reaches \`Ready\`
- [ ] Label a test namespace: \`kubectl label ns test-pull zot-pull/enabled=true\`; \`kubectl get secret zot-pull -n test-pull\` appears within ~5 minutes (controller's refreshTime)
- [ ] Decode the materialized Secret: \`kubectl get secret zot-pull -n test-pull -o jsonpath='{.data.\\\\.dockerconfigjson}' | base64 -d | jq\` — \`auth\` decodes to \`oidc:<jwt>\`; the JWT \`aud\` includes \`zot-registry\` and \`groups\` contains both pusher group names
- [ ] A test Pod with \`imagePullSecrets: [{name: zot-pull}]\` pulling \`registry.shion1305.com/shion1305/demo:latest\` reaches \`Running\`
- [ ] After 15 minutes the Secret is re-rendered with a fresh JWT (\`exp\` claim moves forward)