### PR TITLE
fix(zot): split rules into separate HTTPRoutes (ArgoCD schema compat)

### DIFF
--- a/zot/README.md
+++ b/zot/README.md
@@ -4,19 +4,18 @@ Project-zot v2 deployed cluster-wide as the canonical container image registry f
 
 ## Hostnames and routing
 
-Two hostnames front the same `zot` Service. Each has the same three-rule split:
+Two hostnames front the same `zot` Service. Each has the same three HTTPRoutes:
 
-| Hostname | Gateway | Registry HTTPRoute | UI HTTPRoute |
-| --- | --- | --- | --- |
-| `registry.shion1305.com` | `external` (public) | `zot-registry-external` | `zot-ui-external` |
-| `registry.i.shion1305.com` | `internal` (WireGuard-only) | `zot-registry-internal` | `zot-ui-internal` |
+| Hostname | Gateway | Catalog-probe HTTPRoute | Registry HTTPRoute | UI HTTPRoute |
+| --- | --- | --- | --- | --- |
+| `registry.shion1305.com` | `external` (public) | `zot-catalog-probe-external` | `zot-registry-external` | `zot-ui-external` |
+| `registry.i.shion1305.com` | `internal` (WG-only) | `zot-catalog-probe-internal` | `zot-registry-internal` | `zot-ui-internal` |
 
