### PR TITLE
feat(zot): rewrite Basic auth with oidc: prefix into Bearer for /v2/

### DIFF
--- a/zot/README.md
+++ b/zot/README.md
@@ -1,0 +1,88 @@
+# zot — OCI Registry
+
+Project-zot v2 deployed cluster-wide as the canonical container image registry for `registry.shion1305.com`.
+
+## Hostnames and routing
+
+Two hostnames front the same `zot` Service. The split-by-path pattern applies to both:
+
+| Hostname | Gateway | HTTPRoute (`/v2/`) | HTTPRoute (`/`, `/v2/_zot/`) |
+| --- | --- | --- | --- |
+| `registry.shion1305.com` | `external` (public) | `zot-registry-external` | `zot-ui-external` |
+| `registry.i.shion1305.com` | `internal` (WireGuard-only) | `zot-registry-internal` | `zot-ui-internal` |
+
+The `/v2/` routes carry Docker Registry v2 protocol traffic (push/pull). The other routes serve the SPA, OIDC login flow, and zot's own extension XHRs (`/v2/_zot/...`). Gateway API most-specific-path-wins (GEP-718) keeps `/v2/_zot/...` on the UI route even though `/v2/` matches.
+
+## Auth callers
+
+Three distinct caller types reach zot. zot itself does no Envoy-level OIDC mediation — it speaks to each upstream issuer directly.
+
+```
+                    ┌─────────────────────────────────────────────────────┐
+                    │                 envoy-gateway                       │
+                    │                                                     │
+  GHA crane push ───┼─→ /v2/* ──────────────────────────────────────────┐ │
+  (Bearer JWT)      │                                                   │ │
+                    │                                                   ▼ │
+  kubelet pull ─────┼─→ /v2/* ─→ [Lua: Basic(oidc:JWT)→Bearer JWT] ───→ zot
+  (Basic JWT)       │                                                   ▲ │
+                    │                                                   │ │
+  Browser UI ───────┼─→ /, /v2/_zot/* ──────────────────────────────────┘ │
+  (cookie / OIDC)   │                                                     │
+                    └─────────────────────────────────────────────────────┘
+```
+
+### 1. GitHub Actions push (`Authorization: Bearer <gh-oidc>`)
+
+`crane` reads `~/.docker/config.json` and sends `registrytoken` pre-emptively as Bearer. Validated by `http.auth.bearer.oidc[token.actions.githubusercontent.com]`. CEL claim mapping derives `username = claims.repository` and assigns the right pusher group from `repository_owner`. See `.github/workflows/demo-push-to-zot.yaml`.
+
+### 2. Kubelet/containerd pull (`Authorization: Basic base64("oidc:<jwt>")`)
+
+containerd reads the dockerconfigjson Secret materialised by ESO (see `../zot-pull/`) and sends the `auth` field verbatim as `Authorization: Basic ...`. zot's bearer middleware short-circuits at `pkg/api/authn.go:65-67` and never falls through to Basic auth, so the request would 401 without an envoy-side rewrite.
+
+`envoy-extension-policy.yaml` ships a Lua filter on the two `/v2/` HTTPRoutes that decodes the Basic credential, strips the `oidc:` prefix, and rewrites the header to `Bearer <jwt>` before it reaches zot. After rewrite, the JWT is validated by `http.auth.bearer.oidc[keycloak]` (audience `zot-registry`, hardcoded `groups` mapper on the Keycloak `cluster-puller` client).
+
+The filter only fires on `^[Bb]asic ` — Bearer push traffic from GHA passes through untouched.
+
+### 3. Browser UI (cookie session)
+
+Browsers hit `/` and `/v2/_zot/*`. zot's native `http.auth.openid` provider runs the Authorization Code Flow against the same Keycloak realm, then mints a session cookie. SPA routes `/zot/auth/login/oidc` → `/zot/auth/callback/oidc` → `/`. zot's validator only accepts provider keys `google`/`gitlab`/`oidc` for OpenID, so the provider key is `oidc` (not `keycloak`).
+
+## Access control
+
+`http.accessControl` is group-based:
+
+| Group | Repo glob | Actions |
+| --- | --- | --- |
+| `pusher-shion1305` | `shion1305/**` | read, create, update |
+| `pusher-shion1305dev` | `shion1305dev/**` | read, create, update |
+| `zot-admin` | `**` (admin policy) | read, create, update, delete |
+| _(none)_ | `**` | read (default policy) |
+
+Group claims come from each issuer:
+
+- GHA OIDC → CEL claim mapping derives the group from `repository_owner` (`Shion1305` → `pusher-shion1305`, `Shion1305Dev` → `pusher-shion1305dev`).
+- Keycloak `zot` realm → `groups` claim, populated by per-client mappers.
+
+## ExternalSecrets
+
+Two on-disk artefacts are required for the OpenID UI flow and are mounted as files into the zot Pod via the chart's `externalSecrets[]` hook:
+
+| ExternalSecret | Vault path | Mount path | Purpose |
+| --- | --- | --- | --- |
+| `zot-openid-credentials` | `zot/openid-credentials` | `/secrets/openid` | `keycloak-credentials.json` (zot-ui client_id + client_secret) |
+| `zot-session-keys` | `zot/session-keys` | `/secrets/session` | `sessionKeys.json` (gorilla session HMAC + AES-CTR keys) |
+
+Both are wired through the namespace's `SecretStore` (`secret-store.yaml`) backed by Kubernetes auth role `eso-zot`.
+
+## Cluster-wide pull credential
+
+The pull-side credential pipeline lives outside this directory:
+
+- `../zot-pull-source/` — namespace holding the canonical `zot-pull` dockerconfigjson Secret, populated by ESO from a Keycloak access_token (ClusterGenerator `keycloak-cluster-puller-token`).
+- `../zot-pull/` — `ClusterExternalSecret` definitions that materialise the Secret in `zot-pull-source` (one for the puller credentials, one for the dockerconfigjson token).
+- `../kyverno-policies/zot-pull-injection.yaml` — Kyverno mutate (injects `imagePullSecrets`) + generate.clone (fans the Secret out to consumer namespaces) on Pod admission for any image referencing `registry.i.shion1305.com/*`.
+
+## Image pinning
+
+zot's upstream Helm chart hard-pins to architecture-specific images (`zot-linux-amd64` / `zot-linux-arm64`) instead of a multi-arch manifest list. `values.yaml` pins `zot-linux-amd64` and constrains scheduling with `nodeSelector: kubernetes.io/arch: amd64`. Drop both if upstream switches to a manifest list.

