### PR TITLE
feat(kyverno): cluster-wide zot-pull via Kyverno mutate+generate policies

### DIFF
--- a/apps/kyverno-app.yaml
+++ b/apps/kyverno-app.yaml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kyverno
+  namespace: argocd
+spec:
+  project: default
+  sources:
+    - repoURL: https://kyverno.github.io/kyverno/
+      chart: kyverno
+      targetRevision: 3.8.0
+      helm:
+        valueFiles:
+          - $values/kyverno/values.yaml
+    - repoURL: https://github.com/Shion1305/k8s-GitOps.git
+      targetRevision: HEAD
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kyverno
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/apps/kyverno-policies-app.yaml
+++ b/apps/kyverno-policies-app.yaml
@@ -1,0 +1,27 @@
+# ClusterPolicy resources are cluster-scoped, so the destination namespace is
+# only used for Argo's bookkeeping. We point at `kyverno` for symmetry with
+# the chart Application; the policies themselves are not namespaced.
+#
+# No syncwave annotation is needed — if Kyverno's CRDs aren't installed yet,
+# Argo retries with backoff until they are. Once `apps/kyverno-app.yaml` has
+# applied the chart, the next reconcile of this app succeeds.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kyverno-policies
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Shion1305/k8s-GitOps.git
+    targetRevision: HEAD
+    path: kyverno-policies
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kyverno
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/apps/zot-pull-source-app.yaml
+++ b/apps/zot-pull-source-app.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: zot-pull-source
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Shion1305/k8s-GitOps.git
+    targetRevision: HEAD
+    path: zot-pull-source
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: zot-pull-source
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+      - ServerSideApply=true

--- a/kyverno-policies/kustomization.yaml
+++ b/kyverno-policies/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - zot-pull-injection.yaml

--- a/kyverno-policies/zot-pull-injection.yaml
+++ b/kyverno-policies/zot-pull-injection.yaml
@@ -1,0 +1,115 @@
+# Cluster-wide zot-pull credential injection.
+#
+# Replaces the previous opt-in label model (`zot-pull/enabled=true` on each
+# consumer namespace + ESO fan-out) with on-demand, Kyverno-driven injection
+# triggered by Pod admission. The flow is:
+#
+#   1. ESO materialises Secret `zot-pull` into the source namespace
+#      `zot-pull-source` (see zot-pull/cluster-external-secret.yaml).
+#   2. Pod is admitted in any namespace, with at least one container or
+#      initContainer image referencing `registry.i.shion1305.com/*`.
+#   3. Rule `generate-zot-pull-secret` clones `zot-pull-source/zot-pull` into
+#      the Pod's namespace, with synchronize=true so token rotations propagate.
+#   4. Rule `add-zot-pull-imagepullsecret` mutates the Pod to append `zot-pull`
+#      to spec.imagePullSecrets.
+#
+# Race window on first-ever Pod in a namespace:
+#   Mutate runs synchronously at admission, so the Pod object lands with
+#   imagePullSecrets pointing at `zot-pull`. Generate runs asynchronously after
+#   admission, so the Secret may not yet exist when kubelet first attempts the
+#   pull. kubelet retries on ImagePullBackOff with exponential backoff; the
+#   Secret is typically created within ~1s, so the second pull attempt
+#   succeeds. Subsequent Pods in the same namespace see the Secret already
+#   present and pull without retry.
+#
+# Why failurePolicy: Ignore at the webhook level:
+#   A Kyverno outage must not block Pod admission cluster-wide. With Ignore,
+#   Pods admitted during an outage will simply not get the imagePullSecret
+#   injected and will sit in ImagePullBackOff until Kyverno recovers and
+#   selfHeal/restart re-admits them. This is strictly better than a hard fail
+#   that would prevent unrelated workloads (which don't use registry.i.*) from
+#   scheduling.
+#
+# Why mutateExistingOnPolicyUpdate is left at its default (false):
+#   We only want admission-time mutation. Retroactively patching every
+#   existing Pod across the cluster on each policy reconcile is unnecessary
+#   churn; existing Pods with stale imagePullSecrets will be replaced on the
+#   next deploy or rollout.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: zot-pull-injection
+  annotations:
+    policies.kyverno.io/title: Inject zot-pull imagePullSecret
+    policies.kyverno.io/category: Image Pull Credentials
+    policies.kyverno.io/subject: Pod, Secret
+    policies.kyverno.io/description: >-
+      For Pods referencing the in-cluster zot registry
+      (registry.i.shion1305.com), clones the dockerconfigjson Secret from
+      zot-pull-source into the Pod's namespace and adds it to the Pod's
+      imagePullSecrets.
+spec:
+  # Ignore so a Kyverno outage does not block unrelated Pod admission.
+  # Pods that *do* need the secret will degrade gracefully to ImagePullBackOff
+  # and self-heal once Kyverno is back.
+  webhookConfiguration:
+    failurePolicy: Ignore
+  rules:
+    # ---------------------------------------------------------------------
+    # Rule 1 — mutate: append `zot-pull` to spec.imagePullSecrets when at
+    # least one container or initContainer image references the in-cluster
+    # zot registry hostname.
+    # ---------------------------------------------------------------------
+    - name: add-zot-pull-imagepullsecret
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      preconditions:
+        # OR semantics: fire if the registry appears in EITHER list.
+        # images.containers.*.registry / images.initContainers.*.registry
+        # are Kyverno's parsed image variables (just the hostname, no
+        # scheme). The JMESPath `|| ` + backtick-quoted empty array `[]`
+        # supplies a fallback so Pods without initContainers don't make
+        # AnyIn evaluate against null.
+        any:
+          - key: registry.i.shion1305.com
+            operator: AnyIn
+            value: "{{ images.containers.*.registry || `[]` }}"
+          - key: registry.i.shion1305.com
+            operator: AnyIn
+            value: "{{ images.initContainers.*.registry || `[]` }}"
+      mutate:
+        patchStrategicMerge:
+          spec:
+            imagePullSecrets:
+              - name: zot-pull
+    # ---------------------------------------------------------------------
+    # Rule 2 — generate: clone Secret `zot-pull-source/zot-pull` into the
+    # Pod's namespace. synchronize=true means subsequent rotations of the
+    # source Secret (every 15m via ESO) propagate to all clones.
+    # ---------------------------------------------------------------------
+    - name: generate-zot-pull-secret
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      preconditions:
+        any:
+          - key: registry.i.shion1305.com
+            operator: AnyIn
+            value: "{{ images.containers.*.registry || `[]` }}"
+          - key: registry.i.shion1305.com
+            operator: AnyIn
+            value: "{{ images.initContainers.*.registry || `[]` }}"
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: zot-pull
+        namespace: "{{ request.namespace }}"
+        synchronize: true
+        clone:
+          namespace: zot-pull-source
+          name: zot-pull

