### PR TITLE
fix(kyverno): grant Secret RBAC needed by zot-pull-injection

### DIFF
--- a/kyverno/values.yaml
+++ b/kyverno/values.yaml
@@ -23,6 +23,22 @@ admissionController:
       memory: 128Mi
     limits:
       memory: 384Mi
+  # Required so Kyverno's policy validation webhook can confirm the
+  # background controller will have permission to perform the
+  # `generate.clone` action in our `zot-pull-injection` ClusterPolicy.
+  # Without this the policy itself is rejected at apply time with
+  # "requires permissions list,get for resource v1/Secret in namespace ...".
+  rbac:
+    clusterRole:
+      extraResources:
+        - apiGroups:
+            - ""
+          resources:
+            - secrets
+          verbs:
+            - get
+            - list
+            - watch
 
 backgroundController:
   replicas: 1
@@ -34,6 +50,26 @@ backgroundController:
       memory: 64Mi
     limits:
       memory: 256Mi
+  # The default chart RBAC does not grant the background controller any
+  # permission on Secrets. Our `zot-pull-injection` ClusterPolicy uses
+  # `generate.clone` to copy the source dockerconfigjson Secret from
+  # `zot-pull-source` into every consumer namespace, which requires the
+  # background controller SA to read the source and write the target.
+  rbac:
+    clusterRole:
+      extraResources:
+        - apiGroups:
+            - ""
+          resources:
+            - secrets
+          verbs:
+            - get
+            - list
+            - watch
+            - create
+            - update
+            - patch
+            - delete
 
 reportsController:
   replicas: 1


### PR DESCRIPTION
## Summary
- Adds `extraResources` to both `admissionController.rbac.clusterRole` and `backgroundController.rbac.clusterRole` so Kyverno can validate and execute the `zot-pull-injection` ClusterPolicy
- Without this the policy is rejected at apply time (admission validation), and even after acceptance the background controller is forbidden from cloning the source `zot-pull` Secret out of `zot-pull-source` into consumer namespaces — the dependent Pod stays in `ImagePullBackOff` with `FailedToRetrieveImagePullSecret`
- Discovered while testing the cluster-wide pull pipeline today

## Test plan
- [x] Reproduced the background-controller RBAC error (`secrets "zot-pull" is forbidden ... in the namespace "zot-pull-source"`) from the controller logs
- [ ] After merge: confirm `kyverno:admission-controller` and `kyverno:background-controller` ClusterRoles include Secret rules
- [ ] After merge: re-create `zot-pull-smoketest` Pod, verify the `zot-pull` dockerconfigjson Secret is cloned into the namespace and the Pod transitions to `Completed`

## Related
- #294 introduced the cluster-wide architecture but did not include these RBAC rules
- #295 fixes the upstream ESO Webhook label requirement for the same pipeline