### PR TITLE
fix(zot): only challenge containerd-class clients, not browsers

### DIFF
--- a/zot/README.md
+++ b/zot/README.md
@@ -45,10 +45,12 @@ containerd reads the dockerconfigjson Secret materialised by ESO (see `../zot-pu
 
 `envoy-extension-policy.yaml` ships a Lua filter on the two `/v2/` HTTPRoutes that fixes both halves:
 
-- `envoy_on_response` adds `WWW-Authenticate: Basic realm="zot"` to any 401 from zot that lacks the header. containerd then retries with the credential from the imagePullSecret.
-- `envoy_on_request` decodes the retry's Basic credential, strips the `oidc:` prefix, and rewrites the header to `Bearer <jwt>` before it reaches zot. The JWT is then validated by `http.auth.bearer.oidc[keycloak]` (audience `zot-registry`, hardcoded `groups` mapper on the Keycloak `cluster-puller` client).
+- `envoy_on_request` flags requests from containerd-class User-Agents (`containerd/*`, `docker/*`, `Go-http-client/*` — covers kubelet, the Docker daemon, and `crane`) by stashing `zot.basic_to_bearer/wants_basic_challenge=true` in dynamic metadata. It also decodes any incoming `Basic base64("oidc:<jwt>")` and rewrites it to `Bearer <jwt>` before it reaches zot.
+- `envoy_on_response` reads the metadata flag. On a 401 from a flagged request that lacks `WWW-Authenticate`, it injects `Basic realm="zot"`. containerd then retries with the credential from the imagePullSecret. The retry's JWT is validated by `http.auth.bearer.oidc[keycloak]` (audience `zot-registry`, hardcoded `groups` mapper on the Keycloak `cluster-puller` client).
 
-Bearer push traffic from GHA fails the `^[Bb]asic ` match and passes through untouched. The response-side injection is also a no-op for push because crane sends Bearer pre-emptively and never receives a 401.
+Browsers are deliberately excluded from the response-side injection: the SPA hits `/v2/` and `/v2/_catalog` during boot and 401s on those endpoints. Without the User-Agent gate, the browser would pop up its native Basic-auth dialog before the user could click "Sign in with OIDC".
+
+GHA push traffic from `crane` matches the `Go-http-client` UA so the metadata flag is set, but `crane` sends `Bearer` pre-emptively (`registrytoken`) and never receives a 401, so the response-side injection is a no-op for push.
 
 ### 3. Browser UI (cookie session)
 

--- a/zot/envoy-extension-policy.yaml
+++ b/zot/envoy-extension-policy.yaml
@@ -1,13 +1,20 @@
 # Bridges containerd's Docker Registry v2 auth flow with zot's bearer-OIDC
 # middleware on the `/v2/` HTTPRoutes (external + internal). Two halves:
 #
-#   envoy_on_response — when zot returns 401 without a `WWW-Authenticate`
-#     header, inject `WWW-Authenticate: Basic realm="<host>"`. zot's bearer-
-#     OIDC path emits no challenge of its own (verified empirically — bare
-#     `curl /v2/...` returns 401 with no auth header), so containerd treats
-#     the response as "no scheme advertised" and never retries with creds.
-#     A Basic challenge convinces containerd to retry with the dockerconfig
-#     `auth` value loaded from the imagePullSecret.
+#   envoy_on_response — when zot returns 401 to a containerd-class client
+#     without a `WWW-Authenticate` header, inject
+#     `WWW-Authenticate: Basic realm="zot"`. zot's bearer-OIDC path emits no
+#     challenge of its own (verified empirically — bare `curl /v2/...`
+#     returns 401 with no auth header), so containerd treats the response
+#     as "no scheme advertised" and never retries with creds. A Basic
+#     challenge convinces containerd to retry with the dockerconfig `auth`
+#     value loaded from the imagePullSecret.
+#
+#     The challenge is only injected when the request was from containerd
+#     (User-Agent stash via dynamic metadata). Browsers also hit /v2/* —
+#     the SPA calls /v2/_catalog and /v2/ during boot — and a Basic
+#     challenge there would trigger the browser's native Basic-auth popup
+#     before the user can even click "Sign in with OIDC".
 #
 #   envoy_on_request — on the retry, the Authorization header is
 #     `Basic base64("oidc:<jwt>")` because ESO templates the dockerconfigjson
@@ -67,8 +74,24 @@ spec:
           return table.concat(out)
         end
 
+        -- Filter namespace for stashing per-request hints into dynamic metadata
+        -- so envoy_on_response can read what envoy_on_request observed.
+        local FILTER_NS = "zot.basic_to_bearer"
+
+        local function is_containerd_ua(ua)
+          if not ua then return false end
+          return string.find(ua, "^containerd/") ~= nil
+              or string.find(ua, "^docker/") ~= nil
+              or string.find(ua, "^Go%-http%-client") ~= nil
+        end
+
         function envoy_on_request(request_handle)
           local headers = request_handle:headers()
+          local ua = headers:get("user-agent")
+          if is_containerd_ua(ua) then
+            request_handle:streamInfo():dynamicMetadata():set(
+              FILTER_NS, "wants_basic_challenge", "true")
+          end
           local auth = headers:get("authorization")
           if not auth then return end
           local b64 = string.match(auth, "^[Bb]asic%s+(.+)$")
@@ -84,5 +107,7 @@ spec:
           local headers = response_handle:headers()
           if headers:get(":status") ~= "401" then return end
           if headers:get("www-authenticate") then return end -- don't override
+          local meta = response_handle:streamInfo():dynamicMetadata():get(FILTER_NS)
+          if not meta or meta["wants_basic_challenge"] ~= "true" then return end
           headers:add("www-authenticate", 'Basic realm="zot"')
         end


### PR DESCRIPTION
## Summary

Follow-up to #299. The blanket `WWW-Authenticate: Basic realm="zot"` injection caused the browser to pop a native Basic-auth dialog when users hit `https://registry.i.shion1305.com/login` — the SPA fetches `/v2/` and `/v2/_catalog` during boot, both return 401, and the injected challenge made the browser handle it as Basic.

Gate the injection by request User-Agent. Only `containerd/*`, `docker/*`, and `Go-http-client/*` get the challenge; browser UAs (`Mozilla/...`) pass through with bare 401, letting the SPA's OIDC login button work as intended.

## How

`envoy_on_request` checks the UA and writes `wants_basic_challenge=true` into dynamic metadata under namespace `zot.basic_to_bearer` when the caller looks like a registry client. `envoy_on_response` reads that flag before injecting. (Envoy's Lua `envoy_on_response` doesn't have request handle access, so the metadata stash is the standard cross-callback pattern.)

UA matches:
- `containerd/*` — kubelet image pulls
- `docker/*` — Docker daemon and CLI
- `Go-http-client/*` — `crane` (covers GHA push, even though push never sees a 401)

## Test plan

- [ ] `kubectl kustomize zot/` builds clean and server-side dry-run validates
- [ ] `curl -ksI https://registry.i.shion1305.com/v2/shion1305/demo/manifests/latest` (no UA → curl/) → 401 with **no** `WWW-Authenticate` header
- [ ] `curl -ksI -H 'User-Agent: containerd/2.2.1' https://registry.i.shion1305.com/v2/shion1305/demo/manifests/latest` → 401 **with** `WWW-Authenticate: Basic realm="zot"`
- [ ] Browser visit to `https://registry.i.shion1305.com/login` → no native Basic-auth popup, OIDC sign-in button works
- [ ] `zot-pull-smoketest` Job still pulls successfully (containerd UA still gets the challenge)
- [ ] GitHub Actions `demo-push-to-zot` still pushes successfully

## Rollback

Revert this PR. PR #299 stays in place but kubelet pulls will continue to work because containerd retries are unaffected.