### PR TITLE
refactor(zot): mediate UI auth via Envoy SecurityPolicy.oidc

### DIFF
--- a/keycloak-operator/zot-realm.yaml
+++ b/keycloak-operator/zot-realm.yaml
@@ -5,11 +5,14 @@
 # This file is reconciled by the Keycloak Operator (KeycloakRealmImport CRD).
 # It declares the `zot` realm used to authenticate human users to the zot
 # registry Web UI and to mint pull tokens for in-cluster workloads:
-#   - Browser login flow is handled by zot's native `http.auth.openid`
-#     provider (zot/values.yaml), which performs the Authorization Code
-#     flow against this realm using the `zot-ui` confidential client below
-#     and mints its own session cookie. Envoy Gateway no longer mediates
-#     OIDC for the UI; routing is plain HTTPRoute pass-through.
+#   - Browser login flow is handled by Envoy Gateway's SecurityPolicy.oidc
+#     (zot/securitypolicy.yaml). Envoy runs the Authorization Code flow
+#     against this realm using the `zot-ui` confidential client below and
+#     forwards the resulting access_token upstream as
+#     `Authorization: Bearer <kc_at>`. zot's `bearer.oidc[keycloak]` then
+#     validates the same token. zot itself does NOT run a native openid
+#     provider — `http.auth.openid` is incompatible with `bearer.oidc[]` in
+#     zot v2.1.16 (upstream issue project-zot/zot#4033, intended behaviour).
 #   - In-cluster image pulls (kubelet imagePullSecrets) and manual
 #     `docker login` from WireGuard hosts use the `cluster-puller`
 #     service-account client below (grant_type=client_credentials). ESO's
@@ -37,9 +40,10 @@
 #    overwritten by Keycloak on first import; subsequent reconciles do not
 #    re-apply the placeholder.
 #
-# 2. Repeat for `zot-ui` and `cluster-puller`, then persist all three into
-#    Vault. The zot UI client secret now lives at zot/openid-credentials as
-#    a JSON blob that zot's `http.auth.openid` mounts via ExternalSecret
+# 2. Repeat for `zot-ui` and `cluster-puller`, then persist into Vault. The
+#    zot-ui client_id/client_secret are read by ESO from
+#    zot/openid-credentials (the historical path; shape unchanged) and
+#    projected onto a Secret consumed by Envoy's SecurityPolicy
 #    (zot/external-secret.yaml). cluster-puller is read by ESO via the
 #    `eso-cluster-puller` Vault role (see vault/scripts/setup-eso-policies.sh):
 #      vault kv put zot/openid-credentials \
@@ -47,9 +51,8 @@
 #      vault kv put zot/cluster-puller \
 #        client_id=cluster-puller \
 #        client_secret=<cluster-puller-secret>
-#    Also seed the session encryption keys consumed by zot's openid filter:
-#      vault kv put zot/session-keys \
-#        sessionKeys.json='{"hashKey":"<base64 64B>","encryptKey":"<base64 32B>"}'
+#    Session encryption keys are no longer needed — Envoy generates its own
+#    cookie HMAC/AES key. Drop the legacy zot/session-keys Vault entry.
 #
 # 3. Bind the Browser authentication flow to "Identity Provider Redirector"
 #    pinned to alias `user`, so human web logins skip the choice screen and go
@@ -347,14 +350,17 @@ spec:
         attributes:
           access.token.lifespan: "3600"
 
-      # zot-ui: confidential client driven by zot's native `http.auth.openid`
-      # provider (zot/values.yaml) to run the human Authorization Code flow.
-      # zot mints its own session cookie after exchanging the code; no
-      # `Authorization: Bearer` header reaches the registry HTTP layer for
-      # browser users, so the audience mapper that previously forced
-      # `aud=[zot-registry]` is no longer needed for UI flows. Audience is
-      # still emitted for parity with any other OAuth-aware client that
-      # might call this client_id.
+      # zot-ui: confidential client driven by Envoy Gateway's SecurityPolicy.oidc
+      # (zot/securitypolicy.yaml). Envoy runs the Authorization Code flow,
+      # mints its own encrypted session cookie, and forwards the access_token
+      # upstream as `Authorization: Bearer <kc_at>`. zot's
+      # `bearer.oidc[keycloak]` validates that token (audience=[zot-registry])
+      # and authorizes by the `groups` claim — same mappers, same accessControl.
+      #
+      # The redirect_uri Envoy uses is `https://<host>/oauth2/callback` (its
+      # default for the OAuth2 filter). One redirect URI per hostname is
+      # listed below; webOrigins also covers both so the realm validates
+      # cross-origin where needed.
       - clientId: zot-ui
         protocol: openid-connect
         publicClient: false
@@ -364,8 +370,8 @@ spec:
         directAccessGrantsEnabled: false
         serviceAccountsEnabled: false
         redirectUris:
-          - https://registry.shion1305.com/zot/auth/callback/oidc
-          - https://registry.i.shion1305.com/zot/auth/callback/oidc
+          - https://registry.shion1305.com/oauth2/callback
+          - https://registry.i.shion1305.com/oauth2/callback
         webOrigins:
           - https://registry.shion1305.com
           - https://registry.i.shion1305.com

--- a/zot/README.md
+++ b/zot/README.md
@@ -4,32 +4,38 @@ Project-zot v2 deployed cluster-wide as the canonical container image registry f
 
 ## Hostnames and routing
 
-Two hostnames front the same `zot` Service. The split-by-path pattern applies to both:
+Two hostnames front the same `zot` Service. Each has the same three-rule split:
 
-| Hostname | Gateway | HTTPRoute (`/v2/`) | HTTPRoute (`/`, `/v2/_zot/`) |
+| Hostname | Gateway | Registry HTTPRoute | UI HTTPRoute |
 | --- | --- | --- | --- |
 | `registry.shion1305.com` | `external` (public) | `zot-registry-external` | `zot-ui-external` |
 | `registry.i.shion1305.com` | `internal` (WireGuard-only) | `zot-registry-internal` | `zot-ui-internal` |
 