--- a/kyverno-policies/zot-pull-injection.yaml
+++ b/kyverno-policies/zot-pull-injection.yaml
@@ -1,40 +1,23 @@
-# Cluster-wide zot-pull credential injection.
+# Cluster-wide zot-pull credential injection on Pod admission.
 #
-# Replaces the previous opt-in label model (`zot-pull/enabled=true` on each
-# consumer namespace + ESO fan-out) with on-demand, Kyverno-driven injection
-# triggered by Pod admission. The flow is:
-#
-#   1. ESO materialises Secret `zot-pull` into the source namespace
-#      `zot-pull-source` (see zot-pull/cluster-external-secret.yaml).
-#   2. Pod is admitted in any namespace, with at least one container or
-#      initContainer image referencing `registry.i.shion1305.com/*`.
-#   3. Rule `generate-zot-pull-secret` clones `zot-pull-source/zot-pull` into
-#      the Pod's namespace, with synchronize=true so token rotations propagate.
-#   4. Rule `add-zot-pull-imagepullsecret` mutates the Pod to append `zot-pull`
+# Flow:
+#   1. ESO materialises Secret `zot-pull` into `zot-pull-source`
+#      (zot-pull/cluster-external-secret.yaml).
+#   2. Pod is admitted in any namespace with a container or initContainer
+#      image referencing `registry.i.shion1305.com/*`.
+#   3. `generate-zot-pull-secret` clones `zot-pull-source/zot-pull` into the
+#      Pod's namespace; synchronize=true so token rotations propagate.
+#   4. `add-zot-pull-imagepullsecret` mutates the Pod to append `zot-pull`
 #      to spec.imagePullSecrets.
 #
-# Race window on first-ever Pod in a namespace:
-#   Mutate runs synchronously at admission, so the Pod object lands with
-#   imagePullSecrets pointing at `zot-pull`. Generate runs asynchronously after
-#   admission, so the Secret may not yet exist when kubelet first attempts the
-#   pull. kubelet retries on ImagePullBackOff with exponential backoff; the
-#   Secret is typically created within ~1s, so the second pull attempt
-#   succeeds. Subsequent Pods in the same namespace see the Secret already
-#   present and pull without retry.
+# Race window on the first Pod in a namespace: mutate runs synchronously at
+# admission while generate runs asynchronously, so the Secret may not exist
+# when kubelet first attempts the pull. kubelet retries on ImagePullBackOff;
+# the Secret is typically present within ~1s, so the next pull succeeds.
 #
-# Why failurePolicy: Ignore at the webhook level:
-#   A Kyverno outage must not block Pod admission cluster-wide. With Ignore,
-#   Pods admitted during an outage will simply not get the imagePullSecret
-#   injected and will sit in ImagePullBackOff until Kyverno recovers and
-#   selfHeal/restart re-admits them. This is strictly better than a hard fail
-#   that would prevent unrelated workloads (which don't use registry.i.*) from
-#   scheduling.
-#
-# Why mutateExistingOnPolicyUpdate is left at its default (false):
-#   We only want admission-time mutation. Retroactively patching every
-#   existing Pod across the cluster on each policy reconcile is unnecessary
-#   churn; existing Pods with stale imagePullSecrets will be replaced on the
-#   next deploy or rollout.
+# webhookConfiguration.failurePolicy: Ignore — a Kyverno outage must not block
+# unrelated Pod admission cluster-wide. Pods needing the secret will degrade
+# to ImagePullBackOff and self-heal once Kyverno recovers.
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -49,17 +32,9 @@ metadata:
       zot-pull-source into the Pod's namespace and adds it to the Pod's
       imagePullSecrets.
 spec:
-  # Ignore so a Kyverno outage does not block unrelated Pod admission.
-  # Pods that *do* need the secret will degrade gracefully to ImagePullBackOff
-  # and self-heal once Kyverno is back.
   webhookConfiguration:
     failurePolicy: Ignore
   rules:
