### PR TITLE
fix(zot): unblock mgmt rewrite by dropping content-type gate

### DIFF
--- a/zot/envoy-extension-policy.yaml
+++ b/zot/envoy-extension-policy.yaml
@@ -227,8 +227,10 @@ spec:
           if not meta or meta["active"] ~= "true" then return end
           local headers = response_handle:headers()
           if headers:get(":status") ~= "200" then return end
-          local ct = headers:get("content-type") or ""
-          if not string.find(ct, "application/json") then return end
+          -- zot v2.1.16 mislabels the mgmt response as `text/plain` even
+          -- though the body is JSON (verified empirically). Don't gate on
+          -- content-type; the active=true metadata flag from
+          -- envoy_on_request already restricts us to /v2/_zot/ext/mgmt.
 
           local body = response_handle:body()
           local body_str = tostring(body:getBytes(0, body:length()))
@@ -236,4 +238,5 @@ spec:
           if rewritten == body_str then return end
           body:setBytes(rewritten)
           headers:replace("content-length", tostring(#rewritten))
+          headers:replace("content-type", "application/json")
         end


### PR DESCRIPTION
## Summary

The Lua filter that rewrites the zot `/v2/_zot/ext/mgmt` response — needed so the SPA detects "no auth configured" and skips its login card — never executed because zot v2.1.16 mislabels that response as `Content-Type: text/plain; charset=utf-8` even though the body is JSON. The filter's `application/json` content-type guard returned early, so browsers saw `{"http":{"auth":{"bearer":{...}}}}` and the SPA rendered the "Continue as guest" path.

Drop the content-type check (the `active=true` metadata flag set in `envoy_on_request` already restricts the rewrite to `/v2/_zot/ext/mgmt`), and re-stamp the response Content-Type as `application/json` so downstream callers see a correctly-labeled body.

## Test plan
- [ ] Browse to https://registry.shion1305.com/login while authenticated and confirm DevTools shows the mgmt response body as `{"distSpecVersion":"...","http":{}}` with `Content-Type: application/json`
- [ ] Confirm the SPA navigates straight to `/home` rather than showing the SignIn card
- [ ] Repeat on https://registry.i.shion1305.com/login (internal hostname)
- [ ] crane push smoketest still works (Lua only acts on UI route mgmt path; should be unaffected)
- [ ] kubelet pull smoketest (`zot-pull-smoketest` Application) still healthy