### PR TITLE
Revert "chore(zot): drop OIDC from internal host registry.i.shion1305.com"

### DIFF
--- a/zot/httproute-internal.yaml
+++ b/zot/httproute-internal.yaml
@@ -3,11 +3,10 @@
 # for in-cluster CI/CD or trusted hosts that have WG connectivity, while the
 # public registry.shion1305.com URL handles GitHub Actions and external pulls.
 #
-# Same path-split pattern as the external Gateway, but NO OIDC is attached to
-# either route: the WireGuard tunnel is the access boundary, so the UI loads
-# without login for read access, and the v2 protocol relies on zot's own
-# bearer-OIDC middleware (anonymous reads via defaultPolicy, writes from CI
-# go through the public host).
+# Same path-split pattern as the external Gateway: zot-registry-internal
+# handles Docker v2 protocol traffic (no OIDC, zot does its own bearer
+# challenge), zot-ui-internal handles the SPA + /v2/_zot/* extension XHRs and
+# carries the SecurityPolicy.oidc binding.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/zot/securitypolicy.yaml
+++ b/zot/securitypolicy.yaml
@@ -1,18 +1,12 @@
-# Envoy Gateway-managed OIDC for the zot Web UI on the PUBLIC host only.
+# Envoy Gateway-managed OIDC for the zot Web UI.
 #
-# This SecurityPolicy binds to zot-ui-external. When a browser hits anything
-# other than `/v2/<repo>/...` on registry.shion1305.com, Envoy intercepts the
+# This SecurityPolicy binds to the zot-ui HTTPRoutes (external + internal). When
+# a browser hits anything other than `/v2/<repo>/...`, Envoy intercepts the
 # request, runs the OIDC Authorization Code flow against Keycloak realm `zot`,
 # stores tokens in encrypted cookies, and forwards the resulting access token
 # upstream as `Authorization: Bearer <kc_at>`. zot's `http.auth.bearer.oidc[]`
 # (issuer = this Keycloak realm, audience = `zot-registry`) then validates the
 # same token, enforces ACLs by `groups` claim, and serves the response.
-#
-# The internal host (registry.i.shion1305.com, reachable only over WireGuard)
-# is intentionally NOT in targetRefs — the WG boundary is the access control,
-# and the UI is left unauthenticated for low-friction read access. UI writes
-# from this host don't work (zot's bearer-OIDC middleware has no token to
-# validate); pushes happen via CI against the external host.
 #
 # The Docker Registry v2 protocol path (`/v2/<repo>/...`) lives on a separate
 # HTTPRoute that does NOT have this policy attached, so `docker login` /
@@ -27,6 +21,9 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       name: zot-ui-external
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: zot-ui-internal
   oidc:
     provider:
       issuer: https://keycloak.shion1305.com/realms/zot


### PR DESCRIPTION
## Summary

Reverts #287.

The premise of #287 was that the internal host could serve the zot UI without login because the WireGuard tunnel already gates access. In practice this fails because zot v2's SPA, when the registry advertises `bearer` auth, refuses to render any login UI itself — it expects an external proxy (Envoy) to run the OIDC code flow on its behalf. With OIDC removed, the SPA shows a "Sign In" header but no working login mechanism, so the page is effectively unusable.

Restoring OIDC on `zot-ui-internal` puts the internal host back on parity with the external host: Envoy redirects to Keycloak's `zot` realm, the user logs in (passkey via the brokered `user` realm or username/password), and the SPA loads with a real bearer token. Keycloak's `zot-ui` client already lists `https://registry.i.shion1305.com/oauth2/callback` as a redirect URI (`keycloak-operator/zot-realm.yaml:359`), so no realm change is needed.

## Test plan

- [ ] After ArgoCD sync, `https://registry.i.shion1305.com/` redirects to Keycloak `realms/zot`.
- [ ] After login, the zot SPA loads and image listings render.
- [ ] `SecurityPolicy zot-ui-oidc` reports `Accepted=True` for both `zot-ui-external` and `zot-ui-internal`.
- [ ] External host behavior unchanged.