### PR TITLE
refactor(zot): switch to bearer-only OIDC + Envoy Gateway SecurityPolicy

### DIFF
--- a/zot/external-secret.yaml
+++ b/zot/external-secret.yaml
@@ -1,7 +1,18 @@
+# Materializes the OIDC client credentials that Envoy Gateway's SecurityPolicy
+# (zot/securitypolicy.yaml) consumes to run the OIDC code flow against Keycloak
+# for browser users hitting the zot Web UI.
+#
+# zot itself no longer reads any local secret file: it validates Keycloak access
+# tokens (forwarded by Envoy as `Authorization: Bearer ...`) directly against
+# the issuer JWKS via `http.auth.bearer.oidc[]` in zot/values.yaml.
+#
+# The literal client-id below MUST match the Keycloak client name in
+# `keycloak-operator/zot-realm.yaml`. Don't change one without the other; the
+# Vault secret behind `clientsecret` is the secret of that exact client.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: zot-oidc
+  name: zot-ui-oidc-credentials
   namespace: zot
 spec:
   refreshInterval: 5m
@@ -9,28 +20,20 @@ spec:
     name: vault
     kind: SecretStore
   target:
-    name: zot-oidc
+    name: zot-ui-oidc-credentials
     creationPolicy: Owner
     template:
       type: Opaque
       metadata:
         labels:
           managed-by: external-secrets
+      # Envoy Gateway's SecurityPolicy.oidc requires fixed keys
+      # `client-id` and `client-secret` (see oidc_types.go in v1.7.x).
       data:
-        # zot uses Viper to parse these files and infers format from the
-        # extension — keys must end in .json/.yaml/etc., not bare names.
-        # `openssl rand -base64 64` wraps lines at 76 chars; strip newlines
-        # so the rendered JSON is valid.
-        keycloak-credentials.json: |
-          {"clientid": "zot-registry", "clientsecret": "{{ .clientsecret | trim | replace "\n" "" }}"}
-        session-keys.json: |
-          {"hashKey": "{{ .sessionHashKey | trim | replace "\n" "" }}"}
+        client-id: "zot-ui"
+        client-secret: "{{ .clientsecret | trim | replace \"\n\" \"\" }}"
   data:
     - secretKey: clientsecret
       remoteRef:
         key: keycloak-client
         property: clientsecret
-    - secretKey: sessionHashKey
-      remoteRef:
-        key: session-keys
-        property: key

--- a/zot/httproute-external.yaml
+++ b/zot/httproute-external.yaml
@@ -1,12 +1,23 @@
 # Public registry URL — used by browsers (zot UI / OIDC code-flow login) and by
-# `docker push` from any host that can resolve the public DNS. No SecurityPolicy
-# is attached because the Docker registry v2 protocol negotiates its own bearer
-# tokens (zot delegates to Keycloak), which conflicts with gateway-level JWT
-# enforcement.
+# `docker push` from any host that can resolve the public DNS.
+#
+# Two HTTPRoutes share hostname registry.shion1305.com and split by path:
+#   - zot-registry-external: Docker Registry v2 protocol (/v2/...). No
+#     SecurityPolicy is attached because the Docker registry v2 protocol
+#     negotiates its own bearer tokens (zot delegates to Keycloak), which would
+#     conflict with gateway-level OIDC enforcement.
+#   - zot-ui-external: everything else, including the SPA, /zot/auth/*, and
+#     zot's own extension XHRs under /v2/_zot/*. A SecurityPolicy.oidc is
+#     attached to this route so browser traffic gets gateway-level SSO.
+#
+# Gateway API precedence (most-specific-path-wins, GEP-718) means /v2/_zot/...
+# requests are routed to zot-ui-external even though /v2/ on zot-registry-
+# external also matches — the longer prefix wins regardless of declaration
+# order or HTTPRoute boundary.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: zot-external
+  name: zot-registry-external
   namespace: zot
 spec:
   parentRefs:
@@ -16,6 +27,34 @@ spec:
   hostnames:
     - registry.shion1305.com
   rules:
-    - backendRefs:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v2/
+      backendRefs:
+        - name: zot
+          port: 5000
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: zot-ui-external
+  namespace: zot
+spec:
+  parentRefs:
+    - name: external
+      namespace: envoy-gateway-system
+      sectionName: https
+  hostnames:
+    - registry.shion1305.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+        - path:
+            type: PathPrefix
+            value: /v2/_zot/
+      backendRefs:
         - name: zot
           port: 5000

--- a/zot/httproute-internal.yaml
+++ b/zot/httproute-internal.yaml
@@ -1,11 +1,16 @@
 # Internal registry URL — reachable only via WireGuard (the *.i.shion1305.com
 # DNS A record points to 10.130.5.21). Provides a low-latency / no-egress path
 # for in-cluster CI/CD or trusted hosts that have WG connectivity, while the
