### PR TITLE
fix(zot): add SPA-write HTTPRoute so image-delete carries OIDC Bearer

### DIFF
--- a/zot/README.md
+++ b/zot/README.md
@@ -4,18 +4,19 @@ Project-zot v2 deployed cluster-wide as the canonical container image registry f
 
 ## Hostnames and routing
 
-Two hostnames front the same `zot` Service. Each has the same three HTTPRoutes:
+Two hostnames front the same `zot` Service. Each has the same four HTTPRoutes:
 
-| Hostname | Gateway | Catalog-probe HTTPRoute | Registry HTTPRoute | UI HTTPRoute |
-| --- | --- | --- | --- | --- |
-| `registry.shion1305.com` | `external` (public) | `zot-catalog-probe-external` | `zot-registry-external` | `zot-ui-external` |
-| `registry.i.shion1305.com` | `internal` (WG-only) | `zot-catalog-probe-internal` | `zot-registry-internal` | `zot-ui-internal` |
+| Hostname | Gateway | Catalog-probe | Registry (containerd) | Registry (SPA writes) | UI |
+| --- | --- | --- | --- | --- | --- |
+| `registry.shion1305.com` | `external` (public) | `zot-catalog-probe-external` | `zot-registry-external` | `zot-registry-spa-external` | `zot-ui-external` |
+| `registry.i.shion1305.com` | `internal` (WG-only) | `zot-catalog-probe-internal` | `zot-registry-internal` | `zot-registry-spa-internal` | `zot-ui-internal` |
 
 - `zot-catalog-probe-*` — exact `/v2/` and `/v2/_catalog`. The SPA pings these at `/login` boot. Targeted by the OIDC `SecurityPolicy` so the browser request arrives at zot with the kc_at injected.