--- a/zot/envoy-extension-policy.yaml
+++ b/zot/envoy-extension-policy.yaml
@@ -1,0 +1,76 @@
+# Rewrites `Authorization: Basic base64("oidc:<jwt>")` into
+# `Authorization: Bearer <jwt>` so kubelet/containerd image pulls work against
+# zot's bearer-OIDC middleware, which only accepts JWT bearer tokens.
+#
+# Why this exists:
+#   zot v2.1.16's `http.auth.bearer.oidc[]` short-circuits all auth handling to
+#   the bearer path (pkg/api/authn.go:65-67) and never falls through to Basic
+#   auth. Containerd, on the other hand, reads dockerconfigjson and sends the
+#   `auth` field verbatim as `Authorization: Basic <auth>`. ESO templates the
+#   secret as `auth: base64("oidc:<jwt>")`, so without a rewrite zot sees
+#   `Basic …` and 401s.
+#
+# GitHub Actions push uses `crane` with `registrytoken`, which emits
+# `Authorization: Bearer …` directly. Those requests fail the `^Basic ` match
+# below and pass through untouched.
+#
+# Scope: only the `/v2/` registry HTTPRoutes (external + internal). The UI
+# routes (zot-ui-external / zot-ui-internal) handle browser/OIDC traffic and
+# must not be molested.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyExtensionPolicy
+metadata:
+  name: zot-basic-to-bearer
+  namespace: zot
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: zot-registry-external
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: zot-registry-internal
+  lua:
+    - type: Inline
+      inline: |
+        -- Pure-Lua RFC 4648 base64 decoder. Envoy's Lua filter API exposes
+        -- `base64Escape` (encode) but not a decoder, so we ship one inline.
+        local b64chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+        local b64lookup = {}
+        for i = 1, #b64chars do
+          b64lookup[string.byte(b64chars, i)] = i - 1
+        end
+
+        local function b64decode(input)
+          input = string.gsub(input, "[^A-Za-z0-9+/=]", "")
+          local out = {}
+          local buf, bits = 0, 0
+          for i = 1, #input do
+            local c = string.byte(input, i)
+            if c == 61 then break end -- '='
+            local v = b64lookup[c]
+            if v == nil then return nil end
+            buf = buf * 64 + v
+            bits = bits + 6
+            if bits >= 8 then
+              bits = bits - 8
+              local byte = math.floor(buf / (2 ^ bits))
+              buf = buf - byte * (2 ^ bits)
+              out[#out + 1] = string.char(byte)
+            end
+          end
+          return table.concat(out)
+        end
+
+        function envoy_on_request(request_handle)
+          local headers = request_handle:headers()
+          local auth = headers:get("authorization")
+          if not auth then return end
+          local b64 = string.match(auth, "^[Bb]asic%s+(.+)$")
+          if not b64 then return end -- already Bearer (push) or other scheme
+          local decoded = b64decode(b64)
+          if not decoded then return end
+          local jwt = string.match(decoded, "^oidc:(.+)$")
+          if not jwt then return end
+          headers:replace("authorization", "Bearer " .. jwt)
+        end

--- a/zot/kustomization.yaml
+++ b/zot/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - reference-grant.yaml
   - httproute-external.yaml
   - httproute-internal.yaml
+  - envoy-extension-policy.yaml


### PR DESCRIPTION
## Summary

- Adds `zot/envoy-extension-policy.yaml`: an `EnvoyExtensionPolicy` with an inline Lua filter that decodes `Authorization: Basic base64("oidc:<jwt>")` and rewrites it to `Authorization: Bearer <jwt>`.
- Targets only the two `/v2/` HTTPRoutes (`zot-registry-external`, `zot-registry-internal`); UI routes are untouched.
- Unblocks cluster-wide `kubelet`/`containerd` image pulls (PR #294's architecture) without changing zot, ESO, Vault, Kyverno, or Keycloak.

## Why

zot v2.1.16's `http.auth.bearer.oidc[]` middleware short-circuits all auth at `pkg/api/authn.go:65-67` and never falls through to Basic auth. Containerd, however, reads `dockerconfigjson` and sends the `auth` field verbatim as `Authorization: Basic ...`. ESO templates the secret as `auth: base64("oidc:<jwt>")`, so without a rewrite zot sees `Basic …` and 401s.

GitHub Actions push (`crane` with `registrytoken`) emits `Authorization: Bearer …` directly, fails the `^Basic ` match, and passes through untouched.

## Test plan

- [ ] `kubectl kustomize zot/` builds clean
- [ ] Server-side dry-run validates against the `EnvoyExtensionPolicy` CRD
- [ ] After ArgoCD sync, `zot-pull-smoketest` Job's pod transitions out of `ImagePullBackOff` and pulls successfully
- [ ] zot logs show `200 OK` on `/v2/shion1305/demo/...` requests authenticated as the cluster-puller subject (not `username=oidc`)
- [ ] GitHub Actions `demo-push-to-zot` workflow still pushes successfully (Bearer path untouched)
- [ ] Browser access to `https://registry.shion1305.com` and the OIDC login flow still work (UI route untouched)

## Rollback

`kubectl delete envoyextensionpolicy zot-basic-to-bearer -n zot` (or revert this PR).