-# public docker.shion1305.com URL handles GitHub Actions and external pulls.
+# public registry.shion1305.com URL handles GitHub Actions and external pulls.
+#
+# Same path-split pattern as the external Gateway: zot-registry-internal
+# handles Docker v2 protocol traffic (no OIDC, zot does its own bearer
+# challenge), zot-ui-internal handles the SPA + /v2/_zot/* extension XHRs and
+# carries the SecurityPolicy.oidc binding.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: zot-internal
+  name: zot-registry-internal
   namespace: zot
 spec:
   parentRefs:
@@ -15,6 +20,34 @@ spec:
   hostnames:
     - registry.i.shion1305.com
   rules:
-    - backendRefs:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v2/
+      backendRefs:
+        - name: zot
+          port: 5000
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: zot-ui-internal
+  namespace: zot
+spec:
+  parentRefs:
+    - name: internal
+      namespace: envoy-gateway-system
+      sectionName: https
+  hostnames:
+    - registry.i.shion1305.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+        - path:
+            type: PathPrefix
+            value: /v2/_zot/
+      backendRefs:
         - name: zot
           port: 5000

--- a/zot/kustomization.yaml
+++ b/zot/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - reference-grant.yaml
   - httproute-external.yaml
   - httproute-internal.yaml
+  - securitypolicy.yaml

--- a/zot/securitypolicy.yaml
+++ b/zot/securitypolicy.yaml
@@ -1,0 +1,64 @@
+# Envoy Gateway-managed OIDC for the zot Web UI.
+#
+# This SecurityPolicy binds to the zot-ui HTTPRoutes (external + internal). When
+# a browser hits anything other than `/v2/<repo>/...`, Envoy intercepts the
+# request, runs the OIDC Authorization Code flow against Keycloak realm `zot`,
+# stores tokens in encrypted cookies, and forwards the resulting access token
+# upstream as `Authorization: Bearer <kc_at>`. zot's `http.auth.bearer.oidc[]`
+# (issuer = this Keycloak realm, audience = `zot-registry`) then validates the
+# same token, enforces ACLs by `groups` claim, and serves the response.
+#
+# The Docker Registry v2 protocol path (`/v2/<repo>/...`) lives on a separate
+# HTTPRoute that does NOT have this policy attached, so `docker login` /
+# `docker push` from CI keep their own bearer challenge with zot directly.
+#
+# `passThroughAuthHeader: true` lets requests that already carry a Bearer
+# header (e.g. someone scripting against the UI extension API with a Keycloak
+# token in hand) bypass the redirect dance.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: zot-ui-oidc
+  namespace: zot
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: zot-ui-external
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: zot-ui-internal
+  oidc:
+    provider:
+      issuer: https://keycloak.shion1305.com/realms/zot
+    clientIDRef:
+      name: zot-ui-oidc-credentials
+    clientSecret:
+      name: zot-ui-oidc-credentials
+    # redirectURL omitted on purpose: Envoy auto-derives it as
+    # https://<:authority>/oauth2/callback per request. This lets the same
+    # SecurityPolicy serve both registry.shion1305.com and
+    # registry.i.shion1305.com without a second policy. Keycloak's
+    # `zot-ui` client must list BOTH
+    # `https://registry.shion1305.com/oauth2/callback` and
+    # `https://registry.i.shion1305.com/oauth2/callback` in redirectUris —
+    # already declared in keycloak-operator/zot-realm.yaml.
+    logoutPath: /logout
+    # `openid` is auto-added by Envoy. `groups` is required for zot's
+    # accessControl, sourced from the Keycloak group-membership mapper on the
+    # `zot-ui` client (see keycloak-operator/zot-realm.yaml).
+    scopes:
+      - email
+      - profile
+      - groups
+    # cookieDomain unset → Envoy uses host-only cookies (per request
+    # :authority). This lets cookies on registry.shion1305.com and
+    # registry.i.shion1305.com remain isolated, which is the safer default.
+    cookieConfig:
+      sameSite: Lax
+    cookieNames:
+      accessToken: zot_at
+      idToken: zot_it
+    forwardAccessToken: true
+    refreshToken: true
+    passThroughAuthHeader: true

--- a/zot/values.yaml
+++ b/zot/values.yaml
@@ -20,6 +20,23 @@ startupProbe:
   periodSeconds: 10
   failureThreshold: 6
 