-    # ---------------------------------------------------------------------
-    # Rule 1 — mutate: append `zot-pull` to spec.imagePullSecrets when at
-    # least one container or initContainer image references the in-cluster
-    # zot registry hostname.
-    # ---------------------------------------------------------------------
     - name: add-zot-pull-imagepullsecret
       match:
         any:
@@ -67,12 +42,10 @@ spec:
               kinds:
                 - Pod
       preconditions:
-        # OR semantics: fire if the registry appears in EITHER list.
-        # images.containers.*.registry / images.initContainers.*.registry
-        # are Kyverno's parsed image variables (just the hostname, no
-        # scheme). The JMESPath `|| ` + backtick-quoted empty array `[]`
-        # supplies a fallback so Pods without initContainers don't make
-        # AnyIn evaluate against null.
+        # `images.containers.*.registry` / `images.initContainers.*.registry`
+        # are Kyverno's parsed image variables (hostname only, no scheme). The
+        # `|| `[]`` fallback prevents AnyIn from evaluating against null when
+        # a Pod has no initContainers.
         any:
           - key: registry.i.shion1305.com
             operator: AnyIn
@@ -85,11 +58,6 @@ spec:
           spec:
             imagePullSecrets:
               - name: zot-pull
-    # ---------------------------------------------------------------------
-    # Rule 2 — generate: clone Secret `zot-pull-source/zot-pull` into the
-    # Pod's namespace. synchronize=true means subsequent rotations of the
-    # source Secret (every 15m via ESO) propagate to all clones.
-    # ---------------------------------------------------------------------
     - name: generate-zot-pull-secret
       match:
         any:

--- a/kyverno/values.yaml
+++ b/kyverno/values.yaml
@@ -1,0 +1,68 @@
+# Kyverno is deployed cluster-wide as a generic admission policy engine.
+# Individual ClusterPolicies live in the separate `kyverno-policies` ArgoCD
+# Application (under `kyverno-policies/`), so chart upgrades and policy edits
+# can be reviewed in independent PRs.
+#
+# Sub-controller layout (see kyverno chart 3.8.0 / app v1.18.0):
+#   admissionController – mutating/validating webhook (always required).
+#   backgroundController – periodic reconciliation of mutate/generate rules
+#                          against existing resources. Required for our
+#                          generate-on-Pod-create flow (zot-pull Secret clone).
+#   reportsController   – aggregates PolicyReport CRs. Useful for observability.
+#   cleanupController   – CleanupPolicy CRD support; enabled by default.
+#
+# Resource limits intentionally conservative. Bump if metrics show throttling.
+
+admissionController:
+  replicas: 2
+  serviceMonitor:
+    enabled: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 384Mi
+
+backgroundController:
+  replicas: 1
+  serviceMonitor:
+    enabled: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      memory: 256Mi
+
+reportsController:
+  replicas: 1
+  serviceMonitor:
+    enabled: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      memory: 256Mi
+
+cleanupController:
+  replicas: 1
+  serviceMonitor:
+    enabled: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      memory: 128Mi
+
+# We don't use the bundled grafana subchart — kube-prometheus-stack already
+# provides Grafana cluster-wide.
+grafana:
+  enabled: false
+
+# Reports server is an alternative storage backend for PolicyReports; default
+# (etcd) is fine for our scale.
+reportsServer:
+  enabled: false

--- a/zot-pull-smoketest/job.yaml
+++ b/zot-pull-smoketest/job.yaml
@@ -1,33 +1,27 @@
 # Smoketest Job that proves the cluster-wide zot-pull automation works
 # end-to-end with no manual setup in the consumer namespace.
 #
-# Pull image:
-#   registry.i.shion1305.com/shion1305/demo:latest
-# This is the artifact built and pushed by .github/workflows/demo-push-to-zot.yaml
-# (Dockerfile: zot/demo/Dockerfile). It's a small alpine image whose only
-# purpose is to print a single line and exit.
+# Pull image: registry.i.shion1305.com/shion1305/demo:latest — built and pushed
+# by .github/workflows/demo-push-to-zot.yaml (Dockerfile zot/demo/Dockerfile),
+# a small alpine image that prints a line and exits.
 #
-# Note that this Job does NOT declare `imagePullSecrets`. The whole point of
-# the smoketest is to verify that Kyverno's `zot-pull-injection` ClusterPolicy
-# (kyverno-policies/zot-pull-injection.yaml) injects the imagePullSecret at
-# admission and clones the Secret into this namespace. If you see
-# `imagePullSecrets: [{name: zot-pull}]` on the running Pod, the policy did
-# its job.
+# `imagePullSecrets` is intentionally omitted: Kyverno's `zot-pull-injection`
+# ClusterPolicy injects it at admission and clones the source Secret into this
+# namespace. Seeing `imagePullSecrets: [{name: zot-pull}]` on the running Pod
+# confirms the policy fired.
 #
-# How auth itself works once the Secret is in place:
-#   - Source Secret `zot-pull-source/zot-pull` is a kubernetes.io/dockerconfigjson
-#     where the `auth` value is base64("oidc:<keycloak-access-token>").
+# Auth chain once the Secret is in place:
+#   - Source Secret `zot-pull-source/zot-pull` (kubernetes.io/dockerconfigjson)
+#     carries `auth = base64("oidc:<keycloak-access-token>")`.
 #   - The token is minted by ESO's ClusterGenerator hitting Keycloak's token
 #     endpoint with the `cluster-puller` confidential client.
