### PR TITLE
fix(zot): drop passThroughAuthHeader from SecurityPolicy

### DIFF
--- a/zot/securitypolicy.yaml
+++ b/zot/securitypolicy.yaml
@@ -11,10 +11,6 @@
 # The Docker Registry v2 protocol path (`/v2/<repo>/...`) lives on a separate
 # HTTPRoute that does NOT have this policy attached, so `docker login` /
 # `docker push` from CI keep their own bearer challenge with zot directly.
-#
-# `passThroughAuthHeader: true` lets requests that already carry a Bearer
-# header (e.g. someone scripting against the UI extension API with a Keycloak
-# token in hand) bypass the redirect dance.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:
@@ -61,4 +57,3 @@ spec:
       idToken: zot_it
     forwardAccessToken: true
     refreshToken: true
-    passThroughAuthHeader: true


### PR DESCRIPTION
## Why

Envoy Gateway's SecurityPolicy validator rejects \`oidc.passThroughAuthHeader: true\` unless a JWT block is also configured:

> the OIDC.PassThroughAuthHeader setting must be used in conjunction with JWT settings

Without that fix, the SecurityPolicy is \`Accepted=False\` and never attaches to the UI HTTPRoutes. Browser hits to https://registry.shion1305.com/ get zot's raw page with no Keycloak login flow at all.

## How

Remove the field. The UI is already on its own HTTPRoute (\`zot-ui-{external,internal}\`), distinct from the registry routes that handle docker push, so we don't need a bypass — every request that reaches the UI route should go through OIDC.

## Test plan

- [ ] Argo sync
- [ ] \`kubectl get securitypolicy -n zot zot-ui-oidc -o jsonpath='{.status.ancestors[*].conditions[?(@.type==\"Accepted\")].status}'\` returns \`True\`
- [ ] Open https://registry.shion1305.com/ in a browser → redirected to Keycloak realm \`zot\` → returns to UI authenticated