### PR TITLE
chore(zot): drop OIDC from internal host registry.i.shion1305.com

### DIFF
--- a/zot/httproute-internal.yaml
+++ b/zot/httproute-internal.yaml
@@ -3,10 +3,11 @@
 # for in-cluster CI/CD or trusted hosts that have WG connectivity, while the
 # public registry.shion1305.com URL handles GitHub Actions and external pulls.
 #
-# Same path-split pattern as the external Gateway: zot-registry-internal
-# handles Docker v2 protocol traffic (no OIDC, zot does its own bearer
-# challenge), zot-ui-internal handles the SPA + /v2/_zot/* extension XHRs and
-# carries the SecurityPolicy.oidc binding.
+# Same path-split pattern as the external Gateway, but NO OIDC is attached to
+# either route: the WireGuard tunnel is the access boundary, so the UI loads
+# without login for read access, and the v2 protocol relies on zot's own
+# bearer-OIDC middleware (anonymous reads via defaultPolicy, writes from CI
+# go through the public host).
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/zot/securitypolicy.yaml
+++ b/zot/securitypolicy.yaml
@@ -1,12 +1,18 @@
-# Envoy Gateway-managed OIDC for the zot Web UI.
+# Envoy Gateway-managed OIDC for the zot Web UI on the PUBLIC host only.
 #
-# This SecurityPolicy binds to the zot-ui HTTPRoutes (external + internal). When
-# a browser hits anything other than `/v2/<repo>/...`, Envoy intercepts the
+# This SecurityPolicy binds to zot-ui-external. When a browser hits anything
+# other than `/v2/<repo>/...` on registry.shion1305.com, Envoy intercepts the
 # request, runs the OIDC Authorization Code flow against Keycloak realm `zot`,
 # stores tokens in encrypted cookies, and forwards the resulting access token
 # upstream as `Authorization: Bearer <kc_at>`. zot's `http.auth.bearer.oidc[]`
 # (issuer = this Keycloak realm, audience = `zot-registry`) then validates the
 # same token, enforces ACLs by `groups` claim, and serves the response.
+#
+# The internal host (registry.i.shion1305.com, reachable only over WireGuard)
+# is intentionally NOT in targetRefs — the WG boundary is the access control,
+# and the UI is left unauthenticated for low-friction read access. UI writes
+# from this host don't work (zot's bearer-OIDC middleware has no token to
+# validate); pushes happen via CI against the external host.
 #
 # The Docker Registry v2 protocol path (`/v2/<repo>/...`) lives on a separate
 # HTTPRoute that does NOT have this policy attached, so `docker login` /
@@ -21,9 +27,6 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       name: zot-ui-external
-    - group: gateway.networking.k8s.io
-      kind: HTTPRoute
-      name: zot-ui-internal
   oidc:
     provider:
       issuer: https://keycloak.shion1305.com/realms/zot


### PR DESCRIPTION
## Summary

- Removes \`zot-ui-internal\` from the \`zot-ui-oidc\` SecurityPolicy \`targetRefs\`.
- The internal host \`registry.i.shion1305.com\` is reachable only over WireGuard, so the WG tunnel is the access boundary — no need for an additional OIDC code flow.
- Updates the comment headers in \`securitypolicy.yaml\` and \`httproute-internal.yaml\` to reflect the new split (OIDC on public host only).

## Behavior after merge

| host | route | auth |
| --- | --- | --- |
| \`registry.shion1305.com\` (public) | \`zot-ui-external\` (\`/\`, \`/v2/_zot/\*\`) | Envoy OIDC code flow → Keycloak \`zot\` realm |
| \`registry.shion1305.com\` (public) | \`zot-registry-external\` (\`/v2/\*\`) | zot's own bearer-OIDC middleware (GHA / Keycloak token) |
| \`registry.i.shion1305.com\` (WG only) | \`zot-ui-internal\` (\`/\`, \`/v2/_zot/\*\`) | **none** — read-only browsing without login |
| \`registry.i.shion1305.com\` (WG only) | \`zot-registry-internal\` (\`/v2/\*\`) | zot's own bearer-OIDC middleware (anonymous reads via \`defaultPolicy\`) |

## Test plan

- [ ] After ArgoCD sync, \`https://registry.i.shion1305.com/\` loads the zot SPA directly without redirecting to Keycloak.
- [ ] Image listings and tag detail pages render (anonymous read).
- [ ] \`https://registry.shion1305.com/\` still redirects to Keycloak \`realms/zot\` (unchanged).
- [ ] \`SecurityPolicy zot-ui-oidc\` reports \`Accepted=True\` for \`zot-ui-external\` only.