### PR TITLE
fix(zot): inject WWW-Authenticate Basic on 401 so containerd retries with creds

### DIFF
--- a/zot/README.md
+++ b/zot/README.md
@@ -38,11 +38,17 @@ Three distinct caller types reach zot. zot itself does no Envoy-level OIDC media
 
 ### 2. Kubelet/containerd pull (`Authorization: Basic base64("oidc:<jwt>")`)
 
-containerd reads the dockerconfigjson Secret materialised by ESO (see `../zot-pull/`) and sends the `auth` field verbatim as `Authorization: Basic ...`. zot's bearer middleware short-circuits at `pkg/api/authn.go:65-67` and never falls through to Basic auth, so the request would 401 without an envoy-side rewrite.
+containerd reads the dockerconfigjson Secret materialised by ESO (see `../zot-pull/`) and goes through the standard Docker Registry v2 challenge/retry handshake. zot's bearer-OIDC middleware short-circuits at `pkg/api/authn.go:65-67`, so two things break end-to-end without help:
 
-`envoy-extension-policy.yaml` ships a Lua filter on the two `/v2/` HTTPRoutes that decodes the Basic credential, strips the `oidc:` prefix, and rewrites the header to `Bearer <jwt>` before it reaches zot. After rewrite, the JWT is validated by `http.auth.bearer.oidc[keycloak]` (audience `zot-registry`, hardcoded `groups` mapper on the Keycloak `cluster-puller` client).
+1. zot returns 401 to the unauthenticated probe with **no `WWW-Authenticate` header**. containerd interprets this as "no scheme advertised" and never retries with credentials.
+2. Even if containerd retries, the dockerconfig `auth` field is sent verbatim as `Authorization: Basic ...`, which zot's bearer middleware refuses to parse.
 
-The filter only fires on `^[Bb]asic ` — Bearer push traffic from GHA passes through untouched.
+`envoy-extension-policy.yaml` ships a Lua filter on the two `/v2/` HTTPRoutes that fixes both halves:
+
+- `envoy_on_response` adds `WWW-Authenticate: Basic realm="zot"` to any 401 from zot that lacks the header. containerd then retries with the credential from the imagePullSecret.
+- `envoy_on_request` decodes the retry's Basic credential, strips the `oidc:` prefix, and rewrites the header to `Bearer <jwt>` before it reaches zot. The JWT is then validated by `http.auth.bearer.oidc[keycloak]` (audience `zot-registry`, hardcoded `groups` mapper on the Keycloak `cluster-puller` client).
+
+Bearer push traffic from GHA fails the `^[Bb]asic ` match and passes through untouched. The response-side injection is also a no-op for push because crane sends Bearer pre-emptively and never receives a 401.
 
 ### 3. Browser UI (cookie session)
 

--- a/zot/envoy-extension-policy.yaml
+++ b/zot/envoy-extension-policy.yaml
@@ -1,18 +1,23 @@
-# Rewrites `Authorization: Basic base64("oidc:<jwt>")` into
-# `Authorization: Bearer <jwt>` so kubelet/containerd image pulls work against
-# zot's bearer-OIDC middleware, which only accepts JWT bearer tokens.
+# Bridges containerd's Docker Registry v2 auth flow with zot's bearer-OIDC
+# middleware on the `/v2/` HTTPRoutes (external + internal). Two halves:
 #
-# Why this exists:
-#   zot v2.1.16's `http.auth.bearer.oidc[]` short-circuits all auth handling to
-#   the bearer path (pkg/api/authn.go:65-67) and never falls through to Basic
-#   auth. Containerd, on the other hand, reads dockerconfigjson and sends the
-#   `auth` field verbatim as `Authorization: Basic <auth>`. ESO templates the
-#   secret as `auth: base64("oidc:<jwt>")`, so without a rewrite zot sees
-#   `Basic …` and 401s.
+#   envoy_on_response — when zot returns 401 without a `WWW-Authenticate`
+#     header, inject `WWW-Authenticate: Basic realm="<host>"`. zot's bearer-
+#     OIDC path emits no challenge of its own (verified empirically — bare
+#     `curl /v2/...` returns 401 with no auth header), so containerd treats
+#     the response as "no scheme advertised" and never retries with creds.
+#     A Basic challenge convinces containerd to retry with the dockerconfig
+#     `auth` value loaded from the imagePullSecret.
 #