-#   - kubelet sends `Authorization: Basic base64(oidc:<token>)` on pull; zot's
+#   - kubelet sends `Authorization: Basic base64(oidc:<token>)`; zot's
 #     bearer-OIDC middleware extracts the JWT after the literal `oidc:` prefix
 #     and validates it against the Keycloak issuer.
 #
-# The Job runs once and exits 0 if the image runs. Argo reports Healthy when
-# the Job's `Complete` condition is true. If the pull fails (token expired,
-# RBAC misconfigured, registry unreachable, Kyverno not running), the Pod
-# stays in ImagePullBackOff and the Job never completes — Argo flags
-# Degraded, surfacing the regression.
+# Argo reports Healthy when the Job's Complete condition is true. ImagePullBackOff
+# (token expired, RBAC drift, registry unreachable, Kyverno not running) keeps
+# the Job incomplete and Argo flags Degraded — surfacing the regression.
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/zot-pull-smoketest/job.yaml
+++ b/zot-pull-smoketest/job.yaml
@@ -1,26 +1,33 @@
-# Smoketest Job that proves the zot-pull automation works end-to-end.
+# Smoketest Job that proves the cluster-wide zot-pull automation works
+# end-to-end with no manual setup in the consumer namespace.
 #
 # Pull image:
 #   registry.i.shion1305.com/shion1305/demo:latest
 # This is the artifact built and pushed by .github/workflows/demo-push-to-zot.yaml
-# (Dockerfile: zot/demo/Dockerfile). It's a 6 MB alpine image whose only purpose
-# is to print a single line and exit.
+# (Dockerfile: zot/demo/Dockerfile). It's a small alpine image whose only
+# purpose is to print a single line and exit.
 #
-# How auth works here:
-#   1. zot-pull's ClusterExternalSecret materialises a Secret `zot-pull` of type
-#      kubernetes.io/dockerconfigjson in this namespace (selected by the
-#      `zot-pull/enabled=true` label on the Namespace).
-#   2. The Secret's auth value is `oidc:<keycloak-access-token>` base64-encoded,
-#      where the token is minted by the ClusterGenerator hitting Keycloak's
-#      token endpoint with the `cluster-puller` confidential client.
-#   3. kubelet sends `Authorization: Basic base64(oidc:<token>)` on pull; zot's
-#      bearer-OIDC middleware extracts the JWT after the literal `oidc:` prefix
-#      and validates it against the Keycloak issuer.
+# Note that this Job does NOT declare `imagePullSecrets`. The whole point of
+# the smoketest is to verify that Kyverno's `zot-pull-injection` ClusterPolicy
+# (kyverno-policies/zot-pull-injection.yaml) injects the imagePullSecret at
+# admission and clones the Secret into this namespace. If you see
+# `imagePullSecrets: [{name: zot-pull}]` on the running Pod, the policy did
+# its job.
+#
+# How auth itself works once the Secret is in place:
+#   - Source Secret `zot-pull-source/zot-pull` is a kubernetes.io/dockerconfigjson
+#     where the `auth` value is base64("oidc:<keycloak-access-token>").
+#   - The token is minted by ESO's ClusterGenerator hitting Keycloak's token
+#     endpoint with the `cluster-puller` confidential client.
+#   - kubelet sends `Authorization: Basic base64(oidc:<token>)` on pull; zot's
+#     bearer-OIDC middleware extracts the JWT after the literal `oidc:` prefix
+#     and validates it against the Keycloak issuer.
 #
 # The Job runs once and exits 0 if the image runs. Argo reports Healthy when
-# the Job's `Complete` condition is true. If pull fails (token expired, RBAC
-# misconfigured, registry unreachable), the Pod stays in ImagePullBackOff and
-# the Job never completes — Argo flags Degraded, surfacing the regression.
+# the Job's `Complete` condition is true. If the pull fails (token expired,
+# RBAC misconfigured, registry unreachable, Kyverno not running), the Pod
+# stays in ImagePullBackOff and the Job never completes — Argo flags
+# Degraded, surfacing the regression.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -35,8 +42,6 @@ spec:
         app.kubernetes.io/name: zot-pull-smoketest
     spec:
       restartPolicy: Never
-      imagePullSecrets:
-        - name: zot-pull
       containers:
         - name: smoketest
           image: registry.i.shion1305.com/shion1305/demo:latest

--- a/zot-pull-smoketest/namespace.yaml
+++ b/zot-pull-smoketest/namespace.yaml
@@ -1,24 +1,18 @@
-# Smoketest namespace for the cluster-wide zot-pull automation.
+# Smoketest namespace for the cluster-wide zot-pull automation. Intentionally
+# bare so a Healthy state proves an arbitrary namespace can pull images from
+# the in-cluster zot registry without manual preparation.
 #
-# This namespace is intentionally bare — no `zot-pull/enabled=true` label,
-# no opt-in mechanism. The point of the smoketest is to prove that an
-# arbitrary namespace, with no special preparation, can pull images from the
-# in-cluster zot registry.
+# Expected sequence at sync time:
+#   1. The Job creates a Pod with an image at `registry.i.shion1305.com/...`.
+#   2. Kyverno `zot-pull-injection` fires: mutate appends `zot-pull` to
+#      spec.imagePullSecrets, generate clones the Secret from zot-pull-source.
+#   3. kubelet authenticates with the bearer-OIDC dockerconfigjson and pulls.
+#      Job completes; Argo reports Healthy.
 #