-The `/v2/` routes carry Docker Registry v2 protocol traffic (push/pull). The other routes serve the SPA, OIDC login flow, and zot's own extension XHRs (`/v2/_zot/...`). Gateway API most-specific-path-wins (GEP-718) keeps `/v2/_zot/...` on the UI route even though `/v2/` matches.
+`zot-registry-*` carries Docker Registry v2 protocol traffic and is split into two named rules:
+
+- `catalog-probe` — exact `/v2/` and `/v2/_catalog`. The SPA pings these at `/login` boot. Targeted by the OIDC `SecurityPolicy` via `sectionName: catalog-probe`.
+- `registry-protocol` — the broad `/v2/` PathPrefix that handles every push/pull. **Not** behind the OIDC policy — containerd negotiates its own bearer challenge with zot.
+
+`zot-ui-*` carries `/` and `/v2/_zot/*` (SPA bundle, `/zot/auth/*`, zot's extension XHRs). Fully behind the OIDC `SecurityPolicy`. Gateway API GEP-718 most-specific-path-wins routes `/v2/_zot/...` to `zot-ui-*` even though `/v2/` matches both routes.
 
 ## Auth callers
 
-Three distinct caller types reach zot. zot itself does no Envoy-level OIDC mediation — it speaks to each upstream issuer directly.
+Three distinct caller types reach zot. Browser UI auth is mediated by Envoy Gateway; machine callers go straight to zot's bearer-OIDC middleware.
 
 ```
-                    ┌─────────────────────────────────────────────────────┐
-                    │                 envoy-gateway                       │
-                    │                                                     │
-  GHA crane push ───┼─→ /v2/* ──────────────────────────────────────────┐ │
-  (Bearer JWT)      │                                                   │ │
-                    │                                                   ▼ │
-  kubelet pull ─────┼─→ /v2/* ─→ [Lua: Basic(oidc:JWT)→Bearer JWT] ───→ zot
-  (Basic JWT)       │                                                   ▲ │
-                    │                                                   │ │
-  Browser UI ───────┼─→ /, /v2/_zot/* ──────────────────────────────────┘ │
-  (cookie / OIDC)   │                                                     │
-                    └─────────────────────────────────────────────────────┘
+                    ┌────────────────────────────────────────────────────────────┐
+                    │                        envoy-gateway                       │
+                    │                                                            │
+  GHA crane push ───┼─→ /v2/* ─────────────────────────────────────────────────┐ │
+  (Bearer JWT)      │                                                          │ │
+                    │                                                          ▼ │
+  kubelet pull ─────┼─→ /v2/* ─→ [Lua: Basic(oidc:JWT)→Bearer JWT] ──────────→ zot
+  (Basic JWT)       │                                                          ▲ │
+                    │                                                          │ │
+  Browser UI ───────┼─→ /, /v2/_zot/* ─→ [SecurityPolicy.oidc → Keycloak] ─────┤ │
+  (cookie / OIDC)   │      and /v2/, /v2/_catalog (catalog-probe rule)         │ │
+                    │      [Lua: rewrite /v2/_zot/ext/mgmt response]           │ │
+                    └────────────────────────────────────────────────────────────┘
 ```
 
 ### 1. GitHub Actions push (`Authorization: Bearer <gh-oidc>`)
@@ -43,18 +49,37 @@ containerd reads the dockerconfigjson Secret materialised by ESO (see `../zot-pu
 1. zot returns 401 to the unauthenticated probe with **no `WWW-Authenticate` header**. containerd interprets this as "no scheme advertised" and never retries with credentials.
 2. Even if containerd retries, the dockerconfig `auth` field is sent verbatim as `Authorization: Basic ...`, which zot's bearer middleware refuses to parse.
 
-`envoy-extension-policy.yaml` ships a Lua filter on the two `/v2/` HTTPRoutes that fixes both halves:
+The `zot-basic-to-bearer` filter in `envoy-extension-policy.yaml` ships a Lua filter on the two `zot-registry-*` HTTPRoutes that fixes both halves:
 
 - `envoy_on_request` flags requests from containerd-class User-Agents (`containerd/*`, `docker/*`, `Go-http-client/*` — covers kubelet, the Docker daemon, and `crane`) by stashing `zot.basic_to_bearer/wants_basic_challenge=true` in dynamic metadata. It also decodes any incoming `Basic base64("oidc:<jwt>")` and rewrites it to `Bearer <jwt>` before it reaches zot.
 - `envoy_on_response` reads the metadata flag. On a 401 from a flagged request that lacks `WWW-Authenticate`, it injects `Basic realm="zot"`. containerd then retries with the credential from the imagePullSecret. The retry's JWT is validated by `http.auth.bearer.oidc[keycloak]` (audience `zot-registry`, hardcoded `groups` mapper on the Keycloak `cluster-puller` client).
 
-Browsers are deliberately excluded from the response-side injection: the SPA hits `/v2/` and `/v2/_catalog` during boot and 401s on those endpoints. Without the User-Agent gate, the browser would pop up its native Basic-auth dialog before the user could click "Sign in with OIDC".
+Browsers are deliberately excluded from the response-side injection: the SPA hits `/v2/` and `/v2/_catalog` during boot. Without the User-Agent gate, the browser would pop up its native Basic-auth dialog before the user could click "Sign in with OIDC".
 
 GHA push traffic from `crane` matches the `Go-http-client` UA so the metadata flag is set, but `crane` sends `Bearer` pre-emptively (`registrytoken`) and never receives a 401, so the response-side injection is a no-op for push.
 
-### 3. Browser UI (cookie session)
+### 3. Browser UI (Envoy SecurityPolicy.oidc, cookie session)
 
-Browsers hit `/` and `/v2/_zot/*`. zot's native `http.auth.openid` provider runs the Authorization Code Flow against the same Keycloak realm, then mints a session cookie. SPA routes `/zot/auth/login/oidc` → `/zot/auth/callback/oidc` → `/`. zot's validator only accepts provider keys `google`/`gitlab`/`oidc` for OpenID, so the provider key is `oidc` (not `keycloak`).
+Browsers hit `/`, `/v2/_zot/*`, and the SPA's two boot probes (`/v2/`, `/v2/_catalog`). All four are covered by `securitypolicy.yaml`'s OIDC policy (whole-route attachment for `zot-ui-*`, `sectionName`-scoped attachment for `zot-registry-*` `catalog-probe`).
+
+On first load, Envoy runs the Authorization Code flow against the Keycloak `zot` realm using the `zot-ui` confidential client. After the callback at `/oauth2/callback`, Envoy sets an encrypted session cookie (`zot_at` / `zot_it`) and forwards the Keycloak access_token upstream as `Authorization: Bearer <kc_at>`. zot's `bearer.oidc[keycloak]` validates the same token (audience `zot-registry`) and authorizes by the `groups` claim from the `zot-ui` client's group-membership mapper.
+
+#### Why zot's native `http.auth.openid` is not used
+
+zot v2.1.16's `AuthHandler` short-circuits to its bearer middleware whenever `bearer.oidc[]` is configured (`pkg/api/authn.go:65-67`), so the openid `LoginPath` handler never gets `RelyingParties` initialised and 400s on a nil-map miss. This is upstream issue [project-zot/zot#4033](https://github.com/project-zot/zot/issues/4033) — maintainer-confirmed intended behaviour ("bearer authentication excludes all other authentication options"). Routing UI auth through Envoy keeps machine callers (GHA, kubelet) on `bearer.oidc[]` without running into the conflict.
+
+#### SPA login state with upstream auth
+
+zui (`commit-9333420`, embedded in zot v2.1.16) decides "logged in" via `isAuthenticated()` at `src/utilities/authUtilities.js:31-37`:
+
+1. Cookie `user` set → logged in. zot only sets this from its own htpasswd/LDAP/OIDC-callback paths, none of which run here.
+2. `localStorage.authConfig === '{}'` → logged in (the "no auth configured" branch). Triggered when the SPA's `/v2/_zot/ext/mgmt` probe at `SignIn.jsx:171` sees an empty `http.auth` block.
+
+Because zot still has `bearer.oidc[]` configured for machine callers, its mgmt response advertises `{auth:{bearer:{}}}`. The stock SPA would render a blank login card it can't act on. The `zot-ui-mgmt-rewrite` filter in `envoy-extension-policy.yaml` rewrites the mgmt response body on the UI routes to drop `http.auth`, making the SPA take its auto-login branch and navigate to `/home`. From there every XHR (`/v2/_zot/ext/search`, etc.) rides the cookie session and the Envoy-injected Bearer; zot validates and serves.
+
+#### XHR vs navigation handling
+
+`SecurityPolicy.oidc` defaults to 302-redirecting any unauthenticated request to Keycloak. Cross-origin 302 cannot be followed by `fetch()` (opaque response), so the `denyRedirect.headers` matchers force 401 for AJAX requests (`Sec-Fetch-Mode: cors`, `Sec-Fetch-Dest: empty`, `X-Requested-With: XMLHttpRequest`). The Axios interceptor at `src/api.js:21-26` then redirects to `/login`, which is a top-level navigation and CAN follow the 302 to Keycloak. Same flow for cookie expiry mid-session.
 
 ## Access control
 
@@ -70,18 +95,19 @@ Browsers hit `/` and `/v2/_zot/*`. zot's native `http.auth.openid` provider runs
 Group claims come from each issuer:
 
 - GHA OIDC → CEL claim mapping derives the group from `repository_owner` (`Shion1305` → `pusher-shion1305`, `Shion1305Dev` → `pusher-shion1305dev`).
-- Keycloak `zot` realm → `groups` claim, populated by per-client mappers.
+- Keycloak `zot` realm → `groups` claim, populated by per-client mappers (group-membership mapper on `zot-ui` for browser users; hardcoded mapper on `cluster-puller` for kubelet pulls).
 
 ## ExternalSecrets
 
-Two on-disk artefacts are required for the OpenID UI flow and are mounted as files into the zot Pod via the chart's `externalSecrets[]` hook:
+The OIDC client credentials used by Envoy's `SecurityPolicy.oidc` are sourced from Vault and projected into a Kubernetes Secret. zot itself no longer needs any on-disk secret material.
 
-| ExternalSecret | Vault path | Mount path | Purpose |
+| ExternalSecret | Vault path | Secret keys | Purpose |
 | --- | --- | --- | --- |
-| `zot-openid-credentials` | `zot/openid-credentials` | `/secrets/openid` | `keycloak-credentials.json` (zot-ui client_id + client_secret) |
-| `zot-session-keys` | `zot/session-keys` | `/secrets/session` | `sessionKeys.json` (gorilla session HMAC + AES-CTR keys) |
+| `zot-ui-oidc-credentials` | `zot/openid-credentials` (field `keycloak-credentials.json`, JSON blob) | `client-id`, `client-secret` | Referenced by `securitypolicy.yaml` for the OIDC code flow |
 
-Both are wired through the namespace's `SecretStore` (`secret-store.yaml`) backed by Kubernetes auth role `eso-zot`.
+The Vault blob is a single JSON field of shape `{"clientid":"zot-ui","clientsecret":"..."}`; the ESO template parses it with `fromJson` and emits the two keys Envoy expects. The same Vault path was used by the previous zot-native flow, so no Vault re-key is needed for this migration.
+
+The ServiceAccount/SecretStore plumbing is unchanged from the previous architecture — `eso-zot` Kubernetes auth role bound to the namespace's ServiceAccount, `secret-store.yaml` declares the SecretStore, `reference-grant.yaml` lets the in-namespace HTTPRoutes attach to the cross-namespace Gateways.
 
 ## Cluster-wide pull credential
 

--- a/zot/envoy-extension-policy.yaml
+++ b/zot/envoy-extension-policy.yaml
@@ -1,34 +1,56 @@
-# Bridges containerd's Docker Registry v2 auth flow with zot's bearer-OIDC
-# middleware on the `/v2/` HTTPRoutes (external + internal). Two halves:
+# Two co-located Envoy Lua filters wired to different HTTPRoute scopes.
 #
-#   envoy_on_response — when zot returns 401 to a containerd-class client
-#     without a `WWW-Authenticate` header, inject
-#     `WWW-Authenticate: Basic realm="zot"`. zot's bearer-OIDC path emits no
-#     challenge of its own (verified empirically — bare `curl /v2/...`
-#     returns 401 with no auth header), so containerd treats the response
-#     as "no scheme advertised" and never retries with creds. A Basic
-#     challenge convinces containerd to retry with the dockerconfig `auth`
-#     value loaded from the imagePullSecret.
+# 1. `zot-basic-to-bearer` (registry routes): bridges containerd's Docker
+#    Registry v2 auth flow with zot's bearer-OIDC middleware on the registry-
+#    protocol rule. Two halves:
 #
-#     The challenge is only injected when the request was from containerd
-#     (User-Agent stash via dynamic metadata). Browsers also hit /v2/* —
-#     the SPA calls /v2/_catalog and /v2/ during boot — and a Basic
-#     challenge there would trigger the browser's native Basic-auth popup
-#     before the user can even click "Sign in with OIDC".
+#      envoy_on_response — when zot returns 401 to a containerd-class client
+#        without a `WWW-Authenticate` header, inject
+#        `WWW-Authenticate: Basic realm="zot"`. zot's bearer-OIDC path emits
+#        no challenge of its own (verified empirically — bare `curl /v2/...`
+#        returns 401 with no auth header), so containerd treats the response
+#        as "no scheme advertised" and never retries with creds. A Basic
+#        challenge convinces containerd to retry with the dockerconfig `auth`
+#        value loaded from the imagePullSecret.
 #
-#   envoy_on_request — on the retry, the Authorization header is
-#     `Basic base64("oidc:<jwt>")` because ESO templates the dockerconfigjson
-#     as `auth: base64("oidc:<jwt>")` and containerd forwards it verbatim.
-#     zot's bearer middleware short-circuits at pkg/api/authn.go:65-67 and
-#     does not parse Basic, so we decode here, strip the `oidc:` prefix, and
-#     rewrite to `Bearer <jwt>`. zot's OIDC verifier then validates the JWT.
+#        The challenge is only injected when the request was from containerd
+#        (User-Agent stash via dynamic metadata). Browsers also hit /v2/* —
+#        the SPA calls /v2/_catalog and /v2/ during boot — and a Basic
+#        challenge there would trigger the browser's native Basic-auth popup
+#        before the user can even click "Sign in with OIDC".
 #
-# GitHub Actions push uses `crane` with `registrytoken`, which sends Bearer
-# pre-emptively and never sees the 401 — so neither half affects push.
+#      envoy_on_request — on the retry, the Authorization header is
+#        `Basic base64("oidc:<jwt>")` because ESO templates the dockerconfigjson
+#        as `auth: base64("oidc:<jwt>")` and containerd forwards it verbatim.
+#        zot's bearer middleware short-circuits at pkg/api/authn.go:65-67 and
+#        does not parse Basic, so we decode here, strip the `oidc:` prefix, and
+#        rewrite to `Bearer <jwt>`. zot's OIDC verifier then validates the JWT.
 #
-# Scope: only the `/v2/` registry HTTPRoutes (external + internal). The UI
-# routes (zot-ui-external / zot-ui-internal) handle browser/OIDC traffic and
-# must not be molested.
+#    GitHub Actions push uses `crane` with `registrytoken`, which sends Bearer
+#    pre-emptively and never sees the 401 — so neither half affects push.
+#
+#    Scope: only the registry HTTPRoutes (external + internal). The UI
+#    routes (zot-ui-external / zot-ui-internal) handle browser/OIDC traffic
+#    and must not be molested.
+#
+# 2. `zot-ui-mgmt-rewrite` (UI routes): rewrites the response body of
+#    `GET /v2/_zot/ext/mgmt` to drop the `http.auth` block. zot v2.1.16's
+#    AuthHandler short-circuits to bearer middleware whenever `bearer.oidc[]`
+#    is configured (pkg/api/authn.go:65-67), so its native openid LoginPath
+#    handler 400s with a nil-map miss (upstream issue project-zot/zot#4033;
+#    intended). With Envoy Gateway driving OIDC instead, the SPA at
+#    zui src/components/Login/SignIn.jsx:171-203 fetches /v2/_zot/ext/mgmt at
+#    /login boot and decides:
+#      - if `http.auth` is empty → set authConfig='{}', isLoggedIn=true,
+#        navigate to /home (the desired branch for upstream-mediated auth);
+#      - if `http.auth` is non-empty → render the login card matching
+#        whatever providers are advertised.
+#    Because zot still has `bearer.oidc[]` configured (for machine callers),
+#    its mgmt response advertises `{auth:{bearer:{}}}` — which would lock the
+#    SPA on a blank login card it can't act on. Stripping `http.auth` here
+#    makes the SPA take the auto-login branch; the user is in fact
+#    authenticated by the gateway (cookie + Bearer-injected XHRs), so this is
+#    accurate.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyExtensionPolicy
 metadata:
@@ -110,4 +132,108 @@ spec:
           local meta = response_handle:streamInfo():dynamicMetadata():get(FILTER_NS)
           if not meta or meta["wants_basic_challenge"] ~= "true" then return end
           headers:add("www-authenticate", 'Basic realm="zot"')
+        end
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyExtensionPolicy
+metadata:
+  name: zot-ui-mgmt-rewrite
+  namespace: zot
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: zot-ui-external
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: zot-ui-internal
+  lua:
+    - type: Inline
+      inline: |
+        -- Drop `http.auth` from the /v2/_zot/ext/mgmt response so the SPA
+        -- takes its "no auth configured" branch (zui SignIn.jsx:173) and
+        -- auto-navigates to /home, treating the gateway-injected session as
+        -- the source of truth.
+        --
+        -- Envoy Lua's body API requires opting in via `wantsBody=true` in
+        -- envoy_on_response and accessing `body()` (which returns the entire
+        -- buffered response body as a Buffer). The mgmt response is small
+        -- (~few hundred bytes of JSON), so full buffering is fine.
+        --
+        -- We do not have a JSON parser available, so we use a regex to nuke
+        -- the `"auth":{...}` key and its (possibly nested) value. The value
+        -- is always a single-level JSON object in zot's mgmt response —
+        -- StrippedConfig.Auth.MarshalJSON at pkg/extensions/extension_mgmt.go
+        -- emits an object whose own keys are flat (`bearer:{}`, `htpasswd`,
+        -- `openid`, etc.). A bracket-counting walk handles any one nested
+        -- level safely.
+        local TARGET_PATH_PREFIX = "/v2/_zot/ext/mgmt"
+
+        local function path_matches(path)
+          if not path then return false end
+          -- mgmt may carry query string; match prefix
+          return string.sub(path, 1, #TARGET_PATH_PREFIX) == TARGET_PATH_PREFIX
+        end
+
+        function envoy_on_request(request_handle)
+          local headers = request_handle:headers()
+          if not path_matches(headers:get(":path")) then return end
+          request_handle:streamInfo():dynamicMetadata():set(
+            "zot.ui_mgmt_rewrite", "active", "true")
+        end
+
+        local function strip_auth(body_str)
+          -- Find `"auth":` (allow optional whitespace).
+          local s, e = string.find(body_str, '"auth"%s*:%s*{')
+          if not s then return body_str end
+          -- e points at the `{` after `auth:`. Walk forward counting braces.
+          local depth = 1
+          local i = e + 1
+          while i <= #body_str and depth > 0 do
+            local c = string.byte(body_str, i)
+            if c == 123 then        -- '{'
+              depth = depth + 1
+            elseif c == 125 then    -- '}'
+              depth = depth - 1
+            elseif c == 34 then     -- '"' — skip string content (handles escaped chars)
+              i = i + 1
+              while i <= #body_str do
+                local cc = string.byte(body_str, i)
+                if cc == 92 then         -- '\' escape
+                  i = i + 2
+                elseif cc == 34 then     -- closing '"'
+                  break
+                else
+                  i = i + 1
+                end
+              end
+            end
+            i = i + 1
+          end
+          if depth ~= 0 then return body_str end -- malformed, leave alone
+          -- Range to remove: from `s` through `i-1` (inclusive of closing '}').
+          local prefix = string.sub(body_str, 1, s - 1)
+          local suffix = string.sub(body_str, i)
+          -- Trim a trailing comma from prefix or leading comma from suffix so
+          -- the resulting JSON stays valid whether `auth` was first/middle/last.
+          prefix = string.gsub(prefix, ",%s*$", "")
+          suffix = string.gsub(suffix, "^%s*,", "")
+          return prefix .. suffix
+        end
+
+        function envoy_on_response(response_handle)
+          local meta = response_handle:streamInfo():dynamicMetadata():get(
+            "zot.ui_mgmt_rewrite")
+          if not meta or meta["active"] ~= "true" then return end
+          local headers = response_handle:headers()
+          if headers:get(":status") ~= "200" then return end
+          local ct = headers:get("content-type") or ""
+          if not string.find(ct, "application/json") then return end
+
+          local body = response_handle:body()
+          local body_str = tostring(body:getBytes(0, body:length()))
+          local rewritten = strip_auth(body_str)
+          if rewritten == body_str then return end
+          body:setBytes(rewritten)
+          headers:replace("content-length", tostring(#rewritten))
         end

--- a/zot/external-secret.yaml
+++ b/zot/external-secret.yaml
@@ -1,24 +1,25 @@
-# zot's native `http.auth.openid` provider performs the OIDC Authorization
-# Code Flow against Keycloak realm `zot` and mints its own session cookie.
-# Two ExternalSecrets feed this:
+# Envoy Gateway's SecurityPolicy.oidc reads two keys from a Kubernetes Secret:
 #
-#   1. zot-openid-credentials → mounted at /secrets/openid in zot. zot's
-#      config.json `credentialsFile` reads keycloak-credentials.json, which
-#      contains the `zot-ui` client_id + client_secret as a JSON blob.
-#   2. zot-session-keys → mounted at /secrets/session in zot. zot's
-#      config.json `sessionKeysFile` reads sessionKeys.json, which holds the
-#      hashKey/encryptKey for the gorilla session cookie HMAC + AES-CTR.
+#   - `client-id`     (referenced via `oidc.clientIDRef`)
+#   - `client-secret` (referenced via `oidc.clientSecret`)
 #
-# The literal client-id `zot-ui` MUST match the Keycloak client name in
-# `keycloak-operator/zot-realm.yaml`. Don't change one without the other.
-# The Vault path `zot/openid-credentials` stores the secret with the same
-# JSON shape zot expects on disk; ESO templates it into the Secret with
-# `keycloak-credentials.json` as the data key, which the zot Helm chart's
-# `externalSecrets[].mountPath` projects as a file at that path.
+# Both come from the Keycloak `zot-ui` confidential client in the `zot` realm
+# (see keycloak-operator/zot-realm.yaml). The literal client-id `zot-ui` MUST
+# match the Keycloak client name; don't change one without the other.
+#
+# Vault path zot/openid-credentials stores a single field
+# `keycloak-credentials.json` whose value is a JSON blob:
+#
+#   {"clientid":"zot-ui","clientsecret":"..."}
+#
+# We pull that one field, parse it with ESO's `fromJson` helper, and project
+# the two values into separate keys on the materialized Secret. This keeps the
+# Vault shape unchanged from the previous zot-native flow so a future re-key
+# doesn't require touching the Vault schema.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: zot-openid-credentials
+  name: zot-ui-oidc-credentials
   namespace: zot
 spec:
   refreshInterval: 5m
@@ -26,7 +27,7 @@ spec:
     name: vault
     kind: SecretStore
   target:
-    name: zot-openid-credentials
+    name: zot-ui-oidc-credentials
     creationPolicy: Owner
     template:
       type: Opaque
@@ -34,35 +35,10 @@ spec:
         labels:
           managed-by: external-secrets
       data:
-        keycloak-credentials.json: '{{ .credentials | trim }}'
+        client-id: '{{ ( .credentials | fromJson ).clientid }}'
+        client-secret: '{{ ( .credentials | fromJson ).clientsecret }}'
   data:
     - secretKey: credentials
       remoteRef:
         key: openid-credentials
         property: keycloak-credentials.json
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: zot-session-keys
-  namespace: zot
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: vault
-    kind: SecretStore
-  target:
-    name: zot-session-keys
-    creationPolicy: Owner
-    template:
-      type: Opaque
-      metadata:
-        labels:
-          managed-by: external-secrets
-      data:
-        sessionKeys.json: '{{ .keys | trim }}'
-  data:
-    - secretKey: keys
-      remoteRef:
-        key: session-keys
-        property: sessionKeys.json

--- a/zot/httproute-external.yaml
+++ b/zot/httproute-external.yaml
@@ -1,19 +1,36 @@
-# Public registry URL — used by browsers (zot UI / OIDC login) and by
+# Public registry URL — used by browsers (zot UI / OIDC code-flow login) and by
 # `docker push` from any host that can resolve the public DNS.
 #
-# Two HTTPRoutes share hostname registry.shion1305.com and split by path:
-#   - zot-registry-external: Docker Registry v2 protocol (/v2/...). zot
-#     handles its own bearer-OIDC challenges directly with the upstream
-#     issuer (GitHub Actions / Keycloak realm zot).
-#   - zot-ui-external: everything else, including the SPA, /zot/auth/*, and
-#     zot's own extension XHRs under /v2/_zot/*. zot's native
-#     `http.auth.openid` provider runs the Authorization Code Flow and mints
-#     a session cookie; no Envoy-level OIDC layering.
+# Three rule groups, split by purpose, share hostname registry.shion1305.com:
 #
-# Gateway API precedence (most-specific-path-wins, GEP-718) means /v2/_zot/...
-# requests are routed to zot-ui-external even though /v2/ on zot-registry-
-# external also matches — the longer prefix wins regardless of declaration
-# order or HTTPRoute boundary.
+#   zot-registry-external (Docker Registry v2 protocol):
+#     - rule `catalog-probe` — exact `/v2/` and `/v2/_catalog`. The SPA pings
+#       these at /login boot to detect "guest browse" availability. Routed to
+#       zot via the same backend, but ALSO targeted by the OIDC SecurityPolicy
+#       (sectionName: catalog-probe) so an authenticated browser hits zot with
+#       the kc_at injected. Without this targeting the probe would arrive
+#       without `Authorization`, zot's bearer-OIDC middleware would 401, and
+#       the SPA's "Continue as guest" hint would be wrong (silently logged at
+#       SignIn.jsx:189; not user-visible, but architecturally cleaner this
+#       way).
+#     - rule `registry-protocol` — broad `/v2/` PathPrefix, all repository
+#       traffic (push/pull/blobs/manifests). NOT covered by SecurityPolicy:
+#       containerd and crane do their own bearer challenge and would break if
+#       the gateway tried to redirect them through Keycloak's authcode flow.
+#       The Lua filter (zot/envoy-extension-policy.yaml) bridges containerd
+#       Basic ↔ zot bearer for kubelet pulls.
+#
+#   zot-ui-external:
+#     - rule `ui` — `/` and `/v2/_zot/*`. The SPA bundle, /zot/auth/*, and
+#       zot's extension XHRs (mgmt, search). Fully covered by SecurityPolicy
+#       (whole-route targeting); cookie session is set on /, then attached to
+#       every same-host request the browser issues.
+#
+# Gateway API GEP-718 most-specific-path-wins routes /v2/_zot/... to
+# zot-ui-external (longer prefix beats /v2/) regardless of HTTPRoute order.
+# Within zot-registry-external, the exact matches in `catalog-probe` beat the
+# `/v2/` PathPrefix in `registry-protocol`, so the SPA's two probe paths are
+# isolated cleanly.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -27,7 +44,19 @@ spec:
   hostnames:
     - registry.shion1305.com
   rules:
-    - matches:
+    - name: catalog-probe
+      matches:
+        - path:
+            type: Exact
+            value: /v2/
+        - path:
+            type: Exact
+            value: /v2/_catalog
+      backendRefs:
+        - name: zot
+          port: 5000
+    - name: registry-protocol
+      matches:
         - path:
             type: PathPrefix
             value: /v2/
@@ -48,7 +77,8 @@ spec:
   hostnames:
     - registry.shion1305.com
   rules:
-    - matches:
+    - name: ui
+      matches:
         - path:
             type: PathPrefix
             value: /

--- a/zot/httproute-internal.yaml
+++ b/zot/httproute-internal.yaml
@@ -3,13 +3,12 @@
 # for in-cluster CI/CD or trusted hosts that have WG connectivity, while the
 # public registry.shion1305.com URL handles GitHub Actions and external pulls.
 #
-# Same path-split pattern as the external Gateway: zot-registry-internal
-# handles Docker v2 protocol traffic (zot does its own bearer challenge against
-# the upstream OIDC issuers), zot-ui-internal handles the SPA + /v2/_zot/*
-# extension XHRs. zot's native `http.auth.openid` provider runs the
-# Authorization Code Flow against Keycloak for browser users; no Envoy-level
-# OIDC layering. The internal hostname registry.i.shion1305.com is one of the
-# allowed callback origins, so the same Keycloak `zot-ui` client works here.
+# Same three-rule split as the external Gateway (see httproute-external.yaml
+# for the rationale): `catalog-probe` rule on zot-registry-internal carries
+# the SPA boot probes and is targeted by the OIDC SecurityPolicy via
+# sectionName, while `registry-protocol` carries unauthenticated v2 traffic
+# that the Lua filter bridges. zot-ui-internal carries the SPA + extension
+# XHRs and is fully behind the SecurityPolicy.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -23,7 +22,19 @@ spec:
   hostnames:
     - registry.i.shion1305.com
   rules:
-    - matches:
+    - name: catalog-probe
+      matches:
+        - path:
+            type: Exact
+            value: /v2/
+        - path:
+            type: Exact
+            value: /v2/_catalog
+      backendRefs:
+        - name: zot
+          port: 5000
+    - name: registry-protocol
+      matches:
         - path:
             type: PathPrefix
             value: /v2/
@@ -44,7 +55,8 @@ spec:
   hostnames:
     - registry.i.shion1305.com
   rules:
-    - matches:
+    - name: ui
+      matches:
         - path:
             type: PathPrefix
             value: /

--- a/zot/kustomization.yaml
+++ b/zot/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - httproute-external.yaml
   - httproute-internal.yaml
   - envoy-extension-policy.yaml
+  - securitypolicy.yaml

--- a/zot/securitypolicy.yaml
+++ b/zot/securitypolicy.yaml
@@ -1,0 +1,136 @@
+# Envoy Gateway-managed OIDC for the zot Web UI.
+#
+# Two SecurityPolicy resources, one per hostname (external + internal). They
+# differ only in `redirectURL` — Envoy validates the OIDC `redirect_uri` query
+# param against this exact string and refuses to use the request `:authority`
+# at runtime, so the same policy cannot serve two hostnames.
+#
+# Each policy targets:
+#   - the entire zot-ui-* HTTPRoute (SPA bundle, /zot/auth/*, /v2/_zot/*)
+#   - the `catalog-probe` rule on zot-registry-* (sectionName-scoped, just
+#     `/v2/` and `/v2/_catalog` exact-match — NOT the broad /v2/ PathPrefix
+#     used by docker push/pull)
+#
+# Why the split: Docker Registry v2 protocol (push/pull) negotiates its own
+# bearer challenge with zot. If the OIDC policy fired on /v2/<repo>/blobs/...
+# the gateway would 302 unauthenticated containerd to Keycloak, which can't
+# follow the authcode flow and would break every kubelet pull. The
+# catalog-probe rule isolates the only two /v2/ paths the SPA actually hits at
+# load (SignIn.jsx:183), so the policy can attach there without touching push
+# traffic. SectionName precedence is route-rule > route > listener > gateway
+# (Envoy Gateway SecurityPolicy concepts).
+#
+# Browser ↔ machine differentiation:
+#   - denyRedirect on Sec-Fetch-Mode/Sec-Fetch-Dest matches XHR/fetch from the
+#     SPA so a missing/expired session cookie returns 401 (the Axios
+#     interceptor in zui will redirect to /login) instead of 302 to Keycloak
+#     (which fetch can't follow cross-origin).
+#   - The catalog-probe rule sees both XHR and top-level navigation; the
+#     denyRedirect matchers cover XHR cases and let navigations through.
+#
+# forwardAccessToken: true projects the Keycloak access_token onto the
+# upstream request as `Authorization: Bearer <kc_at>`. zot's
+# `bearer.oidc[keycloak]` (zot/values.yaml) then validates the same token,
+# enforces accessControl by the `groups` claim, and serves the response.
+#
+# The SPA is steered around its own login flow by an Envoy Lua filter
+# (envoy-extension-policy.yaml) that rewrites the /v2/_zot/ext/mgmt response
+# body to drop `http.auth`. With a stripped auth block the SPA takes its "no
+# auth configured" branch (zui SignIn.jsx:173) and treats the user as
+# already-authenticated — which they are, thanks to this policy.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: zot-ui-oidc-external
+  namespace: zot
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: zot-ui-external
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: zot-registry-external
+      sectionName: catalog-probe
+  oidc:
+    provider:
+      issuer: https://keycloak.shion1305.com/realms/zot
+    clientIDRef:
+      name: zot-ui-oidc-credentials
+    clientSecret:
+      name: zot-ui-oidc-credentials
+    redirectURL: https://registry.shion1305.com/oauth2/callback
+    logoutPath: /logout
+    # `openid` is auto-added by Envoy. `groups` is required for zot's
+    # accessControl, sourced from the group-membership mapper on the
+    # Keycloak `zot-ui` client (see keycloak-operator/zot-realm.yaml).
+    scopes:
+      - email
+      - profile
+      - groups
+    forwardAccessToken: true
+    cookieConfig:
+      sameSite: Lax
+    cookieNames:
+      accessToken: zot_at
+      idToken: zot_it
+    # AJAX/fetch from the SPA can't follow a 302 to Keycloak (cross-origin,
+    # opaque response). Force 401 for those requests so the Axios interceptor
+    # at zui src/api.js:21-26 redirects to /login, which IS a top-level
+    # navigation and CAN follow the redirect to Keycloak.
+    denyRedirect:
+      headers:
+        - name: Sec-Fetch-Mode
+          type: Exact
+          value: cors
+        - name: Sec-Fetch-Dest
+          type: Exact
+          value: empty
+        - name: X-Requested-With
+          type: Exact
+          value: XMLHttpRequest
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: zot-ui-oidc-internal
+  namespace: zot
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: zot-ui-internal
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: zot-registry-internal
+      sectionName: catalog-probe
+  oidc:
+    provider:
+      issuer: https://keycloak.shion1305.com/realms/zot
+    clientIDRef:
+      name: zot-ui-oidc-credentials
+    clientSecret:
+      name: zot-ui-oidc-credentials
+    redirectURL: https://registry.i.shion1305.com/oauth2/callback
+    logoutPath: /logout
+    scopes:
+      - email
+      - profile
+      - groups
+    forwardAccessToken: true
+    cookieConfig:
+      sameSite: Lax
+    cookieNames:
+      accessToken: zot_at
+      idToken: zot_it
+    denyRedirect:
+      headers:
+        - name: Sec-Fetch-Mode
+          type: Exact
+          value: cors
+        - name: Sec-Fetch-Dest
+          type: Exact
+          value: empty
+        - name: X-Requested-With
+          type: Exact
+          value: XMLHttpRequest

--- a/zot/values.yaml
+++ b/zot/values.yaml
@@ -20,26 +20,31 @@ startupProbe:
   periodSeconds: 10
   failureThreshold: 6
 
-# zot authenticates three distinct caller types directly, with no Envoy-side
-# OIDC mediation. The split is by `Authorization` header / cookie:
+# zot authenticates two distinct caller types directly via `bearer.oidc[]`.
+# Browser UI auth is NOT done by zot — Envoy Gateway's SecurityPolicy.oidc
+# (zot/securitypolicy.yaml) runs the Authorization Code flow, sets a
+# session cookie, and forwards the Keycloak access_token upstream as
+# `Authorization: Bearer <kc_at>`. zot's bearer.oidc[] then validates it.
 #
 #   1. `Authorization: Bearer <gh-oidc>` from GitHub Actions on /v2/...
-#      → validated by `http.auth.bearer.oidc[token.actions...]`. CEL claim
-#      mapping derives the username (claims.repository) and assigns the
-#      right pusher group based on `repository_owner`.
-#   2. `Authorization: Bearer <kc-cluster-puller>` from kubelet imagePull
-#      service-account on /v2/... → validated by
-#      `http.auth.bearer.oidc[keycloak]`. Audience `zot-registry`, hardcoded
-#      `groups` mapper on the cluster-puller client emits the pusher groups.
-#   3. Browser users hitting / and /zot/auth/* → validated by zot's native
-#      `http.auth.openid.providers.oidc`. zot itself runs the Authorization
-#      Code flow against the same Keycloak realm (provider key must be the
-#      generic `oidc` — zot's validator only accepts google/gitlab/oidc for
-#      OpenID and github for OAuth2), then mints a session cookie. SPA
-#      routes /zot/auth/login/oidc → /zot/auth/callback/oidc → / on success.
+#      → validated by `bearer.oidc[token.actions...]`. CEL claim mapping
+#      derives the username (claims.repository) and assigns the right
+#      pusher group based on `repository_owner`.
+#   2. `Authorization: Bearer <kc-jwt>` from kubelet imagePull and from
+#      browser UI XHRs (Envoy-injected) → validated by
+#      `bearer.oidc[keycloak]`. Audience `zot-registry`. The `groups` claim
+#      (cluster-puller hardcoded; zot-ui group-membership mapper) drives
+#      the accessControl block.
 #
-# The accessControl block is unchanged: groups (`pusher-shion1305`,
-# `pusher-shion1305dev`, `zot-admin`) gate the read/write actions.
+# Why no `http.auth.openid` here: zot's AuthHandler short-circuits to the
+# bearer middleware whenever `bearer.oidc[]` is configured (pkg/api/authn.go
+# lines 65-67), so the openid LoginPath handler never gets RelyingParties
+# initialised and 400s with a nil-map miss. Upstream issue project-zot/zot#4033;
+# maintainer-confirmed intended behaviour. The SPA is steered around its own
+# login flow by the EnvoyExtensionPolicy filter (envoy-extension-policy.yaml)
+# which rewrites the /v2/_zot/ext/mgmt response body to drop `http.auth`,
+# making the SPA take its "no auth configured" branch and treat the user as
+# already-authenticated by the upstream gateway.
 mountConfig: true
 configFiles:
   config.json: |-
@@ -57,7 +62,6 @@ configFiles:
         "externalUrl": "https://registry.shion1305.com",
         "realm": "zot",
         "auth": {
-          "sessionKeysFile": "/secrets/session/sessionKeys.json",
           "bearer": {
             "realm": "zot",
             "service": "registry.shion1305.com",
@@ -88,23 +92,6 @@ configFiles:
                 }
               }
             ]
-          },
-          "openid": {
-            "callbackAllowOrigins": [
-              "https://registry.shion1305.com",
-              "https://registry.i.shion1305.com"
-            ],
-            "providers": {
-              "oidc": {
-                "name": "Keycloak",
-                "issuer": "https://keycloak.shion1305.com/realms/zot",
-                "credentialsFile": "/secrets/openid/keycloak-credentials.json",
-                "scopes": ["openid", "profile", "email", "groups"],
-                "claimMapping": {
-                  "username": "preferred_username"
-                }
-              }
-            }
           }
         },
         "accessControl": {
@@ -156,17 +143,11 @@ configFiles:
       }
     }
 
-# Native `http.auth.openid` requires two on-disk artefacts:
-#   - keycloak-credentials.json (the zot-ui client_id + client_secret)
-#   - sessionKeys.json (gorilla session HMAC + AES-CTR keys)
-# Both are populated by ExternalSecrets (zot/external-secret.yaml) reading
-# from Vault paths zot/openid-credentials and zot/session-keys, then mounted
-# into the zot Pod as files via the chart's externalSecrets[] hook.
-externalSecrets:
-  - secretName: zot-openid-credentials
-    mountPath: /secrets/openid
-  - secretName: zot-session-keys
-    mountPath: /secrets/session
+# zot fetches issuer JWKS over HTTPS at request time; no on-disk client secret
+# or session-encryption key is needed. The OIDC client_id/client_secret used by
+# Envoy's SecurityPolicy lives in the zot-ui-oidc-credentials Secret
+# (zot/external-secret.yaml), which the policy references directly.
+externalSecrets: []
 mountSecret: false
 
 persistence: true


### PR DESCRIPTION
## Summary

- zot v2.1.16's `AuthHandler` short-circuits to bearer middleware whenever `bearer.oidc[]` is configured (`pkg/api/authn.go:65-67`), so `http.auth.openid` cannot coexist with the existing GHA + cluster-puller bearer config (upstream issue [project-zot/zot#4033](https://github.com/project-zot/zot/issues/4033), maintainer-confirmed intended). Browser UI login was returning 400 from `/zot/auth/login` because `RelyingParties` was never populated.
- Move browser OIDC to Envoy Gateway: a new `SecurityPolicy.oidc` (one per hostname — Envoy validates `redirectURL` exactly, so the same policy can't cover both hosts) attaches to the whole `zot-ui-*` HTTPRoute and to the `catalog-probe` rule on `zot-registry-*` (sectionName-scoped, only the SPA's `/v2/` and `/v2/_catalog` boot probes; push/pull stays unprotected so containerd's bearer challenge still works).
- `denyRedirect.headers` force 401 for XHR (`Sec-Fetch-Mode: cors`, etc.) so the SPA's Axios interceptor can redirect to `/login` (a top-level navigation) instead of `fetch()` trying to follow a cross-origin 302.
- A second `EnvoyExtensionPolicy` Lua filter on the UI routes rewrites the `/v2/_zot/ext/mgmt` response body to drop `http.auth`. With that block empty, zui's `SignIn.jsx:173` hits the "no auth configured" branch, sets `isLoggedIn=true` and navigates to `/home`, where every XHR rides the gateway-injected `Authorization: Bearer <kc_at>` and is validated by zot's `bearer.oidc[keycloak]`.
- Drop `http.auth.openid` from `values.yaml`, drop the `zot-openid-credentials` / `zot-session-keys` ExternalSecrets and the chart `externalSecrets[]` mounts. New `zot-ui-oidc-credentials` ESO target parses the same Vault blob (`zot/openid-credentials`, field `keycloak-credentials.json`) via `fromJson` into the `client-id`/`client-secret` keys Envoy's `clientIDRef`/`clientSecret` expect — no Vault re-key. Keycloak `zot-ui` `redirectUris` move back to `/oauth2/callback`.

## Test plan

- [ ] ArgoCD syncs cleanly; `SecurityPolicy`, `EnvoyExtensionPolicy`, and HTTPRoutes all `Accepted=True`.
- [ ] After sync, `kubectl get secret -n zot zot-ui-oidc-credentials -o yaml` has `client-id` and `client-secret` populated (parsed from the Vault JSON blob).
- [ ] `curl -sI https://registry.shion1305.com/v2/_zot/ext/mgmt` (no cookie) returns `302` to Keycloak (top-level navigation path).
- [ ] `curl -sI -H 'Sec-Fetch-Mode: cors' https://registry.shion1305.com/v2/_zot/ext/mgmt` returns `401` (XHR path; `denyRedirect` working).
- [ ] Browser flow: open `https://registry.shion1305.com/` → Keycloak login → redirected to `/home` (not stuck on a blank login card). The mgmt response body should be `{"distSpecVersion":"...","http":{}}` (auth stripped) — verify with DevTools.
- [ ] Browser flow on `https://registry.i.shion1305.com/` works identically (separate SecurityPolicy with internal-host `redirectURL`).
- [ ] `crane push` from CI still pushes (Lua bridge unaffected; `registry-protocol` rule has no SecurityPolicy).
- [ ] Kubelet pull still works (smoketest pod) — `zot-pull-smoketest` pulls in <1s.
- [ ] `/zot/auth/login` no longer reachable in the SPA flow (confirm no 400s in zot logs).