-- `zot-registry-*` — the broad `/v2/` PathPrefix that handles every push/pull. **Not** behind the OIDC policy — containerd negotiates its own bearer challenge with zot, and a 302 to Keycloak would break every kubelet pull.
+- `zot-registry-*` — the broad `/v2/` PathPrefix that handles every containerd/crane push/pull. **Not** behind the OIDC policy — containerd negotiates its own bearer challenge with zot, and a 302 to Keycloak would break every kubelet pull.
+- `zot-registry-spa-*` — the same broad `/v2/` PathPrefix, but matched only when the `X-Zot-Api-Client: zot-ui` request header is present. Targeted by the OIDC `SecurityPolicy` so SPA-initiated writes (image-delete: `DELETE /v2/<repo>/manifests/<digest>`) carry the Envoy-injected Bearer to zot. zui's Axios always stamps the header (zui `src/api.js`); containerd/crane do not, so registry-protocol traffic falls through to `zot-registry-*`.
 - `zot-ui-*` — `/` and `/v2/_zot/*` (SPA bundle, `/zot/auth/*`, zot's extension XHRs). Fully behind the OIDC `SecurityPolicy`.
 
-Gateway API GEP-718 most-specific-path-wins keeps `/v2/_zot/...` on `zot-ui-*` and routes `/v2/` and `/v2/_catalog` exact matches to `zot-catalog-probe-*` over the bare `/v2/` PathPrefix on `zot-registry-*`. Per-rule `sectionName` targeting would be cleaner but requires `HTTPRouteRule.name` (Gateway API v1.2+) which ArgoCD v3.4's embedded OpenAPI schema rejects at diff time, so the rules are split into separate HTTPRoutes instead.
+Gateway API GEP-718 most-specific-path-wins keeps `/v2/_zot/...` on `zot-ui-*`, routes `/v2/` and `/v2/_catalog` exact matches to `zot-catalog-probe-*` over the bare `/v2/` PathPrefix on `zot-registry-*`, and prefers `zot-registry-spa-*` (path + header match) over `zot-registry-*` (path-only) for SPA-tagged traffic. Per-rule `sectionName` targeting would be cleaner but requires `HTTPRouteRule.name` (Gateway API v1.2+) which ArgoCD v3.4's embedded OpenAPI schema rejects at diff time, so the rules are split into separate HTTPRoutes instead.
 
 ## Auth callers
 
@@ -26,13 +27,14 @@ Three distinct caller types reach zot. Browser UI auth is mediated by Envoy Gate
                     │                        envoy-gateway                       │
                     │                                                            │
   GHA crane push ───┼─→ /v2/* ─────────────────────────────────────────────────┐ │
-  (Bearer JWT)      │                                                          │ │
+  (Bearer JWT)      │   (no X-Zot-Api-Client header)                           │ │
                     │                                                          ▼ │
   kubelet pull ─────┼─→ /v2/* ─→ [Lua: Basic(oidc:JWT)→Bearer JWT] ──────────→ zot
-  (Basic JWT)       │                                                          ▲ │
+  (Basic JWT)       │   (no X-Zot-Api-Client header)                           ▲ │
                     │                                                          │ │
   Browser UI ───────┼─→ /, /v2/_zot/* ─→ [SecurityPolicy.oidc → Keycloak] ─────┤ │
   (cookie / OIDC)   │      and /v2/, /v2/_catalog (catalog-probe rule)         │ │
+                    │      and /v2/* with X-Zot-Api-Client: zot-ui (SPA writes)│ │
                     │      [Lua: rewrite /v2/_zot/ext/mgmt response]           │ │
                     └────────────────────────────────────────────────────────────┘
 ```
@@ -59,7 +61,7 @@ GHA push traffic from `crane` matches the `Go-http-client` UA so the metadata fl
 
 ### 3. Browser UI (Envoy SecurityPolicy.oidc, cookie session)
 
-Browsers hit `/`, `/v2/_zot/*`, and the SPA's two boot probes (`/v2/`, `/v2/_catalog`). All four are covered by `securitypolicy.yaml`'s OIDC policy (whole-route attachment for `zot-ui-*`, `sectionName`-scoped attachment for `zot-registry-*` `catalog-probe`).
+Browsers hit `/`, `/v2/_zot/*`, the SPA's two boot probes (`/v2/`, `/v2/_catalog`), and SPA-tagged `/v2/*` writes (image-delete `DELETE /v2/<repo>/manifests/<digest>`, etc.). All are covered by `securitypolicy.yaml`'s OIDC policy: whole-route attachment for `zot-ui-*`, route attachment for `zot-catalog-probe-*` (boot probes), and route attachment for `zot-registry-spa-*` (header-matched on `X-Zot-Api-Client: zot-ui`, set unconditionally by zui's Axios). containerd/crane traffic on the same `/v2/` paths lacks the header, falls through to the OIDC-free `zot-registry-*` route, and uses the Lua filter for its bearer challenge.
 
 On first load, Envoy runs the Authorization Code flow against the Keycloak `zot` realm using the `zot-ui` confidential client. After the callback at `/oauth2/callback`, Envoy sets an encrypted session cookie (`zot_at` / `zot_it`) and forwards the Keycloak access_token upstream as `Authorization: Bearer <kc_at>`. zot's `bearer.oidc[keycloak]` validates the same token (audience `zot-registry`) and authorizes by the `groups` claim from the `zot-ui` client's group-membership mapper.
 

--- a/zot/httproute-external.yaml
+++ b/zot/httproute-external.yaml
@@ -1,7 +1,7 @@
 # Public registry URL — used by browsers (zot UI / OIDC code-flow login) and by
 # `docker push` from any host that can resolve the public DNS.
 #
-# Three HTTPRoutes, all on hostname registry.shion1305.com, split by purpose:
+# Four HTTPRoutes, all on hostname registry.shion1305.com, split by purpose:
 #
 #   zot-catalog-probe-external — exact `/v2/` and `/v2/_catalog`. The SPA pings
 #     these at /login boot. Targeted by the OIDC SecurityPolicy
@@ -10,6 +10,18 @@
 #     `Authorization`, zot's bearer-OIDC middleware would 401, and the SPA's
 #     "Continue as guest" hint would be wrong (silently logged at
 #     SignIn.jsx:189; not user-visible, but architecturally cleaner this way).
+#
+#   zot-registry-spa-external — `/v2/` PathPrefix matched only when the
+#     `X-Zot-Api-Client: zot-ui` request header is present. Targeted by the OIDC
+#     SecurityPolicy so SPA-initiated writes (image-delete hits
+#     `DELETE /v2/<repo>/manifests/<digest>`, etc.) carry the Envoy-injected
+#     Bearer to zot. Without this route the SPA's writes would fall to the
+#     bare /v2/ PathPrefix below, arrive at zot without an Authorization
+#     header, and 401 — the Axios interceptor would then redirect to /login,
+#     bouncing the user off the home page. zui's Axios always stamps this
+#     header (zui src/api.js sets `X-Zot-Api-Client: zot-ui`), so the gate is
+#     reliable. containerd/crane do not set this header, so registry-protocol
+#     traffic falls through to zot-registry-external below.
 #
 #   zot-registry-external — broad `/v2/` PathPrefix, all repository traffic
 #     (push/pull/blobs/manifests). NOT covered by SecurityPolicy: containerd
@@ -25,11 +37,14 @@
 #
 # Gateway API GEP-718 most-specific-path-wins routes /v2/_zot/... to
 # zot-ui-external (longer prefix beats /v2/) regardless of HTTPRoute order.
-# Across the two registry routes the exact matches in zot-catalog-probe-external
+# Across the registry routes the exact matches in zot-catalog-probe-external
 # beat the `/v2/` PathPrefix in zot-registry-external for the same two paths,
 # so the SPA's two probe paths land on the SecurityPolicy-attached route.
+# Header-matched matches in zot-registry-spa-external are more specific than
+# the bare PathPrefix in zot-registry-external (GEP-1742: header matches
+# raise specificity), so SPA-tagged traffic is preferred there.
 #
-# Why three routes instead of one with named rules: HTTPRouteRule.name is a
+# Why separate routes instead of one with named rules: HTTPRouteRule.name is a
 # Gateway API v1.2+ field. The cluster CRD accepts it, but ArgoCD v3.4's
 # structured-merge-diff library has an older embedded OpenAPI schema and
 # rejects the field at diff time ("field not declared in schema"). Splitting
@@ -55,6 +70,30 @@ spec:
         - path:
             type: Exact
             value: /v2/_catalog
+      backendRefs:
+        - name: zot
+          port: 5000
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: zot-registry-spa-external
+  namespace: zot
+spec:
+  parentRefs:
+    - name: external
+      namespace: envoy-gateway-system
+      sectionName: https
+  hostnames:
+    - registry.shion1305.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v2/
+          headers:
+            - name: X-Zot-Api-Client
+              value: zot-ui
       backendRefs:
         - name: zot
           port: 5000

--- a/zot/httproute-internal.yaml
+++ b/zot/httproute-internal.yaml
@@ -3,11 +3,14 @@
 # for in-cluster CI/CD or trusted hosts that have WG connectivity, while the
 # public registry.shion1305.com URL handles GitHub Actions and external pulls.
 #
-# Same three-route split as the external Gateway (see httproute-external.yaml
-# for the rationale): zot-catalog-probe-internal carries the SPA boot probes and
-# is targeted by the OIDC SecurityPolicy, zot-registry-internal carries
-# unauthenticated v2 traffic that the Lua filter bridges, and zot-ui-internal
-# carries the SPA + extension XHRs and is fully behind the SecurityPolicy.
+# Same four-route split as the external Gateway (see httproute-external.yaml
+# for the rationale): zot-catalog-probe-internal carries the SPA boot probes
+# and is targeted by the OIDC SecurityPolicy, zot-registry-spa-internal carries
+# SPA-tagged /v2/ writes (matched by `X-Zot-Api-Client: zot-ui` header) and is
+# also under the SecurityPolicy so the Bearer is injected, zot-registry-internal
+# carries unauthenticated v2 traffic that the Lua filter bridges for
+# containerd/crane, and zot-ui-internal carries the SPA + extension XHRs and is
+# fully behind the SecurityPolicy.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -28,6 +31,30 @@ spec:
         - path:
             type: Exact
             value: /v2/_catalog
+      backendRefs:
+        - name: zot
+          port: 5000
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: zot-registry-spa-internal
+  namespace: zot
+spec:
+  parentRefs:
+    - name: internal
+      namespace: envoy-gateway-system
+      sectionName: https
+  hostnames:
+    - registry.i.shion1305.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v2/
+          headers:
+            - name: X-Zot-Api-Client
+              value: zot-ui
       backendRefs:
         - name: zot
           port: 5000

--- a/zot/securitypolicy.yaml
+++ b/zot/securitypolicy.yaml
@@ -5,11 +5,17 @@
 # param against this exact string and refuses to use the request `:authority`
 # at runtime, so the same policy cannot serve two hostnames.
 #
-# Each policy targets two HTTPRoutes:
+# Each policy targets three HTTPRoutes:
 #   - zot-ui-* (SPA bundle, /zot/auth/*, /v2/_zot/*)
 #   - zot-catalog-probe-* (just `/v2/` and `/v2/_catalog` exact-match — NOT
 #     the broad /v2/ PathPrefix used by docker push/pull, which lives on the
 #     separate zot-registry-* route)
+#   - zot-registry-spa-* (the broad /v2/ PathPrefix, but only when the
+#     `X-Zot-Api-Client: zot-ui` header is set — i.e. SPA-initiated writes
+#     like image-delete `DELETE /v2/<repo>/manifests/<digest>`. containerd
+#     and crane don't set the header, so their /v2/ traffic falls to the
+#     SecurityPolicy-free `zot-registry-*` route, where the Lua filter
+#     handles their auth flow without OIDC interference.)
 #
 # Why the split: Docker Registry v2 protocol (push/pull) negotiates its own
 # bearer challenge with zot. If the OIDC policy fired on /v2/<repo>/blobs/...
@@ -52,6 +58,9 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       name: zot-catalog-probe-external
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: zot-registry-spa-external
   oidc:
     provider:
       issuer: https://keycloak.shion1305.com/realms/zot
@@ -103,6 +112,9 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       name: zot-catalog-probe-internal
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: zot-registry-spa-internal
   oidc:
     provider:
       issuer: https://keycloak.shion1305.com/realms/zot


### PR DESCRIPTION
## Summary

zui's image-delete button hits `DELETE /v2/<repo>/manifests/<digest>`, which matched the broad `/v2/` PathPrefix on `zot-registry-*` — a route deliberately *not* covered by `SecurityPolicy.oidc` (so containerd/crane can do their own bearer challenge). The browser request arrived at zot without an `Authorization` header, zot returned 401, and the Axios interceptor at zui `src/api.js` flipped the user back to `/login`.

Add a parallel `zot-registry-spa-*` HTTPRoute per hostname (external + internal) matched on `PathPrefix=/v2/` **AND** request header `X-Zot-Api-Client: zot-ui` (zui's Axios stamps this unconditionally). Target it with the OIDC `SecurityPolicy` so SPA-tagged writes carry the Keycloak access token as `Authorization: Bearer …` to zot.

containerd / crane do not set `X-Zot-Api-Client`, so their `/v2/` traffic falls through to the existing `zot-registry-*` route and continues to use the Lua basic-to-bearer bridge — registry-protocol auth is unchanged.

GEP-1742: header matchers raise specificity over path-only matchers, so SPA-tagged traffic is preferred on the new route automatically.

## Test plan
- [ ] Browse to https://registry.shion1305.com (authenticated) → click "Delete tag" on an image; confirm 200/202 instead of 401, no `/login` bounce
- [ ] Same on https://registry.i.shion1305.com (internal/WG)
- [ ] crane push smoketest still works (no `X-Zot-Api-Client` header on its requests, falls through to OIDC-free route)
- [ ] kubelet pull smoketest (`zot-pull-smoketest` Application) remains Healthy
- [ ] Confirm the new HTTPRoutes report `Accepted=True` and the SecurityPolicies pick them up