-# What's expected to happen at sync time:
-#   1. The Job in this namespace creates a Pod whose container image is
-#      `registry.i.shion1305.com/...`.
-#   2. Kyverno's `zot-pull-injection` ClusterPolicy fires:
-#        - mutate appends `zot-pull` to the Pod's spec.imagePullSecrets
-#        - generate clones Secret `zot-pull-source/zot-pull` into this ns
-#   3. kubelet authenticates to zot using the bearer-OIDC dockerconfigjson
-#      and pulls the image. Job completes; Argo reports Healthy.
-#
-# If the Pod is stuck in ImagePullBackOff, check (in order):
-#   - kubectl get clusterpolicy zot-pull-injection -o yaml  (rule status)
-#   - kubectl get secret -n zot-pull-source zot-pull  (source materialised?)
-#   - kubectl get pod -n zot-pull-smoketest -o yaml | grep imagePullSecrets
-#     (Kyverno mutate ran?)
+# Debugging ImagePullBackOff (in order):
+#   kubectl get clusterpolicy zot-pull-injection -o yaml      # rule status
+#   kubectl get secret -n zot-pull-source zot-pull            # source materialised?
+#   kubectl get pod -n zot-pull-smoketest -o yaml | grep imagePullSecrets
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/zot-pull-smoketest/namespace.yaml
+++ b/zot-pull-smoketest/namespace.yaml
@@ -1,18 +1,25 @@
-# Smoketest namespace for the zot-pull cluster-wide imagePullSecret automation.
+# Smoketest namespace for the cluster-wide zot-pull automation.
 #
-# The label `zot-pull/enabled=true` is what selects this namespace into the two
-# ClusterExternalSecrets in zot-pull/:
-#   - zot-cluster-puller-credentials → fans the Keycloak client_id/client_secret
-#     here so the ClusterGenerator's webhook can resolve secretRef in this ns.
-#   - zot-pull → renders a kubernetes.io/dockerconfigjson Secret named `zot-pull`
-#     containing a fresh Keycloak access_token, refreshed every 15m.
+# This namespace is intentionally bare — no `zot-pull/enabled=true` label,
+# no opt-in mechanism. The point of the smoketest is to prove that an
+# arbitrary namespace, with no special preparation, can pull images from the
+# in-cluster zot registry.
 #
-# The smoketest Job in this namespace pulls a private image from
-# registry.i.shion1305.com using imagePullSecret=zot-pull, proving end-to-end:
-#   Keycloak client_credentials → bearer token → zot pull authentication.
+# What's expected to happen at sync time:
+#   1. The Job in this namespace creates a Pod whose container image is
+#      `registry.i.shion1305.com/...`.
+#   2. Kyverno's `zot-pull-injection` ClusterPolicy fires:
+#        - mutate appends `zot-pull` to the Pod's spec.imagePullSecrets
+#        - generate clones Secret `zot-pull-source/zot-pull` into this ns
+#   3. kubelet authenticates to zot using the bearer-OIDC dockerconfigjson
+#      and pulls the image. Job completes; Argo reports Healthy.
+#
+# If the Pod is stuck in ImagePullBackOff, check (in order):
+#   - kubectl get clusterpolicy zot-pull-injection -o yaml  (rule status)
+#   - kubectl get secret -n zot-pull-source zot-pull  (source materialised?)
+#   - kubectl get pod -n zot-pull-smoketest -o yaml | grep imagePullSecrets
+#     (Kyverno mutate ran?)
 apiVersion: v1
 kind: Namespace
 metadata:
   name: zot-pull-smoketest
-  labels:
-    zot-pull/enabled: "true"

--- a/zot-pull-source/kustomization.yaml
+++ b/zot-pull-source/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/zot-pull-source/namespace.yaml
+++ b/zot-pull-source/namespace.yaml
@@ -1,24 +1,18 @@
 # Source namespace for the cluster-wide zot-pull credential.
 #
-# This namespace holds the *single* canonical Secret named `zot-pull` (a
-# kubernetes.io/dockerconfigjson) that ESO materialises from a Keycloak
-# access_token. Two ClusterExternalSecrets in `zot-pull/` target this
-# namespace exclusively (selector `kubernetes.io/metadata.name=zot-pull-source`,
-# which Kubernetes auto-applies to every Namespace, so no extra label is
-# needed here).
+# Holds the canonical Secret `zot-pull` (kubernetes.io/dockerconfigjson) that
+# ESO materialises from a Keycloak access_token. Two ClusterExternalSecrets
+# in `zot-pull/` target this namespace exclusively via the auto-applied
+# `kubernetes.io/metadata.name` label, so no extra labels are needed here.
 #
-# Distribution to consumer namespaces is delegated to Kyverno: see
-# kyverno-policies/zot-pull-injection.yaml. When a Pod is admitted whose
-# container/initContainer image references `registry.i.shion1305.com/*`, the
-# generate rule clones this Secret into the Pod's namespace and the mutate
-# rule adds it to the Pod's imagePullSecrets.
+# Kyverno (kyverno-policies/zot-pull-injection.yaml) clones this Secret into
+# consumer namespaces on Pod admission and adds it to imagePullSecrets.
 #