-`zot-registry-*` carries Docker Registry v2 protocol traffic and is split into two named rules:
+- `zot-catalog-probe-*` — exact `/v2/` and `/v2/_catalog`. The SPA pings these at `/login` boot. Targeted by the OIDC `SecurityPolicy` so the browser request arrives at zot with the kc_at injected.
+- `zot-registry-*` — the broad `/v2/` PathPrefix that handles every push/pull. **Not** behind the OIDC policy — containerd negotiates its own bearer challenge with zot, and a 302 to Keycloak would break every kubelet pull.
+- `zot-ui-*` — `/` and `/v2/_zot/*` (SPA bundle, `/zot/auth/*`, zot's extension XHRs). Fully behind the OIDC `SecurityPolicy`.
 
-- `catalog-probe` — exact `/v2/` and `/v2/_catalog`. The SPA pings these at `/login` boot. Targeted by the OIDC `SecurityPolicy` via `sectionName: catalog-probe`.
-- `registry-protocol` — the broad `/v2/` PathPrefix that handles every push/pull. **Not** behind the OIDC policy — containerd negotiates its own bearer challenge with zot.
-
-`zot-ui-*` carries `/` and `/v2/_zot/*` (SPA bundle, `/zot/auth/*`, zot's extension XHRs). Fully behind the OIDC `SecurityPolicy`. Gateway API GEP-718 most-specific-path-wins routes `/v2/_zot/...` to `zot-ui-*` even though `/v2/` matches both routes.
+Gateway API GEP-718 most-specific-path-wins keeps `/v2/_zot/...` on `zot-ui-*` and routes `/v2/` and `/v2/_catalog` exact matches to `zot-catalog-probe-*` over the bare `/v2/` PathPrefix on `zot-registry-*`. Per-rule `sectionName` targeting would be cleaner but requires `HTTPRouteRule.name` (Gateway API v1.2+) which ArgoCD v3.4's embedded OpenAPI schema rejects at diff time, so the rules are split into separate HTTPRoutes instead.
 
 ## Auth callers
 

--- a/zot/httproute-external.yaml
+++ b/zot/httproute-external.yaml
@@ -1,36 +1,64 @@
 # Public registry URL — used by browsers (zot UI / OIDC code-flow login) and by
 # `docker push` from any host that can resolve the public DNS.
 #
-# Three rule groups, split by purpose, share hostname registry.shion1305.com:
+# Three HTTPRoutes, all on hostname registry.shion1305.com, split by purpose:
 #
-#   zot-registry-external (Docker Registry v2 protocol):
-#     - rule `catalog-probe` — exact `/v2/` and `/v2/_catalog`. The SPA pings
-#       these at /login boot to detect "guest browse" availability. Routed to
-#       zot via the same backend, but ALSO targeted by the OIDC SecurityPolicy
-#       (sectionName: catalog-probe) so an authenticated browser hits zot with
-#       the kc_at injected. Without this targeting the probe would arrive
-#       without `Authorization`, zot's bearer-OIDC middleware would 401, and
-#       the SPA's "Continue as guest" hint would be wrong (silently logged at
-#       SignIn.jsx:189; not user-visible, but architecturally cleaner this
-#       way).
-#     - rule `registry-protocol` — broad `/v2/` PathPrefix, all repository
-#       traffic (push/pull/blobs/manifests). NOT covered by SecurityPolicy:
-#       containerd and crane do their own bearer challenge and would break if
-#       the gateway tried to redirect them through Keycloak's authcode flow.
-#       The Lua filter (zot/envoy-extension-policy.yaml) bridges containerd
-#       Basic ↔ zot bearer for kubelet pulls.
+#   zot-catalog-probe-external — exact `/v2/` and `/v2/_catalog`. The SPA pings
+#     these at /login boot. Targeted by the OIDC SecurityPolicy
+#     (zot/securitypolicy.yaml) so an authenticated browser hits zot with the
+#     kc_at injected. Without this targeting the probe would arrive without
+#     `Authorization`, zot's bearer-OIDC middleware would 401, and the SPA's
+#     "Continue as guest" hint would be wrong (silently logged at
+#     SignIn.jsx:189; not user-visible, but architecturally cleaner this way).
 #
-#   zot-ui-external:
-#     - rule `ui` — `/` and `/v2/_zot/*`. The SPA bundle, /zot/auth/*, and
-#       zot's extension XHRs (mgmt, search). Fully covered by SecurityPolicy
-#       (whole-route targeting); cookie session is set on /, then attached to
-#       every same-host request the browser issues.
+#   zot-registry-external — broad `/v2/` PathPrefix, all repository traffic
+#     (push/pull/blobs/manifests). NOT covered by SecurityPolicy: containerd
+#     and crane do their own bearer challenge and would break if the gateway
+#     tried to redirect them through Keycloak's authcode flow. The Lua filter
+#     (zot/envoy-extension-policy.yaml) bridges containerd Basic ↔ zot bearer
+#     for kubelet pulls.
+#
+#   zot-ui-external — `/` and `/v2/_zot/*`. The SPA bundle, /zot/auth/*, and
+#     zot's extension XHRs (mgmt, search). Fully covered by SecurityPolicy;
+#     cookie session is set on /, then attached to every same-host request the
+#     browser issues.
 #
 # Gateway API GEP-718 most-specific-path-wins routes /v2/_zot/... to
 # zot-ui-external (longer prefix beats /v2/) regardless of HTTPRoute order.
-# Within zot-registry-external, the exact matches in `catalog-probe` beat the
-# `/v2/` PathPrefix in `registry-protocol`, so the SPA's two probe paths are
-# isolated cleanly.
+# Across the two registry routes the exact matches in zot-catalog-probe-external
+# beat the `/v2/` PathPrefix in zot-registry-external for the same two paths,
+# so the SPA's two probe paths land on the SecurityPolicy-attached route.
+#
+# Why three routes instead of one with named rules: HTTPRouteRule.name is a
+# Gateway API v1.2+ field. The cluster CRD accepts it, but ArgoCD v3.4's
+# structured-merge-diff library has an older embedded OpenAPI schema and
+# rejects the field at diff time ("field not declared in schema"). Splitting
+# into separate HTTPRoutes lets SecurityPolicy.targetRefs reach each by route
+# name — no rule-level sectionName needed — and keeps the manifest portable.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: zot-catalog-probe-external
+  namespace: zot
+spec:
+  parentRefs:
+    - name: external
+      namespace: envoy-gateway-system
+      sectionName: https
+  hostnames:
+    - registry.shion1305.com
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /v2/
+        - path:
+            type: Exact
+            value: /v2/_catalog
+      backendRefs:
+        - name: zot
+          port: 5000
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -44,19 +72,7 @@ spec:
   hostnames:
     - registry.shion1305.com
   rules:
-    - name: catalog-probe
-      matches:
-        - path:
-            type: Exact
-            value: /v2/
-        - path:
-            type: Exact
-            value: /v2/_catalog
-      backendRefs:
-        - name: zot
-          port: 5000
-    - name: registry-protocol
-      matches:
+    - matches:
         - path:
             type: PathPrefix
             value: /v2/
@@ -77,8 +93,7 @@ spec:
   hostnames:
     - registry.shion1305.com
   rules:
-    - name: ui
-      matches:
+    - matches:
         - path:
             type: PathPrefix
             value: /

--- a/zot/httproute-internal.yaml
+++ b/zot/httproute-internal.yaml
@@ -3,12 +3,35 @@
 # for in-cluster CI/CD or trusted hosts that have WG connectivity, while the
 # public registry.shion1305.com URL handles GitHub Actions and external pulls.
 #
-# Same three-rule split as the external Gateway (see httproute-external.yaml
-# for the rationale): `catalog-probe` rule on zot-registry-internal carries
-# the SPA boot probes and is targeted by the OIDC SecurityPolicy via
-# sectionName, while `registry-protocol` carries unauthenticated v2 traffic
-# that the Lua filter bridges. zot-ui-internal carries the SPA + extension
-# XHRs and is fully behind the SecurityPolicy.
+# Same three-route split as the external Gateway (see httproute-external.yaml
+# for the rationale): zot-catalog-probe-internal carries the SPA boot probes and
+# is targeted by the OIDC SecurityPolicy, zot-registry-internal carries
+# unauthenticated v2 traffic that the Lua filter bridges, and zot-ui-internal
+# carries the SPA + extension XHRs and is fully behind the SecurityPolicy.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: zot-catalog-probe-internal
+  namespace: zot
+spec:
+  parentRefs:
+    - name: internal
+      namespace: envoy-gateway-system
+      sectionName: https
+  hostnames:
+    - registry.i.shion1305.com
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /v2/
+        - path:
+            type: Exact
+            value: /v2/_catalog
+      backendRefs:
+        - name: zot
+          port: 5000
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -22,19 +45,7 @@ spec:
   hostnames:
     - registry.i.shion1305.com
   rules:
-    - name: catalog-probe
-      matches:
-        - path:
-            type: Exact
-            value: /v2/
-        - path:
-            type: Exact
-            value: /v2/_catalog
-      backendRefs:
-        - name: zot
-          port: 5000
-    - name: registry-protocol
-      matches:
+    - matches:
         - path:
             type: PathPrefix
             value: /v2/
@@ -55,8 +66,7 @@ spec:
   hostnames:
     - registry.i.shion1305.com
   rules:
-    - name: ui
-      matches:
+    - matches:
         - path:
             type: PathPrefix
             value: /

--- a/zot/securitypolicy.yaml
+++ b/zot/securitypolicy.yaml
@@ -5,20 +5,21 @@
 # param against this exact string and refuses to use the request `:authority`
 # at runtime, so the same policy cannot serve two hostnames.
 #
-# Each policy targets:
-#   - the entire zot-ui-* HTTPRoute (SPA bundle, /zot/auth/*, /v2/_zot/*)
-#   - the `catalog-probe` rule on zot-registry-* (sectionName-scoped, just
-#     `/v2/` and `/v2/_catalog` exact-match — NOT the broad /v2/ PathPrefix
-#     used by docker push/pull)
+# Each policy targets two HTTPRoutes:
+#   - zot-ui-* (SPA bundle, /zot/auth/*, /v2/_zot/*)
+#   - zot-catalog-probe-* (just `/v2/` and `/v2/_catalog` exact-match — NOT
+#     the broad /v2/ PathPrefix used by docker push/pull, which lives on the
+#     separate zot-registry-* route)
 #
 # Why the split: Docker Registry v2 protocol (push/pull) negotiates its own
 # bearer challenge with zot. If the OIDC policy fired on /v2/<repo>/blobs/...
 # the gateway would 302 unauthenticated containerd to Keycloak, which can't
 # follow the authcode flow and would break every kubelet pull. The
-# catalog-probe rule isolates the only two /v2/ paths the SPA actually hits at
-# load (SignIn.jsx:183), so the policy can attach there without touching push
-# traffic. SectionName precedence is route-rule > route > listener > gateway
-# (Envoy Gateway SecurityPolicy concepts).
+# zot-catalog-probe-* route isolates the only two /v2/ paths the SPA actually
+# hits at load (SignIn.jsx:183), so the policy can attach there without
+# touching push traffic. Per-rule sectionName targeting would be cleaner but
+# requires HTTPRouteRule.name (Gateway API v1.2+), which ArgoCD v3.4's
+# embedded OpenAPI schema rejects at diff time.
 #
 # Browser ↔ machine differentiation:
 #   - denyRedirect on Sec-Fetch-Mode/Sec-Fetch-Dest matches XHR/fetch from the
@@ -50,8 +51,7 @@ spec:
       name: zot-ui-external
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
-      name: zot-registry-external
-      sectionName: catalog-probe
+      name: zot-catalog-probe-external
   oidc:
     provider:
       issuer: https://keycloak.shion1305.com/realms/zot
@@ -102,8 +102,7 @@ spec:
       name: zot-ui-internal
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
-      name: zot-registry-internal
-      sectionName: catalog-probe
+      name: zot-catalog-probe-internal
   oidc:
     provider:
       issuer: https://keycloak.shion1305.com/realms/zot


### PR DESCRIPTION
## Summary

- ArgoCD v3.4's structured-merge-diff embeds an older OpenAPI schema that rejects `HTTPRouteRule.name` (Gateway API v1.2+) at diff time with `field not declared in schema`, even though the cluster CRD (v1.4.1) accepts the field. PR #301 used named rules + `sectionName`-scoped `SecurityPolicy.targetRefs`; this caused the zot Application to go `OutOfSync` with a `ComparisonError` immediately after merge.
- Split the named rules into separate HTTPRoutes (`zot-catalog-probe-{external,internal}`) so `SecurityPolicy.targetRefs` reaches them by route name without relying on rule-level `sectionName`. The basic-to-bearer Lua filter still targets `zot-registry-*` (the broad `/v2/` PathPrefix route); the OIDC `SecurityPolicy` now targets `zot-ui-*` and `zot-catalog-probe-*` instead.
- Routing semantics unchanged: GEP-718 most-specific-path-wins keeps `/v2/` and `/v2/_catalog` exact matches on `zot-catalog-probe-*` over the bare `/v2/` PathPrefix on `zot-registry-*`, and `/v2/_zot/...` on `zot-ui-*` over both.

## Test plan

- [ ] ArgoCD `zot` Application clears `ComparisonError` and reaches `Synced` / `Healthy`.
- [ ] All six HTTPRoutes (`zot-{catalog-probe,registry,ui}-{external,internal}`) report `Accepted=True` and `ResolvedRefs=True`.
- [ ] Both `SecurityPolicy` resources (`zot-ui-oidc-{external,internal}`) report `Accepted=True`.
- [ ] Browser `https://registry.shion1305.com/` still redirects to Keycloak and lands on `/home` (mgmt rewrite works on `zot-ui-external`).
- [ ] `crane push` from CI still pushes (`zot-registry-external` unaffected).
- [ ] Kubelet pull smoketest still pulls (`zot-registry-internal` + Lua bridge unaffected).