-# GitHub Actions push uses `crane` with `registrytoken`, which emits
-# `Authorization: Bearer …` directly. Those requests fail the `^Basic ` match
-# below and pass through untouched.
+#   envoy_on_request — on the retry, the Authorization header is
+#     `Basic base64("oidc:<jwt>")` because ESO templates the dockerconfigjson
+#     as `auth: base64("oidc:<jwt>")` and containerd forwards it verbatim.
+#     zot's bearer middleware short-circuits at pkg/api/authn.go:65-67 and
+#     does not parse Basic, so we decode here, strip the `oidc:` prefix, and
+#     rewrite to `Bearer <jwt>`. zot's OIDC verifier then validates the JWT.
+#
+# GitHub Actions push uses `crane` with `registrytoken`, which sends Bearer
+# pre-emptively and never sees the 401 — so neither half affects push.
 #
 # Scope: only the `/v2/` registry HTTPRoutes (external + internal). The UI
 # routes (zot-ui-external / zot-ui-internal) handle browser/OIDC traffic and
@@ -73,4 +78,11 @@ spec:
           local jwt = string.match(decoded, "^oidc:(.+)$")
           if not jwt then return end
           headers:replace("authorization", "Bearer " .. jwt)
+        end
+
+        function envoy_on_response(response_handle)
+          local headers = response_handle:headers()
+          if headers:get(":status") ~= "401" then return end
+          if headers:get("www-authenticate") then return end -- don't override
+          headers:add("www-authenticate", 'Basic realm="zot"')
         end


### PR DESCRIPTION
## Summary

Follow-up to #298. Adds the missing response-side half of the auth bridge so cluster pulls actually complete.

- `envoy_on_response`: injects `WWW-Authenticate: Basic realm="zot"` on any 401 from /v2/ that lacks the header.
- README updated to describe both halves of the Lua filter and why each is necessary.

## Why #298 alone wasn't enough

zot's bearer-OIDC middleware returns 401 with **no `WWW-Authenticate` header** — verified empirically:

```console
$ curl -ksI https://registry.i.shion1305.com/v2/shion1305/demo/manifests/latest
HTTP/1.1 401 Unauthorized
content-type: application/json
date: ...
content-length: 253
```

(Also reproduced going directly to the zot Service via port-forward, so envoy is not stripping it — zot doesn't emit it.)

containerd interprets a 401 with no scheme advertised as "this server doesn't accept any auth I know about" and never retries with the imagePullSecret credential. Result: zot logs show repeated 401s with no Authorization header in any of them, and #298's `envoy_on_request` rewrite never sees a Basic header to convert.

This PR closes the loop by giving containerd the Basic challenge it needs to populate Authorization on the retry. The existing on_request rewrite then turns that Basic into Bearer for zot's OIDC verifier.

## Test plan

- [ ] `kubectl kustomize zot/` builds clean
- [ ] Server-side dry-run validates against the `EnvoyExtensionPolicy` CRD
- [ ] After ArgoCD sync, `curl -kI https://registry.i.shion1305.com/v2/shion1305/demo/manifests/latest` returns 401 with `WWW-Authenticate: Basic realm="zot"`
- [ ] `zot-pull-smoketest` Job's pod transitions out of `ImagePullBackOff` and pulls successfully
- [ ] zot logs show `200 OK` on `/v2/shion1305/demo/...` requests authenticated as the cluster-puller subject
- [ ] GitHub Actions `demo-push-to-zot` workflow still pushes successfully

## Rollback

Revert this PR (and #298 if needed); no schema changes, no data migrations.