+# zot uses `http.auth.bearer.oidc[]` (zot >= v2.1.14) so the registry can
+# directly validate two upstream OIDC issuers without going through Keycloak
+# token-exchange (deprecated in Keycloak 26+):
+#
+#   1. token.actions.githubusercontent.com — GitHub Actions OIDC tokens are
+#      pushed straight to /v2 by docker login + buildx. CEL claim mapping
+#      derives the username (claims.repository) and assigns the right
+#      pusher group based on `repository_owner`.
+#   2. keycloak.shion1305.com/realms/zot — used for the Web UI. Envoy
+#      Gateway runs the OIDC code flow via SecurityPolicy.oidc and injects
+#      the Keycloak access_token as `Authorization: Bearer ...` upstream
+#      (forwardAccessToken: true), so zot validates it like any other OIDC
+#      token. Cluster pull and manual `docker login` use the same issuer
+#      via the `cluster-puller` service-account client.
+#
+# The accessControl block is unchanged: groups (`pusher-shion1305`,
+# `pusher-shion1305dev`, `zot-admin`) gate the read/write actions.
 mountConfig: true
 configFiles:
   config.json: |-
@@ -37,17 +54,37 @@ configFiles:
         "externalUrl": "https://registry.shion1305.com",
         "realm": "zot",
         "auth": {
-          "openid": {
-            "providers": {
-              "oidc": {
-                "name": "oidc",
+          "bearer": {
+            "realm": "zot",
+            "service": "registry.shion1305.com",
+            "oidc": [
+              {
+                "issuer": "https://token.actions.githubusercontent.com",
+                "audiences": ["registry.shion1305.com"],
+                "claimMapping": {
+                  "variables": [
+                    { "name": "owner", "expression": "claims.repository_owner" }
+                  ],
+                  "validations": [
+                    {
+                      "expression": "vars.owner == 'Shion1305' || vars.owner == 'Shion1305Dev'",
+                      "message": "repository_owner not allowed"
+                    }
+                  ],
+                  "username": "claims.repository",
+                  "groups": "vars.owner == 'Shion1305' ? ['pusher-shion1305'] : ['pusher-shion1305dev']"
+                }
+              },
+              {
                 "issuer": "https://keycloak.shion1305.com/realms/zot",
-                "credentialsFile": "/etc/zot/secrets/keycloak-credentials.json",
-                "scopes": ["openid", "email", "groups"]
+                "audiences": ["zot-registry"],
+                "claimMapping": {
+                  "username": "claims.preferred_username",
+                  "groups": "has(claims.groups) ? claims.groups : []"
+                }
               }
-            }
-          },
-          "sessionKeysFile": "/etc/zot/secrets/session-keys.json"
+            ]
+          }
         },
         "accessControl": {
           "repositories": {
@@ -98,6 +135,9 @@ configFiles:
       }
     }
 
+# zot fetches issuer JWKS over HTTPS at request time; no on-disk client secret
+# or session-encryption key is needed. The ExternalSecret in
+# zot/external-secret.yaml feeds Envoy Gateway's SecurityPolicy, not zot.
 externalSecrets: []
 mountSecret: false
 
@@ -107,16 +147,6 @@ pvc:
   accessModes: ["ReadWriteOnce"]
   storage: 500Gi
   storageClassName: longhorn
-
-extraVolumes:
-  - name: zot-oidc
-    secret:
-      secretName: zot-oidc
-
-extraVolumeMounts:
-  - name: zot-oidc
-    mountPath: /etc/zot/secrets
-    readOnly: true
 
 strategy:
   type: RollingUpdate


### PR DESCRIPTION
## Summary

- Replace zot's deprecated `http.auth.openid` (per-client introspection) with `http.auth.bearer.oidc[]` (direct JWKS validation)
- Add Envoy Gateway `SecurityPolicy.oidc` to drive Web UI SSO; remove the need for any in-cluster oauth2-proxy or zot-side session secret
- Split HTTPRoutes per host into a `/v2/` registry route (no policy — Docker bearer challenge) and a UI route (`/`, `/v2/_zot/`) with the SecurityPolicy attached

## Why this is split from #278

The workflow change in #278 exercises this configuration via a real `docker login` against the cluster. CI can only pass once this manifest set is live. Splitting lets this PR merge on review, ArgoCD reconcile to the new state, and #278 (workflow only) then run green.

## Test plan

- [ ] Merge → ArgoCD picks up at next sync (zot Application currently OutOfSync at 421e0cc)
- [ ] Verify `kubectl get securitypolicy -n zot` shows `zot-ui-oidc` Accepted=True
- [ ] Verify `kubectl get httproute -n zot` lists `zot-registry-{external,internal}` and `zot-ui-{external,internal}` (replacing old `zot-{external,internal}`)
- [ ] Browser hit on https://registry.shion1305.com/ → Keycloak code flow → returns to UI authenticated
- [ ] After this lands, rebase #278 onto main and confirm its `build-push` check passes