### PR TITLE
fix(zot-pull): add webhook type label to cluster-puller credentials

### DIFF
--- a/zot-pull/credentials-cluster-external-secret.yaml
+++ b/zot-pull/credentials-cluster-external-secret.yaml
@@ -29,6 +29,13 @@ spec:
       template:
         type: Opaque
         engineVersion: v2
+        metadata:
+          labels:
+            # Required by ESO Webhook generator (ClusterGenerator
+            # `keycloak-cluster-puller-token`). Without this label ESO refuses
+            # to read the Secret as a Webhook generator credentials source and
+            # the dependent zot-pull ExternalSecret stays SecretSyncedError.
+            external-secrets.io/type: webhook
     data:
       - secretKey: client_id
         remoteRef:


### PR DESCRIPTION
## Summary
- Adds the `external-secrets.io/type: webhook` label to the `zot-cluster-puller-credentials` Secret template
- Without this label the ESO Webhook generator (ClusterGenerator `keycloak-cluster-puller-token`) refuses to read the Secret, so the dependent `zot-pull` ExternalSecret never materialises and the cluster-wide pull credential pipeline stays broken
- Discovered while restoring the zot-pull pipeline today: after populating Vault `zot/cluster-puller` and watching `zot-cluster-puller-credentials` reach `SecretSynced=True`, the next reconcile loop produced `secret does not contain needed label 'external-secrets.io/type: webhook'. Update secret label to use it with webhook`

## Test plan
- [x] Verified ESO error message in `external-secrets` controller logs
- [ ] After merge: confirm `zot-cluster-puller-credentials` Secret in `zot-pull-source` carries the new label
- [ ] After merge: confirm `zot-pull` ExternalSecret reaches `Ready=True` and the dockerconfigjson Secret is materialised
- [ ] After merge: confirm `zot-pull-smoketest` Job/Pod transitions out of ImagePullBackOff