-# Why a dedicated source namespace (instead of e.g. `external-secrets`):
-#   The ClusterGenerator's Webhook provider hard-codes ClusterScoped=false
-#   in ESO v0.19.0, so secretRef lookups always resolve against the
-#   ExternalSecret's own namespace. Co-locating both the puller credentials
-#   Secret and the ExternalSecret that consumes it here keeps that lookup
-#   working without granting wider privileges to other namespaces.
+# Dedicated source namespace because ESO v0.19.0 hard-codes
+# ClusterScoped=false on Webhook generators, so secretRef lookups always
+# resolve against the ExternalSecret's own namespace. Co-locating the puller
+# credentials Secret and its consumer ExternalSecret here keeps that lookup
+# working without widening Vault access to other namespaces.
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/zot-pull-source/namespace.yaml
+++ b/zot-pull-source/namespace.yaml
@@ -1,0 +1,25 @@
+# Source namespace for the cluster-wide zot-pull credential.
+#
+# This namespace holds the *single* canonical Secret named `zot-pull` (a
+# kubernetes.io/dockerconfigjson) that ESO materialises from a Keycloak
+# access_token. Two ClusterExternalSecrets in `zot-pull/` target this
+# namespace exclusively (selector `kubernetes.io/metadata.name=zot-pull-source`,
+# which Kubernetes auto-applies to every Namespace, so no extra label is
+# needed here).
+#
+# Distribution to consumer namespaces is delegated to Kyverno: see
+# kyverno-policies/zot-pull-injection.yaml. When a Pod is admitted whose
+# container/initContainer image references `registry.i.shion1305.com/*`, the
+# generate rule clones this Secret into the Pod's namespace and the mutate
+# rule adds it to the Pod's imagePullSecrets.
+#
+# Why a dedicated source namespace (instead of e.g. `external-secrets`):
+#   The ClusterGenerator's Webhook provider hard-codes ClusterScoped=false
+#   in ESO v0.19.0, so secretRef lookups always resolve against the
+#   ExternalSecret's own namespace. Co-locating both the puller credentials
+#   Secret and the ExternalSecret that consumes it here keeps that lookup
+#   working without granting wider privileges to other namespaces.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: zot-pull-source

--- a/zot-pull/cluster-external-secret.yaml
+++ b/zot-pull/cluster-external-secret.yaml
@@ -1,28 +1,19 @@
-# Fans out a Kubernetes dockerconfigjson Secret named `zot-pull` into every
-# namespace labelled `zot-pull/enabled=true`. The Secret carries a fresh
-# Keycloak access_token minted by the ClusterGenerator (Webhook), so kubelet
-# can `imagePullSecrets`-pull from registry.shion1305.com without storing a
-# long-lived password.
+# Materialises the dockerconfigjson Secret `zot-pull` in the source namespace
+# `zot-pull-source`. Carries a fresh Keycloak access_token minted by the
+# ClusterGenerator (Webhook), refreshed every 15m (Keycloak token lifespan
+# is 1h, so 15m gives a comfortable margin).
 #
-# Refresh cadence:
-#   - refreshTime: 5m   — how often the controller scans for newly labelled
-#                          namespaces and pushes the Secret into them.
-#   - refreshInterval: 15m — how often the templated Secret is re-rendered.
-#                            Keycloak access.token.lifespan is 1h, so 15m
-#                            leaves a comfortable margin for clock skew and
-#                            in-flight pulls.
+# This Secret is the *source of truth* for cluster-wide pull credentials.
+# Distribution to consumer namespaces is delegated to Kyverno: see
+# kyverno-policies/zot-pull-injection.yaml for the generate rule that clones
+# this Secret into namespaces where Pods reference registry.i.shion1305.com,
+# and the mutate rule that adds it to those Pods' imagePullSecrets.
 #
-# Consuming a namespace:
-#   apiVersion: v1
-#   kind: Namespace
-#   metadata:
-#     name: my-app
-#     labels:
-#       zot-pull/enabled: "true"
-#   ---
-#   spec:
-#     imagePullSecrets:
-#       - name: zot-pull
+# Authentication format note:
+#   "auth": base64("oidc:<jwt>")
+# zot's bearer-OIDC middleware extracts the JWT after the literal "oidc:"
+# prefix; the username placeholder is required to make it a valid Basic-style
+# auth value but is otherwise ignored.
 apiVersion: external-secrets.io/v1
 kind: ClusterExternalSecret
 metadata:
@@ -30,7 +21,7 @@ metadata:
 spec:
   namespaceSelector:
     matchLabels:
-      zot-pull/enabled: "true"
+      kubernetes.io/metadata.name: zot-pull-source
   refreshTime: 5m
   externalSecretSpec:
     refreshInterval: 15m
@@ -39,8 +30,6 @@ spec:
       creationPolicy: Owner
       deletionPolicy: Retain
       template:
-        # Standard kubelet pull-secret format. zot ignores the username on
-        # bearer-OIDC; "oidc" is just a non-empty placeholder.
         type: kubernetes.io/dockerconfigjson
         engineVersion: v2
         data:

--- a/zot-pull/cluster-external-secret.yaml
+++ b/zot-pull/cluster-external-secret.yaml
@@ -1,19 +1,15 @@
-# Materialises the dockerconfigjson Secret `zot-pull` in the source namespace
-# `zot-pull-source`. Carries a fresh Keycloak access_token minted by the
-# ClusterGenerator (Webhook), refreshed every 15m (Keycloak token lifespan
-# is 1h, so 15m gives a comfortable margin).
+# Materialises the dockerconfigjson Secret `zot-pull` in `zot-pull-source`.
+# This Secret carries a fresh Keycloak access_token minted by the
+# ClusterGenerator and is the source of truth for cluster-wide pull
+# credentials. Distribution to consumer namespaces is delegated to Kyverno
+# (kyverno-policies/zot-pull-injection.yaml).
 #
