### PR TITLE
fix(zot): use 'oidc' provider key — zot rejects 'keycloak'

### DIFF
--- a/keycloak-operator/zot-realm.yaml
+++ b/keycloak-operator/zot-realm.yaml
@@ -364,8 +364,8 @@ spec:
         directAccessGrantsEnabled: false
         serviceAccountsEnabled: false
         redirectUris:
-          - https://registry.shion1305.com/zot/auth/callback/keycloak
-          - https://registry.i.shion1305.com/zot/auth/callback/keycloak
+          - https://registry.shion1305.com/zot/auth/callback/oidc
+          - https://registry.i.shion1305.com/zot/auth/callback/oidc
         webOrigins:
           - https://registry.shion1305.com
           - https://registry.i.shion1305.com

--- a/zot/values.yaml
+++ b/zot/values.yaml
@@ -32,10 +32,11 @@ startupProbe:
 #      `http.auth.bearer.oidc[keycloak]`. Audience `zot-registry`, hardcoded
 #      `groups` mapper on the cluster-puller client emits the pusher groups.
 #   3. Browser users hitting / and /zot/auth/* → validated by zot's native
-#      `http.auth.openid.providers.keycloak`. zot itself runs the
-#      Authorization Code flow against the same Keycloak realm, then mints
-#      a session cookie. SPA routes /zot/auth/login/keycloak →
-#      /zot/auth/callback/keycloak → / on success.
+#      `http.auth.openid.providers.oidc`. zot itself runs the Authorization
+#      Code flow against the same Keycloak realm (provider key must be the
+#      generic `oidc` — zot's validator only accepts google/gitlab/oidc for
+#      OpenID and github for OAuth2), then mints a session cookie. SPA
+#      routes /zot/auth/login/oidc → /zot/auth/callback/oidc → / on success.
 #
 # The accessControl block is unchanged: groups (`pusher-shion1305`,
 # `pusher-shion1305dev`, `zot-admin`) gate the read/write actions.
@@ -94,7 +95,7 @@ configFiles:
               "https://registry.i.shion1305.com"
             ],
             "providers": {
-              "keycloak": {
+              "oidc": {
                 "name": "Keycloak",
                 "issuer": "https://keycloak.shion1305.com/realms/zot",
                 "credentialsFile": "/secrets/openid/keycloak-credentials.json",


### PR DESCRIPTION
## Summary

Follow-up to #289. zot v2.1.16 crashes at startup with:

```
Error: invalid server config: unsupported openid/oauth2 provider
```

`validateOpenIDConfig` ([root.go:705-722](https://github.com/project-zot/zot/blob/v2.1.16/pkg/cli/server/root.go#L705-L722)) checks the provider name against a fixed allowlist defined in [config.go:25-26](https://github.com/project-zot/zot/blob/v2.1.16/pkg/api/config/config.go#L25-L26):

```go
openIDSupportedProviders = [...]string{"google", "gitlab", "oidc"}
oauth2SupportedProviders = [...]string{"github"}
```

`keycloak` is not in either list. Switch to the generic `oidc` key, which goes through standard OIDC discovery against whatever `issuer` is set, so Keycloak still works fine — only the URL slug changes.

## Side effects

zot derives the SPA's login + callback paths from the provider key, so the Keycloak `zot-ui` client redirectUris flip from `/zot/auth/callback/keycloak` to `/zot/auth/callback/oidc`.

## Test plan

- [ ] zot Pod transitions out of CrashLoopBackOff
- [ ] After Keycloak operator reconciles, `zot-ui` client redirectUris show `/zot/auth/callback/oidc` (UI verify)
- [ ] `https://registry.shion1305.com/` → click login → Keycloak → `/zot/auth/callback/oidc` → SPA shows logged-in state