### PR TITLE
test(zot-pull): smoketest Job proves end-to-end pull works

### DIFF
--- a/apps/zot-pull-smoketest-app.yaml
+++ b/apps/zot-pull-smoketest-app.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: zot-pull-smoketest
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Shion1305/k8s-GitOps.git
+    targetRevision: HEAD
+    path: zot-pull-smoketest
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: zot-pull-smoketest
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+      - ServerSideApply=true

--- a/zot-pull-smoketest/job.yaml
+++ b/zot-pull-smoketest/job.yaml
@@ -1,0 +1,43 @@
+# Smoketest Job that proves the zot-pull automation works end-to-end.
+#
+# Pull image:
+#   registry.i.shion1305.com/shion1305/demo:latest
+# This is the artifact built and pushed by .github/workflows/demo-push-to-zot.yaml
+# (Dockerfile: zot/demo/Dockerfile). It's a 6 MB alpine image whose only purpose
+# is to print a single line and exit.
+#
+# How auth works here:
+#   1. zot-pull's ClusterExternalSecret materialises a Secret `zot-pull` of type
+#      kubernetes.io/dockerconfigjson in this namespace (selected by the
+#      `zot-pull/enabled=true` label on the Namespace).
+#   2. The Secret's auth value is `oidc:<keycloak-access-token>` base64-encoded,
+#      where the token is minted by the ClusterGenerator hitting Keycloak's
+#      token endpoint with the `cluster-puller` confidential client.
+#   3. kubelet sends `Authorization: Basic base64(oidc:<token>)` on pull; zot's
+#      bearer-OIDC middleware extracts the JWT after the literal `oidc:` prefix
+#      and validates it against the Keycloak issuer.
+#
+# The Job runs once and exits 0 if the image runs. Argo reports Healthy when
+# the Job's `Complete` condition is true. If pull fails (token expired, RBAC
+# misconfigured, registry unreachable), the Pod stays in ImagePullBackOff and
+# the Job never completes — Argo flags Degraded, surfacing the regression.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: zot-pull-smoketest
+  namespace: zot-pull-smoketest
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zot-pull-smoketest
+    spec:
+      restartPolicy: Never
+      imagePullSecrets:
+        - name: zot-pull
+      containers:
+        - name: smoketest
+          image: registry.i.shion1305.com/shion1305/demo:latest
+          imagePullPolicy: Always

--- a/zot-pull-smoketest/kustomization.yaml
+++ b/zot-pull-smoketest/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - job.yaml

--- a/zot-pull-smoketest/namespace.yaml
+++ b/zot-pull-smoketest/namespace.yaml
@@ -1,0 +1,18 @@
+# Smoketest namespace for the zot-pull cluster-wide imagePullSecret automation.
+#
+# The label `zot-pull/enabled=true` is what selects this namespace into the two
+# ClusterExternalSecrets in zot-pull/:
+#   - zot-cluster-puller-credentials → fans the Keycloak client_id/client_secret
+#     here so the ClusterGenerator's webhook can resolve secretRef in this ns.
+#   - zot-pull → renders a kubernetes.io/dockerconfigjson Secret named `zot-pull`
+#     containing a fresh Keycloak access_token, refreshed every 15m.
+#
+# The smoketest Job in this namespace pulls a private image from
+# registry.i.shion1305.com using imagePullSecret=zot-pull, proving end-to-end:
+#   Keycloak client_credentials → bearer token → zot pull authentication.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: zot-pull-smoketest
+  labels:
+    zot-pull/enabled: "true"


### PR DESCRIPTION
## Summary

- Adds `zot-pull-smoketest` namespace + Job that opts into `zot-pull/enabled=true` and runs the demo image from `registry.i.shion1305.com/shion1305/demo:latest`.
- Health of the new ArgoCD app becomes the live signal that the zot-pull cluster-wide imagePullSecret automation (PR #283 + #291) is working end-to-end.

## What this proves

When the smoketest app reports **Healthy** in Argo:
- The `zot-cluster-puller-credentials` ClusterExternalSecret materialised a Secret in the new namespace.
- The `zot-pull` ClusterExternalSecret resolved the ClusterGenerator (Keycloak `client_credentials` → access_token), and rendered a dockerconfigjson Secret named `zot-pull` in the namespace.
- kubelet successfully sent `Authorization: Basic base64(oidc:<jwt>)` to zot, zot's bearer-OIDC middleware accepted it, and the image was pulled.

When it goes **Degraded**, exactly one of those layers broke — the Job's `ImagePullBackOff` or the missing Secret will tell us which.

## Test plan
- [ ] Argo `zot-pull-smoketest` app reaches Synced + Healthy
- [ ] `kubectl get secret -n zot-pull-smoketest zot-pull zot-cluster-puller-credentials` returns both Secrets
- [ ] `kubectl logs -n zot-pull-smoketest job/zot-pull-smoketest` prints `hello from zot smoke test`

## Notes

The Job has `ttlSecondsAfterFinished: 86400` so a successful run is observable for a day before being garbage-collected. ArgoCD selfHeal will re-create it on next sync after that, giving us a ~daily heartbeat.