-# This Secret is the *source of truth* for cluster-wide pull credentials.
-# Distribution to consumer namespaces is delegated to Kyverno: see
-# kyverno-policies/zot-pull-injection.yaml for the generate rule that clones
-# this Secret into namespaces where Pods reference registry.i.shion1305.com,
-# and the mutate rule that adds it to those Pods' imagePullSecrets.
+# refreshInterval: 15m gives a comfortable margin under the Keycloak token
+# lifespan of 1h.
 #
-# Authentication format note:
-#   "auth": base64("oidc:<jwt>")
-# zot's bearer-OIDC middleware extracts the JWT after the literal "oidc:"
-# prefix; the username placeholder is required to make it a valid Basic-style
-# auth value but is otherwise ignored.
+# auth format: base64("oidc:<jwt>"). zot's bearer-OIDC middleware extracts the
+# JWT after the literal "oidc:" prefix; the username placeholder is required
+# to form a valid Basic-style auth value but is otherwise ignored.
 apiVersion: external-secrets.io/v1
 kind: ClusterExternalSecret
 metadata:

--- a/zot-pull/credentials-cluster-external-secret.yaml
+++ b/zot-pull/credentials-cluster-external-secret.yaml
@@ -1,30 +1,13 @@
 # Materialises the Keycloak `cluster-puller` client credentials (client_id /
 # client_secret from Vault) as a Secret in the `zot-pull-source` namespace.
 #
-# Why a single source namespace, not fan-out:
-#   The previous `zot-pull/enabled=true` label selector pattern required every
-#   workload namespace to opt in by labelling itself. That was inverted in
-#   favour of Kyverno-driven on-demand generation: see
-#   kyverno-policies/zot-pull-injection.yaml. The flow is now:
-#     ESO → Secret in zot-pull-source ns → Kyverno generate clones it on Pod
-#     admission to the consumer ns → mutate adds imagePullSecrets to the Pod.
+# Co-located with the ClusterGenerator-consuming ExternalSecret in
+# `zot-pull-source` because ESO v0.19.0 hard-codes ClusterScoped=false on
+# Webhook generators (pkg/common/webhook/webhook.go:52-66), so `secretRef.name`
+# is always resolved against the ExternalSecret's own namespace.
 #
-# Why this Secret needs to be co-located with the consumer of the
-# ClusterGenerator (i.e. zot-pull's ExternalSecret), rather than sitting in
-# `external-secrets/`:
-#   ESO v0.19.0 hard-codes ClusterScoped=false on Webhook generators
-#   (pkg/common/webhook/webhook.go:52-66), so `secretRef.name` is always
-#   resolved against the consumer namespace. As long as both this Secret AND
-#   the Webhook-Generator-consuming ExternalSecret live in `zot-pull-source`,
-#   the lookup succeeds.
-#
-# Refresh cadence:
-#   - refreshTime: 5m  — controller scan cadence (how often the selector is
-#                         re-evaluated). Since we target a single fixed
-#                         namespace, this just controls retry on transient
-#                         failures.
-#   - refreshInterval: 1h — Keycloak client_secret rotation cadence; re-read
-#                            from Vault hourly to pick up rotation.
+# refreshInterval: 1h matches Keycloak client_secret rotation cadence — re-read
+# from Vault hourly to pick up rotation.
 apiVersion: external-secrets.io/v1
 kind: ClusterExternalSecret
 metadata:

--- a/zot-pull/credentials-cluster-external-secret.yaml
+++ b/zot-pull/credentials-cluster-external-secret.yaml
@@ -1,16 +1,30 @@
-# Fans the Keycloak `cluster-puller` client credentials directly from Vault
-# into every namespace selected by `zot-pull/enabled=true`. ESO's webhook
-# `ClusterGenerator` resolves `secretRef` against the *consumer* namespace
-# (each materialised target), so the credentials Secret must exist there —
-# placing it only in the controller namespace is not enough (ESO v0.19.0
-# `pkg/common/webhook/webhook.go:52-66` hard-codes ClusterScoped=false on
-# webhook generators referenced from a ClusterGenerator).
+# Materialises the Keycloak `cluster-puller` client credentials (client_id /
+# client_secret from Vault) as a Secret in the `zot-pull-source` namespace.
+#
+# Why a single source namespace, not fan-out:
+#   The previous `zot-pull/enabled=true` label selector pattern required every
+#   workload namespace to opt in by labelling itself. That was inverted in
+#   favour of Kyverno-driven on-demand generation: see
+#   kyverno-policies/zot-pull-injection.yaml. The flow is now:
+#     ESO → Secret in zot-pull-source ns → Kyverno generate clones it on Pod
+#     admission to the consumer ns → mutate adds imagePullSecrets to the Pod.
+#
+# Why this Secret needs to be co-located with the consumer of the
+# ClusterGenerator (i.e. zot-pull's ExternalSecret), rather than sitting in
+# `external-secrets/`:
+#   ESO v0.19.0 hard-codes ClusterScoped=false on Webhook generators
+#   (pkg/common/webhook/webhook.go:52-66), so `secretRef.name` is always
+#   resolved against the consumer namespace. As long as both this Secret AND
+#   the Webhook-Generator-consuming ExternalSecret live in `zot-pull-source`,
+#   the lookup succeeds.
 #
 # Refresh cadence:
-#   - refreshTime: 5m   — how often the controller scans for newly labelled
-#                          namespaces and pushes the credentials Secret in.
-#   - refreshInterval: 1h — Keycloak client_secret rotation cadence; we re-read
-#                            from Vault hourly in case the operator rotates it.
+#   - refreshTime: 5m  — controller scan cadence (how often the selector is
+#                         re-evaluated). Since we target a single fixed
+#                         namespace, this just controls retry on transient
+#                         failures.
+#   - refreshInterval: 1h — Keycloak client_secret rotation cadence; re-read
+#                            from Vault hourly to pick up rotation.
 apiVersion: external-secrets.io/v1
 kind: ClusterExternalSecret
 metadata:
@@ -18,7 +32,7 @@ metadata:
 spec:
   namespaceSelector:
     matchLabels:
-      zot-pull/enabled: "true"
+      kubernetes.io/metadata.name: zot-pull-source
   refreshTime: 5m
   externalSecretSpec:
     refreshInterval: 1h


### PR DESCRIPTION
## Summary

Migrates the cluster-wide `zot-pull` imagePullSecret automation from the
ESO-fanout-by-namespace-label model to a Kyverno-driven, Pod-admission-time
mutate-and-generate flow. ESO still materialises the canonical Secret, but
distribution is now triggered on-demand rather than opt-in.

## Architecture

```
ESO (Vault → Keycloak token-exchange)
   └─> Secret zot-pull (in zot-pull-source ns)
                 │
                 ▼
   Kyverno ClusterPolicy `zot-pull-injection`
     - mutate: append `zot-pull` to spec.imagePullSecrets
     - generate: clone Secret into the Pod's namespace (synchronize=true)
                 │
                 ▼
   kubelet pulls registry.i.shion1305.com/<image> with bearer token
```

Both rules fire only when the admitting Pod has at least one container or
initContainer image whose registry hostname is `registry.i.shion1305.com`.

## What's in this PR

- `apps/zot-pull-source-app.yaml` + `zot-pull-source/` — new namespace that
  holds the canonical `zot-pull` Secret. ESO's two ClusterExternalSecrets
  (already retargeted in commit `d26e336`) materialise into this one ns.
- `apps/kyverno-policies-app.yaml` + `kyverno-policies/zot-pull-injection.yaml`
  — `ClusterPolicy` with the mutate rule (adds imagePullSecret) and generate
  rule (clones Secret), guarded by `AnyIn` preconditions on
  `images.containers.*.registry` / `images.initContainers.*.registry`.
- `zot-pull-smoketest/` — drops the `zot-pull/enabled=true` namespace label
  and the explicit `imagePullSecrets` field from the Job; Kyverno now
  supplies both.

This is **not** a draft. Reviewer approval expected.

## Pre-merge prerequisite

Vault path `zot/cluster-puller` MUST contain `client_id` and `client_secret`
for ESO to materialise the source Secret. Without that the smoketest will
sit in ImagePullBackOff regardless of Kyverno status — the failure mode is
identical to a missing Vault secret today.

```
vault kv get zot/cluster-puller   # must show both keys
```

## Behavioural notes

**Race window on first Pod in a namespace.** Mutate runs synchronously at
admission, generate runs asynchronously. The Pod object lands with
`imagePullSecrets: [{name: zot-pull}]` immediately, but the cloned Secret
may not exist when kubelet first pulls. kubelet retries with backoff on
ImagePullBackOff; the Secret is typically created within ~1s, so the second
attempt succeeds. Subsequent Pods in the same namespace see the Secret
already present.

**failurePolicy: Ignore** at the webhook level. A Kyverno outage will not
block unrelated Pod admission cluster-wide. Pods that depend on the secret
will degrade gracefully to ImagePullBackOff and self-heal once Kyverno
recovers — strictly better than failing closed and blocking the cluster.

## Removal of the opt-in label

The `zot-pull/enabled=true` namespace label is no longer used by any
ClusterExternalSecret. I grepped the repo:

- `zot-pull/credentials-cluster-external-secret.yaml` — comment only
  (the existing selector already keys off `kubernetes.io/metadata.name`).
- `zot-pull-smoketest/namespace.yaml` — label removed in this PR.
- `kyverno-policies/zot-pull-injection.yaml` — comment only (explains what
  was retired).
- `keycloak-operator/zot-realm.yaml` — two stale comment-block references;
  left untouched per scope but worth a follow-up.

If any namespace outside this repo is still relying on that label for its
`zot-pull` Secret, it will lose the Secret on the next ESO sync. None
detected in this codebase.

## Test plan

- [ ] After merge, watch `kubectl get clusterpolicy zot-pull-injection -o yaml`
      — both rules should report `ready: true`.
- [ ] `kubectl get secret -n zot-pull-source zot-pull` — source Secret
      materialised by ESO.
- [ ] `kubectl get application -n argocd zot-pull-smoketest` — Healthy.
- [ ] `kubectl get pod -n zot-pull-smoketest -o yaml | grep -A 2 imagePullSecrets`
      — Kyverno injected `zot-pull` even though the Job manifest did not
      specify it.
- [ ] `kubectl get secret -n zot-pull-smoketest zot-pull` — generate rule
      cloned the Secret into the consumer namespace.
- [ ] Pick a second arbitrary namespace, deploy a Pod with image
      `registry.i.shion1305.com/...`, verify the same flow kicks in
      without any namespace pre-prep.