### PR TITLE
feat(harbor): add Harbor OCI registry alongside zot

### DIFF
--- a/apps/harbor-app.yaml
+++ b/apps/harbor-app.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: harbor
+  namespace: argocd
+  annotations:
+    # Sync after postgres-shared (default wave 0) so the `harbor` user/DB
+    # exist before Harbor core tries to connect. Without this, the first
+    # sync still converges via Pod CrashLoopBackOff retries (see
+    # langfuse-app for the no-wave precedent), but waving avoids the
+    # noisy startup window.
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+  sources:
+    - repoURL: https://helm.goharbor.io
+      chart: harbor
+      targetRevision: 1.19.0
+      helm:
+        valueFiles:
+          - $values/harbor/values.yaml
+    - repoURL: https://github.com/Shion1305/k8s-GitOps.git
+      targetRevision: HEAD
+      ref: values
+    - repoURL: https://github.com/Shion1305/k8s-GitOps.git
+      targetRevision: HEAD
+      path: harbor
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: harbor
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/apps/harbor-pull-app.yaml
+++ b/apps/harbor-pull-app.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: harbor-pull
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Shion1305/k8s-GitOps.git
+    targetRevision: HEAD
+    path: harbor-pull
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: external-secrets
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/apps/harbor-pull-source-app.yaml
+++ b/apps/harbor-pull-source-app.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: harbor-pull-source
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Shion1305/k8s-GitOps.git
+    targetRevision: HEAD
+    path: harbor-pull-source
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: harbor-pull-source
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+      - ServerSideApply=true

--- a/harbor-pull-source/kustomization.yaml
+++ b/harbor-pull-source/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - zot-pull-injection.yaml
-  - harbor-pull-injection.yaml
+  - namespace.yaml

--- a/harbor-pull-source/namespace.yaml
+++ b/harbor-pull-source/namespace.yaml
@@ -1,0 +1,20 @@
+# Source namespace for the cluster-wide harbor-pull credential.
+#
+# Sole purpose: hold the canonical Secret `harbor-pull`
+# (kubernetes.io/dockerconfigjson) that ESO materialises from the Vault path
+# `harbor/robot-puller`. The ClusterExternalSecret in `harbor-pull/` targets
+# this namespace exclusively via the auto-applied `kubernetes.io/metadata.name`
+# label, so no extra labels are needed here.
+#
+# Kyverno (kyverno-policies/harbor-pull-injection.yaml) clones this Secret
+# into consumer namespaces on Pod admission and adds it to imagePullSecrets.
+#
+# Architectural note vs zot-pull-source: zot needed a dedicated source
+# namespace primarily because ESO v0.19.0 hard-codes ClusterScoped=false on
+# Webhook generators (it had to co-locate the credentials Secret with its
+# consumer ExternalSecret). Harbor doesn't use a generator, so the dedicated
+# namespace here is purely a Kyverno clone-source convention — no ESO quirk.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: harbor-pull-source

--- a/harbor-pull/cluster-external-secret.yaml
+++ b/harbor-pull/cluster-external-secret.yaml
@@ -1,0 +1,63 @@
+# Materialises the dockerconfigjson Secret `harbor-pull` in `harbor-pull-source`.
+# This Secret carries the static Harbor robot-account credentials and is the
+# source of truth for cluster-wide pull credentials for the Harbor registry.
+# Distribution to consumer namespaces is delegated to Kyverno
+# (kyverno-policies/harbor-pull-injection.yaml).
+#
+# Architectural note vs zot-pull: this pipeline is deliberately much simpler.
+# zot needs ESO's ClusterGenerator to mint fresh Keycloak access_tokens every
+# 15 minutes (token lifespan 1h). Harbor robot credentials are long-lived
+# static strings rotated maybe yearly, so we read them straight from Vault
+# at `harbor/robot-puller` and template the dockerconfigjson directly.
+#
+# refreshInterval: 1h is generous; the underlying Vault data only changes when
+# the robot account is rotated manually. The hourly poll picks up rotation
+# without needing a manual sync.
+#
+# auth format: base64("<username>:<password>") — standard HTTP Basic. Harbor
+# accepts this on /v2/* for any robot account that has pull permission on the
+# referenced project. Both the public (harbor.shion1305.com) and internal
+# (harbor.i.shion1305.com) hostnames get the same credential entry so kubelet
+# can match either form a Pod's image reference uses.
+apiVersion: external-secrets.io/v1
+kind: ClusterExternalSecret
+metadata:
+  name: harbor-pull
+spec:
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: harbor-pull-source
+  refreshTime: 5m
+  externalSecretSpec:
+    refreshInterval: 1h
+    secretStoreRef:
+      name: vault-harbor-pull
+      kind: ClusterSecretStore
+    target:
+      name: harbor-pull
+      creationPolicy: Owner
+      deletionPolicy: Retain
+      template:
+        type: kubernetes.io/dockerconfigjson
+        engineVersion: v2
+        data:
+          .dockerconfigjson: |
+            {
+              "auths": {
+                "harbor.shion1305.com": {
+                  "auth": "{{ printf "%s:%s" .username .password | b64enc }}"
+                },
+                "harbor.i.shion1305.com": {
+                  "auth": "{{ printf "%s:%s" .username .password | b64enc }}"
+                }
+              }
+            }
+    data:
+      - secretKey: username
+        remoteRef:
+          key: robot-puller
+          property: username
+      - secretKey: password
+        remoteRef:
+          key: robot-puller
+          property: password

--- a/harbor-pull/cluster-secret-store.yaml
+++ b/harbor-pull/cluster-secret-store.yaml
@@ -1,0 +1,30 @@
+# ClusterSecretStore so the ClusterExternalSecret can read the Harbor robot
+# account credentials from Vault and materialise a dockerconfigjson Secret in
+# `harbor-pull-source`.
+#
+# Bound to the cluster-scoped SA `external-secrets/external-secrets` via a
+# Vault role `eso-harbor-pull` (defined in vault/scripts/setup-eso-policies.sh).
+#
+# Architectural note vs zot-pull: this pipeline is deliberately much simpler.
+# zot uses short-lived (1h) Keycloak access_tokens, so zot-pull needs an
+# ESO ClusterGenerator to refresh them hourly via OAuth2 client_credentials.
+# Harbor uses long-lived robot-account credentials (rotated manually, maybe
+# yearly), so we just read username/password from Vault directly — no
+# ClusterGenerator, no token endpoint, no per-namespace credentials Secret.
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: vault-harbor-pull
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "harbor"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "eso-harbor-pull"
+          serviceAccountRef:
+            name: "external-secrets"
+            namespace: "external-secrets"

--- a/harbor-pull/kustomization.yaml
+++ b/harbor-pull/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - zot-pull-injection.yaml
-  - harbor-pull-injection.yaml
+  - cluster-secret-store.yaml
+  - cluster-external-secret.yaml

--- a/harbor/README.md
+++ b/harbor/README.md
@@ -1,0 +1,453 @@
+# harbor — OCI Registry
+
+Harbor v2.x deployed cluster-wide as the canonical container image registry. This deployment replaced the previous zot-based registry; see [Architecture decisions](#architecture-decisions) for the why.
+
+## Overview
+
+Harbor speaks OIDC at the application layer (unlike zot, where Envoy mediated browser auth via `SecurityPolicy.oidc`), so the integration here is comparatively simple: routes go to the chart's Services, OIDC settings are seeded into Harbor's own Postgres database from Vault, and the Keycloak `harbor` realm is the IdP.
+
+Two hostnames front different parts of the deployment:
+
+| Hostname | Gateway | Surface |
+| --- | --- | --- |
+| `harbor.shion1305.com` | `external` (public) | `/v2/` + `/service/token` only — primarily for GitHub Actions push |
+| `harbor.i.shion1305.com` | `internal` (WireGuard-only) | full surface — portal, OIDC callback, `/api/`, `/v2/`, `/c/`, `/chartrepo/` |
+
+Intended pull traffic happens from inside the cluster against the internal hostname. **However**, the `/v2/` PathPrefix on the public Gateway cannot distinguish push from pull — both verbs share the same path namespace — so any project flagged `public` in the Harbor portal is world-readable on `harbor.shion1305.com`. Treat project visibility as the access-control boundary: keep all projects private and lock project creation to admins (`project_creation_restriction=adminonly`).
+
+## Architecture
+
+```
+                                     ┌───────────────────────────────────────────┐
+                                     │             envoy-gateway                  │
+                                     │                                            │
+   GHA crane push ───────────────────┼─→ harbor.shion1305.com  (external)         │
+   (Basic robot creds)               │     /v2/, /service/token                   │
+                                     │     httproute-external.yaml                │
+                                     │                                            │
+   kubelet pull (in-cluster) ────────┼─→ harbor.i.shion1305.com  (internal)       │
+   (Basic robot creds)               │     /v2/                                   │
+                                     │     via Kyverno-injected harbor-pull       │
+                                     │                                            │
+   Browser portal ───────────────────┼─→ harbor.i.shion1305.com  (internal)       │
+   (cookie session, OIDC)            │     /, /api/, /c/, /service/, /chartrepo/  │
+                                     │     httproute-internal.yaml                │
+                                     └───────────────────────────────────────────┘
+                                                         │
+                                                         ▼
+                                ┌──────────────────────────────────────────────┐
+                                │   harbor-portal (SPA)    harbor-core (API)   │
+                                └──────────────────────────────────────────────┘
+                                                         │
+            ┌────────────────────────────────────────────┼──────────────────────────────┐
+            ▼                                            ▼                              ▼
+   ┌─────────────────┐                       ┌───────────────────┐         ┌────────────────────┐
+   │ postgres-shared │                       │ keycloak (harbor  │         │ longhorn PVC       │
+   │ user/db: harbor │                       │ realm + harbor-ui │         │ (registry blobs)   │
+   │ via ESO k8s     │                       │ confidential cli) │         │                    │
+   │ provider        │                       └───────────────────┘         └────────────────────┘
+   └─────────────────┘                                 ▲
+            ▲                                          │
+            │       ┌──────────────────────────────────┴─────────────────────────────┐
+            │       │                                                                │
+            │       │ Vault (harbor/ KV v2 mount)                                    │
+            │       │   harbor/openid-credentials   harbor/admin-password            │
+            │       │   harbor/secret-key           harbor/core-secret               │
+            │       │   harbor/robot-puller         harbor/robot-pusher              │
+            │       │   harbor/broker-credentials                                    │
+            │       └────────────────────────────────────────────────────────────────┘
+            │                  │
+            │                  ▼ ESO (per-namespace SecretStore + ExternalSecret)
+            │       ┌──────────────────────────────────────────────────────────────┐
+            │       │ Kyverno ClusterPolicy `harbor-pull-injection`                │
+            │       │   on Pod admission: clones harbor-pull-source/harbor-pull    │
+            │       │   into Pod ns + appends to imagePullSecrets                  │
+            │       └──────────────────────────────────────────────────────────────┘
+```
+
+Components and who hits what:
+
+- **External Gateway (`envoy-gateway-system/external`)** — terminates TLS for `harbor.shion1305.com` (public). Used only by GHA push.
+- **Internal Gateway (`envoy-gateway-system/internal`)** — terminates TLS for `harbor.i.shion1305.com` (WireGuard-only A record `10.130.5.21`). Used by browser, kubelet, in-cluster automation.
+- **`harbor-core` Service** — Harbor's API + registry endpoints (`/v2/`, `/api/`, `/service/`, `/c/`, `/chartrepo/`).
+- **`harbor-portal` Service** — static SPA bundle (`/`).
+- **`postgres-shared` cluster** (in `postgres-operator-deployment`) — provides the `harbor` database and the `harbor` user, materialized into the `harbor` namespace as `harbor-db-credentials` by ESO's k8s provider (`db-secret-store.yaml` + `db-external-secret.yaml`).
+- **Keycloak (`harbor` realm)** — drives OIDC for the portal. Realm imported declaratively via `keycloak-operator/harbor-realm.yaml`.
+- **Vault (`harbor/` KV v2 mount)** — single source of truth for OIDC client secrets, Harbor's admin password, AES secret key, core inter-component secret, and robot-account credentials.
+- **Kyverno (`harbor-pull-injection`)** — fans the cluster-wide `harbor-pull` dockerconfigjson Secret into any namespace whose Pods reference `harbor.shion1305.com/*` or `harbor.i.shion1305.com/*` images.
+
+## Hostname split
+
+The split between `harbor.shion1305.com` (public, push-only) and `harbor.i.shion1305.com` (internal, full surface) is intentional. See header comments in `httproute-external.yaml` and `httproute-internal.yaml` for the canonical justifications.
+
+- **`harbor.shion1305.com` (public)** — only `/v2/` (PathPrefix) and `/service/token` (Exact) match; the SPA, `/api/`, `/c/`, and `/chartrepo/` are all unreachable. The worst case from a leaked credential here is a stolen robot-account token, not a compromised admin session. Note: `/v2/` allows both push and pull verbs, so public-visibility projects ARE world-readable — keep all projects private (see [Hostname split](#hostname-split)).
+- **`harbor.i.shion1305.com` (internal)** — the SPA at `/`, `/api/`, `/service/`, `/v2/`, `/c/`, and `/chartrepo/` are all served. Two HTTPRoutes on the same hostname (`harbor-portal-internal` for `/` to `harbor-portal:80`, `harbor-core-internal` for the longer prefixes to `harbor-core:80`); Gateway API GEP-718 most-specific-path-wins handles ordering automatically.
+
+The single redirect URI on the `harbor-ui` Keycloak client (`https://harbor.i.shion1305.com/c/oidc/callback`) reflects that there is no externally-facing portal to log into.
+
+## Authentication flows
+
+Three discrete flows touch Harbor. None of them go through Envoy's `SecurityPolicy.oidc` — Harbor handles OIDC natively.
+
+### a. Browser portal login (OIDC)
+
+```
+user → https://harbor.i.shion1305.com/
+     → harbor-portal (SPA) loads
+     → user clicks "Login via OIDC"
+     → harbor-core (302) redirect to Keycloak `harbor` realm `harbor-ui` client
+     → Keycloak `harbor` realm Browser flow has Identity Provider Redirector
+       pinned to alias `user` → silently redirects to `user` realm
+     → user authenticates with passkey in the `user` realm
+     → callback through `harbor-broker` IdP → `harbor` realm session
+     → final callback to https://harbor.i.shion1305.com/c/oidc/callback
+     → harbor-core stamps its own session cookie, returns to /
+```
+
+Authorization is by the `groups` claim. The `harbor-ui` client has a `groups` group-membership mapper; Harbor's `oidc_groups_claim=groups` setting maps those onto its internal projects. Adding a Keycloak user to the `harbor-admin` realm group makes them a Harbor admin on next login.
+
+### b. In-cluster image pull (kubelet)
+
+```
+Pod in any namespace references harbor.i.shion1305.com/<repo>:<tag>
+  → admission: Kyverno ClusterPolicy `harbor-pull-injection` fires
+      - mutate: appends `imagePullSecrets: [{name: harbor-pull}]`
+      - generate.clone: copies harbor-pull-source/harbor-pull → <pod-ns>/harbor-pull
+  → kubelet reads dockerconfigjson for the harbor.i.shion1305.com host
+  → kubelet → /v2/ on harbor-core
+      - Harbor returns 401 + WWW-Authenticate: Bearer realm=...
+      - kubelet → /service/token with Basic auth (robot creds)
+      - Harbor mints a short-lived bearer token
+      - kubelet retries /v2/<repo>/blobs/<digest> with the bearer
+  → blob fetch
+```
+
+Robot credentials live in Vault at `harbor/robot-puller`. ESO's `ClusterExternalSecret` (`harbor-pull/cluster-external-secret.yaml`) reads them via the cluster-scoped `vault-harbor-pull` SecretStore (bound to the `external-secrets/external-secrets` SA via Vault role `eso-harbor-pull`) and templates a dockerconfigjson into `harbor-pull-source/harbor-pull`. Both `harbor.shion1305.com` and `harbor.i.shion1305.com` are listed in the dockerconfig so kubelet matches whichever form a Pod uses.
+
+There is intentionally no ESO `ClusterGenerator` in the picture (zot needed one to refresh hourly Keycloak access_tokens). Harbor robot accounts are long-lived static credentials — yearly manual rotation is the model.
+
+### c. GitHub Actions push (handled in a follow-up PR)
+
+The GHA push workflow and demo image live in a separate PR that lands after this one merges and Harbor is verified healthy in the cluster. The shape of the auth flow is:
+
+```
+GHA workflow → docker buildx → OCI-layout tarball
+  → write ~/.docker/config.json with auth = base64("$HARBOR_ROBOT_USER:$HARBOR_ROBOT_TOKEN")
+  → crane push /tmp/oci harbor.shion1305.com/<project>/<repo>:<sha>
+      - crane → POST /v2/ with Basic robot creds
+      - Harbor 401 + WWW-Authenticate: Bearer realm=https://harbor.shion1305.com/service/token
+      - crane → GET /service/token with Basic creds
+      - Harbor mints bearer, validates project ACL
+      - crane → POST /v2/.../blobs/uploads/ with Bearer
+      - blob + manifest upload
+```
+
+GHA repo secrets `HARBOR_ROBOT_USER` (e.g. `robot$shion1305+gha-pusher`) and `HARBOR_ROBOT_TOKEN` come from Harbor's portal at robot-creation time. Robot accounts are not declarative — they're created in Harbor's UI and the token is shown exactly once.
+
+## Bootstrap (first-time deployment)
+
+Manual steps in order. None of these are declarative.
+
+### 1. Enable the Vault KV mount
+
+```bash
+vault secrets enable -path=harbor kv-v2
+```
+
+### 2. Add the eso-harbor role
+
+Re-run `vault/scripts/setup-eso-policies.sh` (idempotent) to apply the `eso-harbor` policy + role. This grants the `eso` ServiceAccount in the `harbor` namespace read access to `harbor/data/*`. While the script is running, also confirm the `eso-harbor-pull` role exists for the cluster-scoped `harbor-pull` automation.
+
+### 3. Pre-seed Vault paths
+
+Write placeholder values now; replace with real ones during steps 5 and 6.
+
+```bash
+# Bootstrap admin password (used for the very first portal login only — OIDC
+# takes over after).
+vault kv put harbor/admin-password password=<admin-password>
+
+# AES key for at-rest encryption of OIDC refresh tokens, registry creds, etc.
+# MUST be exactly 16 characters. Rotating it invalidates all stored encrypted
+# blobs, so treat as long-lived.
+vault kv put harbor/secret-key secretKey=<sixteen-char-key>
+
+# Random string for inter-component auth (jobservice, registry, core).
+vault kv put harbor/core-secret secret=<random-string>
+
+# OIDC creds — leave as a stub for now; populated in step 5.
+vault kv put harbor/openid-credentials \
+  keycloak-credentials.json='{"clientid":"harbor-ui","clientsecret":"PLACEHOLDER"}'
+```
+
+### 4. Apply the ArgoCD app
+
+Argo creates the `harbor` namespace and runs the chart. The `postgres-shared` cluster (in `postgres-operator-deployment`) already lists `harbor` in `users:` and `databases:` — the postgres-operator creates the role+DB on first reconcile and writes the credentials Secret `harbor.postgres-shared.credentials.postgresql.acid.zalan.do` into its own namespace. ESO's `harbor-db-credentials` ExternalSecret (`db-external-secret.yaml`) mirrors that Secret into the `harbor` namespace.
+
+```bash
+kubectl apply -f apps/harbor-app.yaml
+kubectl get application harbor -n argocd -w
+```
+
+OIDC is **not yet wired** at this point — `oidc_client_secret` is set out-of-band by the post-sync Job in step 9. Until then, the portal will only accept the built-in `admin` account.
+
+### 5. Resolve the Keycloak `harbor-ui` client secret
+
+The `harbor` realm import (`keycloak-operator/harbor-realm.yaml`) ships with `secret: PLACEHOLDER_REPLACE_AFTER_REALM_IMPORT` for the `harbor-ui` confidential client. Keycloak generates the real value on first import.
+
+```bash
+# 1. Open Keycloak admin UI: https://keycloak.shion1305.com
+# 2. Realm: harbor → Clients → harbor-ui → Credentials → "Client secret" → copy
+# 3. Persist into Vault
+vault kv put harbor/openid-credentials \
+  keycloak-credentials.json='{"clientid":"harbor-ui","clientsecret":"<harbor-ui-secret>"}'
+```
+
+### 6. Resolve the `harbor-broker` IdP secret
+
+Same pattern for the brokered IdP into the `user` realm:
+
+```bash
+# Realm harbor → Identity Providers → user → Settings → Client Secret → copy
+vault kv put harbor/broker-credentials \
+  client_id=harbor-broker \
+  client_secret=<harbor-broker-secret>
+```
+
+Then write the same value into the `user` realm's broker client (in the Keycloak admin UI, under realm `user` → Clients → `harbor-broker` → Credentials). The `KeycloakRealmImport` v2alpha1 CRD does not reconcile this on its own.
+
+### 7. Bind the Browser flow to the IdP redirector
+
+In the Keycloak admin UI, realm `harbor` → Authentication → Flows → Browser → add execution **Identity Provider Redirector** at the top, **Required**, with config `Default Identity Provider = user`. Bind that flow as the realm's Browser flow. This skips the IdP-choice screen so users go straight to passkey login in the `user` realm.
+
+### 8. Force ESO refresh
+
+```bash
+for es in harbor-oidc-credentials harbor-admin-password harbor-secret-key harbor-core-secret; do
+  kubectl annotate externalsecret -n harbor "$es" force-sync="$(date +%s)" --overwrite
+done
+```
+
+### 9. Trigger the post-sync OIDC Job
+
+The `harbor-configure-oidc` Job (declared in `harbor/configure-oidc-job.yaml` as an Argo `PostSync` hook) reads `harbor-oidc-credentials.client-secret` and PUTs it to Harbor's `/api/v2.0/configurations` endpoint. This is the only OIDC setting that is NOT seeded via `core.configureUserSettings` — Harbor's `CONFIG_OVERWRITE_JSON` parser does not expand env vars, so a secret value cannot live in committed YAML.
+
+The Job runs automatically on first sync. To re-run it (after rotating the client secret in Vault, for example):
+
+```bash
+# Sync of the harbor app re-creates the Job (BeforeHookCreation policy).
+argocd app sync harbor --resource batch:Job:harbor-configure-oidc
+
+# Or delete-and-let-Argo-recreate:
+kubectl delete job -n harbor harbor-configure-oidc
+```
+
+### 10. Restart harbor-core (one-time)
+
+`harbor-core` re-applies `configureUserSettings` on every start. After step 9 has populated the encrypted `oidc_client_secret`, a restart is unnecessary unless you need to pick up a rotated AES key or core secret:
+
+```bash
+kubectl rollout status -n harbor deploy/harbor-core
+```
+
+### 11. First portal login
+
+Visit `https://harbor.i.shion1305.com` (WireGuard required). Log in **once** as the built-in `admin` user with the password from `harbor/admin-password`. This bootstraps the admin session; subsequent logins should go through OIDC.
+
+### 12. Create the `shion1305` project and robot accounts
+
+In the portal:
+
+- **Projects → New Project**: name `shion1305`, **Public OFF** (the default; do not change). Public projects are world-readable on `harbor.shion1305.com`.
+- **Configuration → System Settings → Project Creation**: `Admin Only`. Prevents non-admins from creating projects (and accidentally flipping them public).
+- **Members**: add Keycloak group `harbor-admin` as project admin (after the first OIDC user is auto-onboarded — see Day 2 ops).
+- **Robot Accounts → New Robot Account**:
+  - `gha-pusher`: push + pull on Repository ONLY (uncheck artifact deletion, tag deletion, helm chart, scan, label permissions). Expiration 365 days. Save the token to:
+    - GitHub repo secrets `HARBOR_ROBOT_USER` (full username with the `robot$` project-scope prefix, e.g. `robot$shion1305+gha-pusher`) and `HARBOR_ROBOT_TOKEN`.
+    - Vault: `vault kv put harbor/robot-pusher username=<robot$...> password=<token>`
+  - `puller`: pull on Repository ONLY. Expiration 365 days. Save to:
+    - Vault: `vault kv put harbor/robot-puller username=<robot$...> password=<token>`
+
+ESO's `harbor-pull` `ClusterExternalSecret` will materialize the dockerconfigjson into `harbor-pull-source/harbor-pull` within `refreshInterval` (1h). To shortcut the wait:
+
+```bash
+kubectl annotate clusterexternalsecret harbor-pull force-sync="$(date +%s)" --overwrite
+```
+
+The end-to-end push + pull smoketest (GHA workflow + cluster-side `harbor-pull-smoketest` Job) lives in a follow-up PR; that PR is the verification gate before zot is decommissioned.
+
+## Day 2 operations
+
+### Rotate `harbor-ui` Keycloak client secret
+
+1. Keycloak admin UI → realm `harbor` → Clients → `harbor-ui` → Credentials → Regenerate.
+2. `vault kv put harbor/openid-credentials keycloak-credentials.json='{"clientid":"harbor-ui","clientsecret":"<new-secret>"}'`
+3. ESO syncs within 5 minutes (or force with `kubectl annotate externalsecret -n harbor harbor-oidc-credentials force-sync="$(date +%s)" --overwrite`).
+4. Re-run the `harbor-configure-oidc` Job to push the new secret into Harbor's DB:
+   ```bash
+   kubectl delete job -n harbor harbor-configure-oidc
+   argocd app sync harbor
+   ```
+5. No rollout-restart needed — Harbor reads `oidc_client_secret` from the DB on every login attempt.
+
+### Rotate Harbor admin password
+
+1. `vault kv put harbor/admin-password password=<new-password>`
+2. ESO syncs; no restart needed (Harbor reads the Secret on next admin login).
+
+### Rotate a robot account
+
+1. Harbor portal → project → Robot Accounts → New Robot Account (same scope and permissions).
+2. Save the new token.
+3. `vault kv put harbor/robot-puller username=<new> password=<new-token>` (or `harbor/robot-pusher`).
+4. Update GitHub repo secrets `HARBOR_ROBOT_USER` / `HARBOR_ROBOT_TOKEN` if rotating the pusher.
+5. ESO syncs; for the puller, `harbor-pull` re-materializes within 1h. To force: `kubectl annotate clusterexternalsecret harbor-pull force-sync="$(date +%s)" --overwrite`.
+6. Once running Pods have re-pulled with the new credentials, revoke the old robot in the portal.
+
+### Add a new Keycloak user as a Harbor admin
+
+1. User signs in once via the portal (auto-onboarded thanks to `oidc_auto_onboard=true`).
+2. Keycloak admin UI → realm `harbor` → Users → find the user → Groups → Join → `harbor-admin`.
+3. User logs out and back in — the new `groups` claim picks up the role.
+
+### Backup
+
+Two stateful surfaces:
+
+- **Postgres** — `harbor` database in the `postgres-shared` cluster, backed up by the postgres-operator's WAL-archiving + base-backup pipeline (see `postgres-shared/`).
+- **Registry blobs** — Longhorn PVC `<release>-harbor-registry`, backed up by Longhorn snapshots (see `longhorn/backup-target.yaml`).
+
+Restoring requires both — the database knows about manifests, the PVC holds the actual layer blobs.
+
+### Upgrade Harbor chart
+
+1. Bump `targetRevision` in `apps/harbor-app.yaml` (Renovate also automerges PRs for this).
+2. Argo syncs.
+3. For major-version bumps, read [goharbor/harbor-helm release notes](https://github.com/goharbor/harbor-helm/releases) for breaking changes (DB schema migrations, value-key renames).
+
+## Troubleshooting
+
+### "Login redirects to Keycloak then 400 invalid redirect URI"
+
+The `harbor-ui` client's `redirectUris` doesn't include `https://harbor.i.shion1305.com/c/oidc/callback`. Check `keycloak-operator/harbor-realm.yaml` and re-import the realm if the YAML was changed (re-import requires deleting the `KeycloakRealmImport` CR — the operator silently ignores edits to existing imports; see header comment in `harbor-realm.yaml`).
+
+### "Push fails with 'unauthorized: authentication required'"
+
+GHA secrets `HARBOR_ROBOT_USER` / `HARBOR_ROBOT_TOKEN` are missing, or the robot account was revoked / expired in Harbor. Check the robot's status in the portal under the project's Robot Accounts tab.
+
+### "Pull fails with ImagePullBackOff"
+
+Walk the pull pipeline:
+
+```bash
+# 1. Is the Kyverno policy installed and ready?
+kubectl get clusterpolicy harbor-pull-injection -o yaml
+
+# 2. Did ESO materialize the source Secret?
+kubectl get secret -n harbor-pull-source harbor-pull
+
+# 3. Did Kyverno clone the Secret into the consumer namespace?
+kubectl get secret -n <pod-ns> harbor-pull
+
+# 4. Did Kyverno append imagePullSecrets to the Pod?
+kubectl get pod -n <pod-ns> <pod> -o yaml | grep -A1 imagePullSecrets
+
+# 5. Has the robot account expired?
+# Harbor portal → project → Robot Accounts → expiration column
+```
+
+### "Portal shows 'connection refused' or 500 on first sync"
+
+`harbor-core` started before `harbor-oidc-credentials` was materialized. Restart:
+
+```bash
+kubectl rollout restart -n harbor deploy/harbor-core
+```
+
+### "Manifest URLs return http:// instead of https://"
+
+Set `registry.relativeurls: true` in `harbor/values.yaml`. Harbor's registry component needs this when behind a TLS-terminating proxy (Envoy Gateway).
+
+### "OIDC redirect goes to wrong hostname"
+
+Harbor's `externalURL` setting (set via Helm chart values, key `externalURL`) doesn't match the hostname the user is hitting. The portal calls back to whatever `externalURL` says, regardless of the Host header it received. Set to `https://harbor.i.shion1305.com`.
+
+## Architecture decisions
+
+These are the WHYs that aren't obvious from the manifests.
+
+### Why Harbor over zot
+
+zot v2.1.16's bearer-OIDC middleware short-circuits `AuthHandler` whenever `bearer.oidc[]` is configured (`pkg/api/authn.go:65-67`), so the SPA's `authConfig` flow never gets `RelyingParties` initialized — see [project-zot/zot#4033](https://github.com/project-zot/zot/issues/4033). Working around this by mediating UI auth via Envoy's `SecurityPolicy.oidc` worked for happy-path login but ran into:
+
+- `denyRedirect` API limitations for AJAX vs. navigation handling.
+- Lua filter ordering issues for the `Basic(oidc:JWT)` → `Bearer JWT` rewrite required by containerd's challenge/retry handshake.
+- An Envoy-Lua `mgmt`-response rewrite needed just to make the SPA take its auto-login branch.
+
+Harbor solves all of this natively because it speaks OIDC at the application layer and mints its own bearer tokens for the registry protocol.
+
+### Why robot accounts not Keycloak service-account tokens
+
+Harbor's `/v2/` token endpoint does not validate external OIDC JWTs. It accepts either Basic auth (username/password or robot creds) or an OIDC ID token submitted to `/c/login` from a browser flow. Robot accounts are the supported CI auth model — long-lived, project-scoped, revocable from the portal.
+
+This is the cleanest break from the zot setup: zot's GHA push used GitHub OIDC token-exchange directly, and zot's kubelet pull used a refresh-every-hour Keycloak client_credentials grant. Harbor needs neither — both flows collapse to "Basic with robot creds."
+
+### Why hostname split
+
+Public pull and public portal access are not requirements for this cluster. Minimizing the public attack surface to push-only — no admin UI, no `/api/`, no `/c/oidc/callback` — is cheaper than running a WAF or hardening the SPA against credential-stuffing. A leaked robot-account token is the worst case on `harbor.shion1305.com`; a compromised admin session would have been the worst case if the portal were exposed.
+
+### Why postgres-shared instead of a dedicated cluster
+
+Consistency with langfuse, keycloak, mlflow, openwebui — they all live in `postgres-shared`. Harbor's DB load is light (project metadata + manifest pointers, not blobs). Failure isolation against a shared cluster outage was deemed not worth the operational overhead of a second cluster.
+
+### Why secretKey / coreSecret / adminPassword in Vault, not chart-generated
+
+See `external-secret.yaml` header comment for the canonical version. Three reasons:
+
+1. **Idempotency on chart upgrades** — Helm `lookup` values can churn if the release is recreated, breaking sessions and encrypted columns.
+2. **Audit trail** — every value lives in Vault with version history.
+3. **No Helm secret leaks** — `values.yaml` stays in git without any sensitive material; the chart only sees Secret references.
+
+## ExternalSecrets
+
+| ExternalSecret | Source | Vault path / k8s key | Materialized Secret | Consumer |
+| --- | --- | --- | --- | --- |
+| `harbor-oidc-credentials` | Vault (`harbor/`) | `harbor/openid-credentials` field `keycloak-credentials.json` | `harbor-oidc-credentials` (`client-id`, `client-secret`) | harbor-core OIDC config |
+| `harbor-admin-password` | Vault (`harbor/`) | `harbor/admin-password` field `password` | `harbor-admin-password` (`HARBOR_ADMIN_PASSWORD`) | harbor-core bootstrap admin |
+| `harbor-secret-key` | Vault (`harbor/`) | `harbor/secret-key` field `secretKey` | `harbor-secret-key` (`secretKey`) | harbor-core at-rest AES key |
+| `harbor-core-secret` | Vault (`harbor/`) | `harbor/core-secret` field `secret` | `harbor-core-secret` (`secret`) | harbor-core inter-component auth |
+| `harbor-db-credentials` | k8s (`postgres-operator-deployment`) | `harbor.postgres-shared.credentials.postgresql.acid.zalan.do` | `harbor-db-credentials` (`username`, `password`) | harbor-core external DB connection |
+| `harbor-pull` (cluster-wide) | Vault (`harbor/`) | `harbor/robot-puller` fields `username`, `password` | `harbor-pull-source/harbor-pull` (dockerconfigjson) | Kyverno clone target → kubelet |
+
+The two ServiceAccounts in the namespace (`eso` for the Vault provider, `eso-db` for the k8s provider) exist because ESO binds a SecretStore to a single auth provider; the Vault path uses Kubernetes auth bound to `eso-harbor`, while the k8s path uses the in-cluster API to read the postgres-operator's generated Secret.
+
+## Files in this directory
+
+| File | Purpose |
+| --- | --- |
+| `secret-store.yaml` | ServiceAccount `eso` + Vault `SecretStore` (Kubernetes auth role `eso-harbor`) |
+| `external-secret.yaml` | Four ExternalSecrets sourcing from Vault `harbor/` |
+| `db-secret-store.yaml` | ServiceAccount `eso-db` + k8s-provider `SecretStore` for `postgres-operator-deployment` |
+| `db-external-secret.yaml` | ExternalSecret mirroring the postgres-operator's `harbor.postgres-shared.credentials.postgresql.acid.zalan.do` Secret into this namespace |
+| `reference-grant.yaml` | Allows Gateways in `envoy-gateway-system` to attach HTTPRoutes living in this namespace |
+| `httproute-external.yaml` | Public Registry-v2-only HTTPRoute on `harbor.shion1305.com` (`/v2/` + `/service/token`) |
+| `httproute-internal.yaml` | Internal HTTPRoutes on `harbor.i.shion1305.com` (portal + core) |
+| `configure-oidc-job.yaml` | Argo PostSync Job that PUTs `oidc_client_secret` into Harbor via `/api/v2.0/configurations` |
+
+Cluster-wide pull credential plumbing lives outside this directory:
+
+- `../harbor-pull-source/` — namespace holding the canonical `harbor-pull` dockerconfigjson Secret.
+- `../harbor-pull/` — `ClusterSecretStore` + `ClusterExternalSecret` materializing that Secret from `harbor/robot-puller`.
+- `../kyverno-policies/harbor-pull-injection.yaml` — Kyverno mutate (`imagePullSecrets`) + generate.clone (Secret fan-out) on Pod admission.
+
+The end-to-end push/pull smoketest (GHA workflow + `harbor-pull-smoketest` Job) is intentionally NOT included in this PR — it lands in a follow-up PR after Harbor is up and running.
+
+## References
+
+- Harbor docs: https://goharbor.io/docs/2.15.0/
+- Harbor Helm chart: https://github.com/goharbor/harbor-helm/tree/v1.19.0
+- Harbor OIDC config keys: `src/lib/config/metadata/manifest.go` in [goharbor/harbor](https://github.com/goharbor/harbor)
+- Keycloak realm import: `keycloak-operator/harbor-realm.yaml`
+- Postgres user/db declaration: `postgres-shared/postgres-cluster.yaml`
+- ESO policy + role: `vault/scripts/setup-eso-policies.sh` (`eso-harbor`, `eso-harbor-pull`)
+- GHA push workflow: lands in the follow-up PR (after this one merges)

--- a/harbor/configure-oidc-job.yaml
+++ b/harbor/configure-oidc-job.yaml
@@ -1,0 +1,180 @@
+# Post-sync Job that injects the OIDC client secret into Harbor.
+#
+# WHY THIS JOB EXISTS
+# -------------------
+# The Harbor chart's `core.configureUserSettings` value is rendered into the
+# `CONFIG_OVERWRITE_JSON` env var on the core Deployment and is parsed by
+# Harbor as plain JSON — there is NO `$VAR` interpolation. Anything that looks
+# like an env reference (e.g. `$HARBOR_OIDC_CLIENT_SECRET`) would be stored
+# verbatim in the DB. Therefore the OIDC client secret cannot live in
+# committed values.yaml.
+#
+# Instead:
+#   1. values.yaml seeds every OIDC setting EXCEPT `oidc_client_secret` via
+#      `configureUserSettings`. Harbor reapplies these on every core start
+#      (seed-and-pin).
+#   2. After first sync, this Job authenticates as the built-in `admin` user
+#      (the `harbor-admin-password` Secret) and PUTs `oidc_client_secret`
+#      from the `harbor-oidc-credentials` Secret to Harbor's
+#      `/api/v2.0/configurations` endpoint. Harbor encrypts the value with
+#      its AES key (`harbor-secret-key`) and stores it in the `properties`
+#      table.
+#   3. The Job is annotated `argocd.argoproj.io/hook: PostSync` so ArgoCD
+#      runs it after the rest of the application materialises. It is
+#      idempotent — re-running it just re-PUTs the same value, which is a
+#      no-op for Harbor.
+#
+# ROTATION
+# --------
+# To rotate the client secret: update `harbor/openid-credentials` in Vault,
+# wait for ESO refresh (5m), then delete this Job (`kubectl delete job
+# -n harbor harbor-configure-oidc`) so ArgoCD re-runs it on next sync.
+# Or trigger an out-of-band re-sync of the harbor-app to force the hook.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: harbor-configure-oidc
+  namespace: harbor
+# The Pod doesn't talk to the kube-apiserver — only to harbor-core via the
+# in-cluster Service. We disable token automount on the Pod side, but we
+# also make sure the SA itself doesn't auto-mount.
+automountServiceAccountToken: false
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: harbor-configure-oidc
+  namespace: harbor
+  annotations:
+    # PostSync runs after the main application's resources have been applied
+    # AND reported healthy. That guarantees harbor-core is up before the Job
+    # starts hitting the API.
+    argocd.argoproj.io/hook: PostSync
+    # BeforeHookCreation deletes the previous Job (if any) right before
+    # creating a new one on each sync, so re-syncing the harbor app re-runs
+    # the OIDC config push idempotently. We deliberately do NOT use
+    # HookSucceeded — that would delete the Job (and its logs) the moment
+    # it succeeds, which makes troubleshooting a borderline-failed PUT much
+    # harder.
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  ttlSecondsAfterFinished: 86400
+  backoffLimit: 6
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: harbor-configure-oidc
+    spec:
+      serviceAccountName: harbor-configure-oidc
+      automountServiceAccountToken: false
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: configure-oidc
+          # Digest-pinned to defeat tag-mutation supply-chain attacks. Update
+          # both tag and digest together. (alpine/curl 8.17.0 amd64+arm64.)
+          image: alpine/curl:8.17.0@sha256:9705b37f23afbca210481a6ed5d4c1c22c9322ea4c300cd4f28f270eea2cc89d
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: HARBOR_URL
+              # In-cluster Service URL of the core component. Avoids the
+              # external Gateway and any TLS dependency.
+              # NOTE: this name resolves to "harbor-core" because the Argo
+              # Application name is `harbor` (Helm release name = `harbor`).
+              # If the Application is ever renamed, the chart's
+              # `harbor.fullname` helper will produce a different prefix and
+              # this Service URL will break — keep them in sync.
+              value: http://harbor-core.harbor.svc.cluster.local
+            - name: HARBOR_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: harbor-admin-password
+                  key: HARBOR_ADMIN_PASSWORD
+            - name: OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: harbor-oidc-credentials
+                  key: client-secret
+          volumeMounts:
+            # readOnlyRootFilesystem requires a writable scratch dir for the
+            # request body and response.
+            - name: scratch
+              mountPath: /tmp
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+
+              # Wait for harbor-core to accept API calls. PostSync should
+              # already imply readiness, but a short retry loop costs almost
+              # nothing and avoids brittle race conditions on first sync.
+              echo "Waiting for harbor-core to be ready..."
+              for i in $(seq 1 60); do
+                if curl -fsS -o /dev/null \
+                     -u "admin:${HARBOR_ADMIN_PASSWORD}" \
+                     "${HARBOR_URL}/api/v2.0/configurations"; then
+                  echo "harbor-core is ready"
+                  break
+                fi
+                echo "attempt ${i}/60 — sleeping 5s"
+                sleep 5
+              done
+
+              # PUT only the OIDC client secret. Every other OIDC setting is
+              # already managed by `core.configureUserSettings` (seeded on
+              # each core start), so we touch the absolute minimum here.
+              #
+              # Body is built with `printf` into a temp file rather than an
+              # inline heredoc — sh heredoc terminators must sit at column 0,
+              # and YAML's literal-block indent makes that error-prone. Using
+              # a temp file is also more robust to special characters in the
+              # secret (Keycloak client secrets are normally [A-Za-z0-9_-]+,
+              # but we avoid relying on that assumption).
+              echo "Setting oidc_client_secret via Harbor API..."
+              umask 077
+              printf '{"oidc_client_secret":"%s"}' "${OIDC_CLIENT_SECRET}" > /tmp/body.json
+              http_status=$(curl -sS -o /tmp/resp -w '%{http_code}' \
+                -X PUT \
+                -u "admin:${HARBOR_ADMIN_PASSWORD}" \
+                -H 'Content-Type: application/json' \
+                --data-binary @/tmp/body.json \
+                "${HARBOR_URL}/api/v2.0/configurations")
+
+              # Wipe the body before doing anything else — guarantees the
+              # cleartext secret is unrecoverable from the scratch volume
+              # even if the Pod is paused / inspected post-failure.
+              rm -f /tmp/body.json
+
+              if [ "${http_status}" != "200" ]; then
+                # NEVER print /tmp/resp directly — Harbor's 4xx responses can
+                # echo offending field VALUES (including secrets) back in the
+                # error body. Strip any token-like substrings before
+                # surfacing. We use a conservative redactor: anything
+                # resembling a JSON value paired with a sensitive-looking
+                # key gets replaced with REDACTED.
+                echo "Harbor API returned HTTP ${http_status}; sanitised body:"
+                sed -E 's/("(oidc_client_secret|password|secret|token)"[[:space:]]*:[[:space:]]*)"[^"]*"/\1"REDACTED"/g' /tmp/resp || true
+                echo
+                rm -f /tmp/resp
+                exit 1
+              fi
+              rm -f /tmp/resp
+              echo "OIDC client secret configured successfully"
+      volumes:
+        - name: scratch
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Mi

--- a/harbor/db-external-secret.yaml
+++ b/harbor/db-external-secret.yaml
@@ -1,0 +1,38 @@
+# The Zalando postgres-operator generates the database user `harbor`
+# automatically when `harbor: []` is added to the `users:` block of the
+# `postgres-shared` cluster manifest (postgres-cluster.yaml). On user
+# creation the operator materializes a Kubernetes Secret named per its
+# convention `<user>.<cluster>.credentials.postgresql.acid.zalan.do` in
+# the operator's namespace (`postgres-operator-deployment`).
+#
+# This ExternalSecret uses ESO's k8s provider (see db-secret-store.yaml)
+# to mirror that Secret into the `harbor` namespace as
+# `harbor-db-credentials`, which Harbor's chart reads via existingSecret
+# references for the external database connection.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: harbor-db-credentials
+  namespace: harbor
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: k8s-postgres
+    kind: SecretStore
+  target:
+    name: harbor-db-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+  data:
+    - secretKey: username
+      remoteRef:
+        key: harbor.postgres-shared.credentials.postgresql.acid.zalan.do
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: harbor.postgres-shared.credentials.postgresql.acid.zalan.do
+        property: password

--- a/harbor/db-secret-store.yaml
+++ b/harbor/db-secret-store.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso-db
+  namespace: harbor
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: k8s-postgres
+  namespace: harbor
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: postgres-operator-deployment
+      server:
+        url: "https://kubernetes.default.svc"
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: eso-db

--- a/harbor/external-secret.yaml
+++ b/harbor/external-secret.yaml
@@ -1,0 +1,152 @@
+# Vault path `harbor/` is a separate KV v2 mount that must be enabled manually
+# before first sync:
+#
+#   vault secrets enable -path=harbor kv-v2
+#
+# This mount holds four distinct paths, each materialized into its own
+# Kubernetes Secret in the `harbor` namespace via the ExternalSecrets below:
+#
+#   - harbor/openid-credentials
+#       field `keycloak-credentials.json` is a JSON blob
+#       {"clientid":"harbor-ui","clientsecret":"..."} for the Keycloak
+#       `harbor-ui` confidential client. Consumed by Harbor core for OIDC
+#       login.
+#
+#   - harbor/admin-password
+#       field `password` holds the bootstrap password for the built-in
+#       `admin` user. Harbor's chart accepts an `existingSecret` reference
+#       so we don't have to put the value in values.yaml.
+#
+#   - harbor/secret-key
+#       field `secretKey` holds the AES key Harbor uses to encrypt OIDC
+#       refresh tokens and registry credentials at rest in its database.
+#       MUST be exactly 16 characters; rotating it invalidates all stored
+#       encrypted blobs, so treat as long-lived.
+#
+#   - harbor/core-secret
+#       field `secret` is used by Harbor core to authenticate inter-component
+#       calls (jobservice, registry, etc.). The chart can auto-generate it,
+#       but we keep it in Vault so rotations are deliberate and auditable.
+#
+# Why `existingSecret` references instead of letting the chart auto-generate
+# these values:
+#
+#   1. Idempotency on chart upgrades — Helm-generated lookup values can churn
+#      if the release is recreated, breaking sessions and encrypted columns.
+#   2. Audit trail — every value lives in Vault with version history; we can
+#      see who wrote what and when.
+#   3. No Helm secret leaks — values.yaml stays in git without any sensitive
+#      material; the chart only ever sees Secret references.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: harbor-oidc-credentials
+  namespace: harbor
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  target:
+    name: harbor-oidc-credentials
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+      data:
+        client-id: '{{ ( .credentials | fromJson ).clientid }}'
+        client-secret: '{{ ( .credentials | fromJson ).clientsecret }}'
+  data:
+    - secretKey: credentials
+      remoteRef:
+        key: openid-credentials
+        property: keycloak-credentials.json
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: harbor-admin-password
+  namespace: harbor
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  target:
+    name: harbor-admin-password
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+  data:
+    - secretKey: HARBOR_ADMIN_PASSWORD
+      remoteRef:
+        key: admin-password
+        property: password
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: harbor-secret-key
+  namespace: harbor
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  target:
+    name: harbor-secret-key
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+      data:
+        # Harbor's AES key MUST be exactly 16 bytes — the encryption code
+        # path has no fallback and panics on any other length, leaving the
+        # core pod CrashLooping with an unhelpful error. ESO's Sprig
+        # template language (engineVersion: v2 above) gives us a hard-fail
+        # at sync time so a misconfigured Vault entry never reaches the
+        # cluster. `len` returns byte length for non-UTF-8-aware Go
+        # strings, which is exactly what Harbor checks.
+        secretKey: |-
+          {{- if ne (len .secretKey) 16 -}}
+          {{- fail (printf "harbor-secret-key must be exactly 16 bytes, got %d" (len .secretKey)) -}}
+          {{- end -}}
+          {{ .secretKey }}
+  data:
+    - secretKey: secretKey
+      remoteRef:
+        key: secret-key
+        property: secretKey
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: harbor-core-secret
+  namespace: harbor
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  target:
+    name: harbor-core-secret
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+  data:
+    - secretKey: secret
+      remoteRef:
+        key: core-secret
+        property: secret

--- a/harbor/httproute-external.yaml
+++ b/harbor/httproute-external.yaml
@@ -1,0 +1,69 @@
+# Public Harbor URL — Docker Registry v2 protocol only.
+#
+# The only intended callers we expose externally are GitHub Actions runners
+# pushing OCI images via `crane` or `docker push`. There is intentionally NO
+# portal (SPA), NO `/api/`, NO `/c/` (OIDC), and NO admin surface on this
+# hostname — only the Registry v2 wire protocol.
+#
+# IMPORTANT — pull surface honesty:
+#   The `/v2/` PathPrefix below cannot distinguish push from pull at the path
+#   level. `docker pull` and `docker push` use the same `/v2/<repo>/...`
+#   namespace, with the only difference being HTTP verb (GET vs POST/PATCH/PUT).
+#   So in practice this route ALSO serves pulls, and any project flagged
+#   `public` in the Harbor portal is world-readable on this hostname WITHOUT
+#   credentials. Treat project visibility as the access-control boundary:
+#     - Default-private all projects (Harbor's chart default).
+#     - Restrict project creation to admins (system setting
+#       `project_creation_restriction=adminonly`).
+#     - Audit project visibility regularly; flipping a project to public
+#       publishes its contents on the public internet.
+#   Pull from inside the cluster is the supported flow: the kubelet resolves
+#   harbor.i.shion1305.com (WireGuard-only A record) and pulls from harbor-core
+#   via the internal HTTPRoute. External pull is incidental, not a feature.
+#
+# Why this split keeps attack surface small:
+#   - No admin UI, no `/api/`, no `/c/` on the public internet. A leaked robot
+#     token is the worst case here, not a compromised admin session.
+#   - Avoids any need for an Envoy SecurityPolicy.oidc on this Gateway. Harbor
+#     handles its own OIDC internally on the portal route (see
+#     httproute-internal.yaml); the public route never touches a browser, so
+#     there is nothing to mediate.
+#
+# Single HTTPRoute, two matches, both routed to harbor-core:80:
+#
+#   /v2/ (PathPrefix) — the Docker Registry v2 protocol surface: HEAD/GET/PUT
+#     manifests, POST/PATCH/PUT blob uploads, GET blobs (used by both push
+#     cross-repo mounts and pulls).
+#
+#   /service/token (Exact) — Harbor's Registry v2 token endpoint. The Docker
+#     daemon and crane hit this automatically after a 401 from /v2/ with
+#     `Www-Authenticate: Bearer realm=...`. Without this match the bearer
+#     challenge would dead-end at the gateway and pushes would fail before
+#     any blob is uploaded.
+#
+# Note: the Harbor chart 1.19.0 splits the SPA from the API across two
+# Services. /v2/ and /service/token are core endpoints, hence harbor-core. The
+# harbor-portal Service is intentionally not referenced from this file.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: harbor-push-external
+  namespace: harbor
+spec:
+  parentRefs:
+    - name: external
+      namespace: envoy-gateway-system
+      sectionName: https
+  hostnames:
+    - harbor.shion1305.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v2/
+        - path:
+            type: Exact
+            value: /service/token
+      backendRefs:
+        - name: harbor-core
+          port: 80

--- a/harbor/httproute-internal.yaml
+++ b/harbor/httproute-internal.yaml
@@ -1,0 +1,92 @@
+# Internal Harbor URL — reachable only via WireGuard (the *.i.shion1305.com
+# DNS A record points to 10.130.5.21). This is the FULL-ACCESS hostname:
+# browser portal (SPA), OIDC code-flow callback, push, pull, robot-account
+# auth, admin API — everything Harbor exposes lives here.
+#
+# Harbor chart 1.19.0 splits the SPA bundle from the API across two Services,
+# so we need two HTTPRoutes on the same hostname:
+#
+#   harbor-portal-internal — `/` PathPrefix → harbor-portal:80. Serves the
+#     SPA bundle (HTML/JS/CSS). The portal Service has no API endpoints; it
+#     is purely the static frontend.
+#
+#   harbor-core-internal — five PathPrefixes → harbor-core:80:
+#       /api/      — Harbor's REST API (projects, repos, robots, etc.).
+#       /service/  — Registry v2 token endpoint and related auth services.
+#       /v2/       — Docker Registry v2 protocol (push/pull/blobs/manifests).
+#       /c/        — Harbor controller endpoints, including
+#                    /c/oidc/callback (the OIDC redirect target — see below).
+#       /chartrepo/— Helm chartmuseum-compatible chart repo endpoints.
+#
+# Routing precedence (Gateway API GEP-718 most-specific-path-wins): even
+# though `/` PathPrefix in harbor-portal-internal would match every request
+# on this hostname, the longer prefixes in harbor-core-internal (/api/,
+# /service/, /v2/, /c/, /chartrepo/) automatically win for those paths. So a
+# browser GET `/` lands on the portal, while a fetch to `/api/v2.0/projects`
+# from the same SPA lands on harbor-core. No explicit ordering is needed.
+#
+# OIDC: Harbor handles OIDC entirely inside its own application — there is
+# NO Envoy SecurityPolicy.oidc attached to these routes (this is a deliberate
+# departure from the zot setup, where Envoy is the OIDC mediator because zot's
+# UI doesn't speak OIDC directly). Harbor's portal redirects unauthenticated
+# browsers through the harbor-ui Keycloak client, receives the auth-code on
+# /c/oidc/callback, and stamps its own session cookie. The HTTPRoutes here
+# are pure path → backend plumbing; auth is upstream's concern.
+#
+# Why no explicit /oauth2/ match: the Keycloak client's redirect-URI lands at
+# /c/oidc/callback, which already falls under the /c/ PathPrefix routed to
+# harbor-core. Adding /oauth2/ would be a no-op because Harbor doesn't expose
+# anything at that path.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: harbor-portal-internal
+  namespace: harbor
+spec:
+  parentRefs:
+    - name: internal
+      namespace: envoy-gateway-system
+      sectionName: https
+  hostnames:
+    - harbor.i.shion1305.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: harbor-portal
+          port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: harbor-core-internal
+  namespace: harbor
+spec:
+  parentRefs:
+    - name: internal
+      namespace: envoy-gateway-system
+      sectionName: https
+  hostnames:
+    - harbor.i.shion1305.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/
+        - path:
+            type: PathPrefix
+            value: /service/
+        - path:
+            type: PathPrefix
+            value: /v2/
+        - path:
+            type: PathPrefix
+            value: /c/
+        - path:
+            type: PathPrefix
+            value: /chartrepo/
+      backendRefs:
+        - name: harbor-core
+          port: 80

--- a/harbor/kustomization.yaml
+++ b/harbor/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - secret-store.yaml
+  - external-secret.yaml
+  - db-secret-store.yaml
+  - db-external-secret.yaml
+  - reference-grant.yaml
+  - httproute-external.yaml
+  - httproute-internal.yaml
+  - configure-oidc-job.yaml

--- a/harbor/reference-grant.yaml
+++ b/harbor/reference-grant.yaml
@@ -1,0 +1,14 @@
+# Allows Gateways in envoy-gateway-system to attach HTTPRoutes living in the harbor namespace.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-envoy-gateway
+  namespace: harbor
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: envoy-gateway-system
+  to:
+    - group: ""
+      kind: Service

--- a/harbor/secret-store.yaml
+++ b/harbor/secret-store.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso
+  namespace: harbor
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: vault
+  namespace: harbor
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "harbor"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "eso-harbor"
+          serviceAccountRef:
+            name: "eso"

--- a/harbor/values.yaml
+++ b/harbor/values.yaml
@@ -1,0 +1,234 @@
+# Harbor Helm chart values
+# Chart: harbor (https://helm.goharbor.io), version 1.19.0, appVersion 2.15.0.
+#
+# This deployment replaces the previous zot registry. Harbor was chosen because
+# its OIDC integration is application-native (no Envoy SecurityPolicy mediation
+# required) and its robot-account model is the supported way to authenticate
+# kubelet pulls and CI pushes — both of which were brittle on zot's
+# Keycloak-token-exchange model.
+#
+# See harbor/README.md for the full architecture, bootstrap order, and
+# day-2 operational runbook.
+
+# -----------------------------------------------------------------------------
+# expose / TLS
+# -----------------------------------------------------------------------------
+# `expose.type=clusterIP` is the chart's "no ingress / no LoadBalancer" mode.
+# We do NOT use the chart-rendered nginx fronting Service or HTTPRoute — those
+# would conflict with the Envoy Gateway-attached HTTPRoutes in
+# harbor/httproute-external.yaml and harbor/httproute-internal.yaml, which
+# target the per-component Services `harbor-core` and `harbor-portal` directly.
+#
+# `tls.enabled=false` disables in-cluster TLS plumbing. Envoy Gateway handles
+# TLS termination at the edge; cluster-internal traffic between Envoy and
+# Harbor pods is plaintext (`internalTLS.enabled: false` below reinforces this).
+expose:
+  type: clusterIP
+  tls:
+    enabled: false
+    certSource: none
+  clusterIP:
+    name: harbor
+    ports:
+      httpPort: 80
+      httpsPort: 443
+
+# -----------------------------------------------------------------------------
+# externalURL — single source of truth for OIDC redirect_uri and embedded URLs
+# -----------------------------------------------------------------------------
+# Set to the INTERNAL hostname even though pushes also arrive on the public
+# hostname. Reasoning (verified against Harbor v2.15.0 source code):
+#
+#   - `tokenSvcURL` (src/server/middleware/v2auth/auth.go) builds the /v2/ 401
+#     `Www-Authenticate: Bearer realm=...` value from `req.Host`, NOT from
+#     externalURL. So a `docker push harbor.shion1305.com/...` always gets
+#     `realm="https://harbor.shion1305.com/service/token"` regardless of this
+#     setting — pushes work via the public hostname.
+#
+#   - OIDC `redirect_uri` (src/lib/config/userconfig.go:164,176) IS hard-bound
+#     to externalURL with no per-request override. Setting this to the public
+#     host would send browsers to https://harbor.shion1305.com/c/oidc/callback,
+#     which (a) breaks session/cookie binding (browser is on the .i. host),
+#     and (b) requires exposing /c/ externally — which is undesirable.
+#
+# Therefore: externalURL=internal-only-host. Push handshake works because
+# /service/token is exposed externally (httproute-external.yaml). OIDC works
+# because redirect_uri stays on the internal host.
+externalURL: https://harbor.i.shion1305.com
+
+# -----------------------------------------------------------------------------
+# persistence
+# -----------------------------------------------------------------------------
+persistence:
+  enabled: true
+  resourcePolicy: keep
+  persistentVolumeClaim:
+    registry:
+      storageClass: longhorn
+      accessMode: ReadWriteOnce
+      size: 200Gi
+    jobservice:
+      jobLog:
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 5Gi
+    # database: ignored — we use external PostgreSQL (postgres-shared cluster).
+    database:
+      storageClass: ""
+      size: 1Gi
+    redis:
+      storageClass: longhorn
+      accessMode: ReadWriteOnce
+      size: 5Gi
+    trivy:
+      storageClass: longhorn
+      accessMode: ReadWriteOnce
+      size: 10Gi
+  imageChartStorage:
+    type: filesystem
+    filesystem:
+      rootdirectory: /storage
+    disableredirect: false
+
+# -----------------------------------------------------------------------------
+# database — external (Zalando postgres-operator's `postgres-shared` cluster)
+# -----------------------------------------------------------------------------
+# The `harbor` user/database are created automatically by postgres-operator
+# (declared in postgres-shared/postgres-cluster.yaml). The operator-generated
+# password Secret in `postgres-operator-deployment` is mirrored into the
+# `harbor` namespace as `harbor-db-credentials` by ESO's k8s provider
+# (harbor/db-external-secret.yaml). The chart's `existingSecret` key reads the
+# `password` key from that Secret.
+database:
+  type: external
+  external:
+    host: postgres-shared.postgres-operator-deployment.svc.cluster.local
+    port: "5432"
+    username: harbor
+    coreDatabase: harbor
+    sslmode: disable
+    existingSecret: harbor-db-credentials
+  maxIdleConns: 100
+  maxOpenConns: 900
+
+# -----------------------------------------------------------------------------
+# redis — internal (chart-bundled), single replica
+# -----------------------------------------------------------------------------
+redis:
+  type: internal
+
+# -----------------------------------------------------------------------------
+# Harbor admin password — sourced from Vault via ESO
+# -----------------------------------------------------------------------------
+# Built-in `admin` account password materialised from Vault path
+# `harbor/admin-password` (harbor/external-secret.yaml). Used mainly during
+# first-time bootstrap before OIDC is wired up. The chart's plain-text
+# `harborAdminPassword` value is ignored when `existingSecretAdminPassword`
+# is set, so it is omitted here.
+existingSecretAdminPassword: harbor-admin-password
+existingSecretAdminPasswordKey: HARBOR_ADMIN_PASSWORD
+
+# -----------------------------------------------------------------------------
+# secret keys — sourced from Vault via ESO
+# -----------------------------------------------------------------------------
+# - existingSecretSecretKey: the AES key Harbor uses to encrypt OIDC refresh
+#   tokens and registry credentials at rest in its DB. MUST be exactly 16 chars;
+#   rotating invalidates all stored encrypted blobs. Materialised from Vault
+#   path `harbor/secret-key` field `secretKey`.
+# - core.existingSecret / core.secretName: Harbor core's inter-component auth
+#   secret. Materialised from Vault path `harbor/core-secret` field `secret`.
+existingSecretSecretKey: harbor-secret-key
+
+# -----------------------------------------------------------------------------
+# internal TLS — disabled (TLS terminated at Envoy Gateway)
+# -----------------------------------------------------------------------------
+internalTLS:
+  enabled: false
+
+# -----------------------------------------------------------------------------
+# core / portal / registry / jobservice / trivy / exporter
+# -----------------------------------------------------------------------------
+# `configureUserSettings` is rendered into the `CONFIG_OVERWRITE_JSON` env on
+# the core Deployment. Harbor reads it on EVERY startup and overwrites matching
+# keys in the `properties` table — so this is a true seed-and-pin mechanism,
+# not first-boot-only. Value MUST be a JSON STRING — Harbor parses it with
+# `encoding/json` directly. There is NO `$VAR` interpolation: anything looking
+# like an env reference would be stored verbatim in the DB.
+#
+# That is why `oidc_client_secret` is intentionally absent from this JSON: a
+# secret value cannot live in committed YAML. The OIDC client secret is set
+# AFTER first sync by the post-sync Job in harbor/configure-oidc-job.yaml,
+# which calls Harbor's `PUT /api/v2.0/configurations` with the value mounted
+# from the `harbor-oidc-credentials` Secret. All other OIDC settings here are
+# safe in git and serve as the seed-and-pin source of truth.
+#
+# OIDC settings (declarative, seeded on every core start):
+#   - oidc_endpoint:  Keycloak realm `harbor` issuer
+#   - oidc_client_id: `harbor-ui` (matches the client in keycloak-operator/harbor-realm.yaml)
+#   - oidc_groups_claim=groups — Harbor reads project-level RBAC from the
+#       `groups` claim emitted by the harbor-ui client's group-membership
+#       protocol mapper.
+#   - oidc_admin_group=harbor-admin — members of this Keycloak group get
+#       Harbor admin privileges automatically on first login.
+#   - oidc_auto_onboard=true — first-time OIDC users are created in Harbor
+#       without an explicit admin invite. Trust boundary is the Keycloak
+#       `user` realm (passkey-only).
+#   - oidc_user_claim=preferred_username — uses Keycloak's username (matches
+#       user-realm passkey-bound usernames brokered through the user IdP).
+core:
+  replicas: 1
+  existingSecret: harbor-core-secret
+  configureUserSettings: |
+    {
+      "auth_mode": "oidc_auth",
+      "oidc_name": "keycloak",
+      "oidc_endpoint": "https://keycloak.shion1305.com/realms/harbor",
+      "oidc_client_id": "harbor-ui",
+      "oidc_scope": "openid,profile,email,groups",
+      "oidc_verify_cert": "true",
+      "oidc_auto_onboard": "true",
+      "oidc_user_claim": "preferred_username",
+      "oidc_groups_claim": "groups",
+      "oidc_admin_group": "harbor-admin",
+      "oidc_extra_redirect_parms": "{}"
+    }
+
+portal:
+  replicas: 1
+
+registry:
+  # If you see absolute http:// (not https://) URLs in pushed manifests'
+  # Location headers, set this to true so the registry emits relative URLs and
+  # lets the gateway resolve scheme/host. Not currently needed because Harbor
+  # uses externalURL for those, and externalURL is https://.
+  relativeurls: false
+
+trivy:
+  enabled: true
+  replicas: 1
+
+exporter:
+  enabled: true
+
+# -----------------------------------------------------------------------------
+# metrics — Prometheus /metrics + ServiceMonitor (kube-prometheus-stack)
+# -----------------------------------------------------------------------------
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    additionalLabels:
+      release: kube-prometheus-stack
+
+# -----------------------------------------------------------------------------
+# logging
+# -----------------------------------------------------------------------------
+logLevel: info
+
+# -----------------------------------------------------------------------------
+# trace / cache — leave default
+# -----------------------------------------------------------------------------
+trace:
+  enabled: false
+cache:
+  enabled: false

--- a/keycloak-operator/harbor-realm.yaml
+++ b/keycloak-operator/harbor-realm.yaml
@@ -1,0 +1,406 @@
+# =============================================================================
+# Keycloak Realm Import: harbor
+# =============================================================================
+#
+# This file is reconciled by the Keycloak Operator (KeycloakRealmImport CRD).
+# It declares the `harbor` realm used to authenticate human users to the
+# Harbor OCI registry's portal:
+#   - Browser login flow is handled by Harbor itself. When a user hits the
+#     portal, Harbor's `core` component runs the Authorization Code flow
+#     against this realm using the `harbor-ui` confidential client below.
+#     Harbor stores its OIDC settings in its own Postgres DB (seeded by the
+#     Helm chart's `core.configureUserSettings` env on first start), NOT
+#     via Envoy Gateway's SecurityPolicy.oidc. So unlike zot, there is no
+#     Envoy OIDC layer in front of Harbor for browser auth — Harbor speaks
+#     OIDC natively and just needs a working realm + client to point at.
+#   - Authorization is driven by the `groups` claim Harbor maps onto its
+#     internal projects (Harbor's `oidc_groups_claim=groups` setting reads
+#     from the same `groups` scope declared below).
+#
+# Machine pulls do NOT pass through Keycloak. Harbor uses long-lived
+# **robot accounts** — static credentials minted via Harbor's own API and
+# scoped to specific projects — for kubelet `imagePullSecrets` and for
+# GitHub Actions push/pull. There is no `cluster-puller`-equivalent client
+# in this realm because the kubelet would need a refresh path Keycloak
+# cannot give it cheaply, and Harbor's robot accounts solve the same
+# problem natively. Likewise there is no `harbor-registry` audience-target
+# client: Harbor's OIDC integration uses a single confidential client and
+# validates inbound tokens by `client_id`, not by an `aud` claim, so the
+# audience-mapper indirection used in the zot realm is unnecessary.
+#
+# External portal access is intentionally not exposed. The public hostname
+# `harbor.shion1305.com` only serves the docker registry endpoints
+# (`/v2/`, `/service/token`) for push/pull from the public internet; the
+# SPA portal and the OIDC callback are reachable ONLY at
+# `harbor.i.shion1305.com` (WireGuard-only). The single `redirectUris`
+# entry below reflects this — there is no second internet-facing redirect
+# URI to add.
+#
+# -----------------------------------------------------------------------------
+# Manual post-import steps (one-time, after first successful sync):
+# -----------------------------------------------------------------------------
+# 1. Retrieve the auto-generated client secret for the `harbor-ui` client
+#    from the Keycloak admin UI:
+#      https://keycloak.shion1305.com -> realm `harbor` -> Clients -> harbor-ui
+#      -> Credentials -> "Client secret".
+#    The placeholder `PLACEHOLDER_REPLACE_AFTER_REALM_IMPORT` declared below is
+#    overwritten by Keycloak on first import; subsequent reconciles do not
+#    re-apply the placeholder. Persist the value into Vault so ESO can
+#    project it onto the Secret Harbor's `core` reads at startup:
+#      vault kv put harbor/openid-credentials \
+#        keycloak-credentials.json='{"clientid":"harbor-ui","clientsecret":"<harbor-ui-secret>"}'
+#
+# 2. Retrieve the auto-generated client secret for the `harbor-broker`
+#    Identity Provider. Broker IdPs implicitly create a service-account
+#    client in the brokered (`user`) realm; its secret is shown under:
+#      realm `harbor` -> Identity Providers -> user -> Settings -> Client Secret.
+#    Persist into Vault:
+#      vault kv put harbor/broker-credentials \
+#        client_id=harbor-broker \
+#        client_secret=<harbor-broker-secret>
+#
+# 3. Bind the Browser authentication flow to "Identity Provider Redirector"
+#    pinned to alias `user`, so human web logins skip the choice screen and go
+#    straight to the `user` realm (passkey-only):
+#      Authentication -> Flows -> Browser -> add "Identity Provider Redirector"
+#      execution at the top, Required, with config
+#      `Default Identity Provider = user`. Bind that flow as the realm's
+#      Browser flow. This step is not declarative on the v2alpha1 CRD.
+#
+# 4. Assign the `harbor-admin` / `harbor-developer` groups to the appropriate
+#    users (after first-broker-login from the `user` realm). This is per-user
+#    state and lives in Keycloak, not git.
+#
+# -----------------------------------------------------------------------------
+# Realm recreation (when YAML changes need to take effect):
+# -----------------------------------------------------------------------------
+# `KeycloakRealmImport` is one-shot reconcile; subsequent edits are silently
+# ignored once the realm exists. To apply changes:
+#   kubectl delete keycloakrealmimport harbor -n keycloak
+#   # admin UI: realm `harbor` -> Realm Settings -> Action -> Delete
+# ArgoCD then recreates the import CR; the operator reimports.
+# WARNING: this drops federated-identity links and group memberships for
+# every brokered user; re-run step 4 above for each affected user.
+# =============================================================================
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: KeycloakRealmImport
+metadata:
+  name: harbor
+  namespace: keycloak
+spec:
+  keycloakCRName: keycloak
+  realm:
+    realm: harbor
+    enabled: true
+    registrationAllowed: false
+    # `external` = HTTPS required for any non-loopback request. Cluster-internal
+    # plaintext (Pod IP, ClusterIP) still satisfies this because traffic is TLS-
+    # terminated at Envoy Gateway and the `xforwarded` proxy headers config on
+    # the Keycloak CR makes Keycloak treat `X-Forwarded-Proto: https` requests
+    # as HTTPS.
+    sslRequired: external
+
+    # -------------------------------------------------------------------------
+    # Realm roles. Harbor's project-level RBAC keys off the `groups` claim in
+    # the JWT (groups carry their associated realmRole into the claim).
+    # -------------------------------------------------------------------------
+    roles:
+      realm:
+        - name: harbor-admin
+          description: Full admin (read/create/update/delete) on all projects in Harbor
+        - name: harbor-developer
+          description: Push/pull on dev projects in Harbor
+
+    # -------------------------------------------------------------------------
+    # Groups mirror the realm roles. The group-membership mapper on the
+    # `harbor-ui` client emits the group name into the JWT `groups` claim,
+    # which Harbor's `oidc_groups_claim=groups` setting reads to drive
+    # project-level RBAC.
+    # -------------------------------------------------------------------------
+    groups:
+      - name: harbor-admin
+        realmRoles:
+          - harbor-admin
+      - name: harbor-developer
+        realmRoles:
+          - harbor-developer
+
+    # -------------------------------------------------------------------------
+    # Client scopes
+    # -------------------------------------------------------------------------
+    # When a realm is imported with a non-empty `clientScopes` list, Keycloak
+    # uses it as the COMPLETE set of scopes for the realm and skips the
+    # auto-seeded built-ins. So we have to declare every scope we want -- both
+    # the OIDC built-ins (`profile`, `email`, `roles`, `web-origins`, `acr`,
+    # `basic`) and our custom `groups`.
+    defaultDefaultClientScopes:
+      - basic
+      - profile
+      - email
+      - roles
+      - web-origins
+      - acr
+      - groups
+    defaultOptionalClientScopes: []
+    clientScopes:
+      - name: basic
+        description: "OpenID Connect scope for add all basic claims to the token"
+        protocol: openid-connect
+        attributes:
+          include.in.token.scope: "false"
+          display.on.consent.screen: "false"
+        protocolMappers:
+          - name: sub
+            protocol: openid-connect
+            protocolMapper: oidc-sub-mapper
+            config:
+              access.token.claim: "true"
+              introspection.token.claim: "true"
+          - name: auth_time
+            protocol: openid-connect
+            protocolMapper: oidc-usersessionmodel-note-mapper
+            config:
+              user.session.note: "AUTH_TIME"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              introspection.token.claim: "true"
+              claim.name: "auth_time"
+              jsonType.label: "long"
+
+      - name: profile
+        description: "OpenID Connect built-in scope: profile"
+        protocol: openid-connect
+        attributes:
+          include.in.token.scope: "true"
+          display.on.consent.screen: "true"
+          consent.screen.text: "${profileScopeConsentText}"
+        protocolMappers:
+          - name: full name
+            protocol: openid-connect
+            protocolMapper: oidc-full-name-mapper
+            config:
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+              introspection.token.claim: "true"
+          - name: family name
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            config:
+              user.attribute: "lastName"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+              introspection.token.claim: "true"
+              claim.name: "family_name"
+              jsonType.label: "String"
+          - name: given name
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            config:
+              user.attribute: "firstName"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+              introspection.token.claim: "true"
+              claim.name: "given_name"
+              jsonType.label: "String"
+          - name: username
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            config:
+              user.attribute: "username"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+              introspection.token.claim: "true"
+              claim.name: "preferred_username"
+              jsonType.label: "String"
+          - name: locale
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            config:
+              user.attribute: "locale"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+              introspection.token.claim: "true"
+              claim.name: "locale"
+              jsonType.label: "String"
+
+      - name: email
+        description: "OpenID Connect built-in scope: email"
+        protocol: openid-connect
+        attributes:
+          include.in.token.scope: "true"
+          display.on.consent.screen: "true"
+          consent.screen.text: "${emailScopeConsentText}"
+        protocolMappers:
+          - name: email
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-attribute-mapper
+            config:
+              user.attribute: "email"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+              introspection.token.claim: "true"
+              claim.name: "email"
+              jsonType.label: "String"
+          - name: email verified
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-property-mapper
+            config:
+              user.attribute: "emailVerified"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+              introspection.token.claim: "true"
+              claim.name: "email_verified"
+              jsonType.label: "boolean"
+
+      - name: roles
+        description: "OpenID Connect scope for add user roles to the access token"
+        protocol: openid-connect
+        attributes:
+          include.in.token.scope: "false"
+          display.on.consent.screen: "true"
+          consent.screen.text: "${rolesScopeConsentText}"
+        protocolMappers:
+          - name: realm roles
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-realm-role-mapper
+            config:
+              multivalued: "true"
+              access.token.claim: "true"
+              introspection.token.claim: "true"
+              claim.name: "realm_access.roles"
+              jsonType.label: "String"
+          - name: client roles
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-client-role-mapper
+            config:
+              multivalued: "true"
+              access.token.claim: "true"
+              introspection.token.claim: "true"
+              claim.name: "resource_access.${client_id}.roles"
+              jsonType.label: "String"
+          - name: audience resolve
+            protocol: openid-connect
+            protocolMapper: oidc-audience-resolve-mapper
+            config:
+              access.token.claim: "true"
+              introspection.token.claim: "true"
+
+      - name: web-origins
+        description: "OpenID Connect scope for add allowed web origins to the access token"
+        protocol: openid-connect
+        attributes:
+          include.in.token.scope: "false"
+          display.on.consent.screen: "false"
+          consent.screen.text: ""
+        protocolMappers:
+          - name: allowed web origins
+            protocol: openid-connect
+            protocolMapper: oidc-allowed-origins-mapper
+            config:
+              access.token.claim: "true"
+              introspection.token.claim: "true"
+
+      - name: acr
+        description: "OpenID Connect scope for add acr (authentication context class reference) to the token"
+        protocol: openid-connect
+        attributes:
+          include.in.token.scope: "false"
+          display.on.consent.screen: "false"
+        protocolMappers:
+          - name: acr loa level
+            protocol: openid-connect
+            protocolMapper: oidc-acr-mapper
+            config:
+              id.token.claim: "true"
+              access.token.claim: "true"
+              introspection.token.claim: "true"
+
+      - name: groups
+        description: Group memberships claim
+        protocol: openid-connect
+        attributes:
+          include.in.token.scope: "true"
+          display.on.consent.screen: "false"
+
+    # -------------------------------------------------------------------------
+    # Clients
+    # -------------------------------------------------------------------------
+    clients:
+      # harbor-ui: confidential client driven by Harbor's `core` component.
+      # Harbor runs the Authorization Code flow itself (no Envoy OIDC layer)
+      # using OIDC settings stored in its own DB and seeded from Vault via
+      # the Helm chart's `core.configureUserSettings` env on first start.
+      # Harbor authorizes by the `groups` claim (oidc_groups_claim=groups)
+      # which maps onto its internal projects.
+      #
+      # Single redirect URI / web origin: external portal access is NOT
+      # exposed (only push/pull endpoints serve `harbor.shion1305.com`);
+      # only `harbor.i.shion1305.com` (WireGuard-only) hosts the SPA + the
+      # OIDC callback path.
+      - clientId: harbor-ui
+        protocol: openid-connect
+        publicClient: false
+        clientAuthenticatorType: client-secret
+        # Keycloak generates the real value on first import and never re-applies
+        # this placeholder. Do NOT commit the actual secret.
+        secret: PLACEHOLDER_REPLACE_AFTER_REALM_IMPORT
+        standardFlowEnabled: true
+        directAccessGrantsEnabled: false
+        serviceAccountsEnabled: false
+        redirectUris:
+          - https://harbor.i.shion1305.com/c/oidc/callback
+        webOrigins:
+          - https://harbor.i.shion1305.com
+        attributes:
+          access.token.lifespan: "3600"
+        protocolMappers:
+          # Emit `groups` claim so Harbor's `oidc_groups_claim=groups` can
+          # drive project-level RBAC. No audience mapper: Harbor validates
+          # by client_id, not by `aud`.
+          - name: groups
+            protocolMapper: oidc-group-membership-mapper
+            protocol: openid-connect
+            consentRequired: false
+            config:
+              claim.name: "groups"
+              full.path: "false"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+
+    # -------------------------------------------------------------------------
+    # Identity Providers
+    # -------------------------------------------------------------------------
+    # Browser-flow IdP redirector binding (manual step #3 in the header) routes
+    # human web logins through the `user` realm (passkey-only) without showing
+    # a choice screen.
+    identityProviders:
+      - alias: user
+        displayName: "Sign in with passkey"
+        providerId: keycloak-oidc
+        enabled: true
+        storeToken: false
+        addReadTokenRoleOnCreate: false
+        trustEmail: true
+        firstBrokerLoginFlowAlias: "first broker login"
+        config:
+          issuer: "https://keycloak.shion1305.com/realms/user"
+          authorizationUrl: "https://keycloak.shion1305.com/realms/user/protocol/openid-connect/auth"
+          tokenUrl: "https://keycloak.shion1305.com/realms/user/protocol/openid-connect/token"
+          userInfoUrl: "https://keycloak.shion1305.com/realms/user/protocol/openid-connect/userinfo"
+          logoutUrl: "https://keycloak.shion1305.com/realms/user/protocol/openid-connect/logout"
+          jwksUrl: "https://keycloak.shion1305.com/realms/user/protocol/openid-connect/certs"
+          useJwksUrl: "true"
+          validateSignature: "true"
+          clientAuthMethod: "client_secret_post"
+          clientId: "harbor-broker"
+          clientSecret: PLACEHOLDER_REPLACE_AFTER_REALM_IMPORT
+          defaultScope: "openid profile email"
+          syncMode: IMPORT

--- a/keycloak-operator/kustomization.yaml
+++ b/keycloak-operator/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - zot-realm.yaml
   - user-realm.yaml
   - ynufes-tech-realm.yaml
+  - harbor-realm.yaml

--- a/kyverno-policies/harbor-pull-injection.yaml
+++ b/kyverno-policies/harbor-pull-injection.yaml
@@ -1,0 +1,103 @@
+# Cluster-wide harbor-pull credential injection on Pod admission.
+#
+# Flow:
+#   1. ESO materialises Secret `harbor-pull` into `harbor-pull-source`
+#      (harbor-pull/cluster-external-secret.yaml).
+#   2. Pod is admitted in any namespace with a container or initContainer
+#      image referencing `harbor.shion1305.com/*` or `harbor.i.shion1305.com/*`.
+#   3. `generate-harbor-pull-secret` clones `harbor-pull-source/harbor-pull`
+#      into the Pod's namespace; synchronize=true so credential rotations
+#      propagate.
+#   4. `add-harbor-pull-imagepullsecret` mutates the Pod to append `harbor-pull`
+#      to spec.imagePullSecrets.
+#
+# Race window on the first Pod in a namespace: mutate runs synchronously at
+# admission while generate runs asynchronously, so the Secret may not exist
+# when kubelet first attempts the pull. kubelet retries on ImagePullBackOff;
+# the Secret is typically present within ~1s, so the next pull succeeds.
+#
+# webhookConfiguration.failurePolicy: Ignore — a Kyverno outage must not block
+# unrelated Pod admission cluster-wide. Pods needing the secret will degrade
+# to ImagePullBackOff and self-heal once Kyverno recovers.
+#
+# Architectural note vs zot-pull-injection: structurally identical, just
+# matches a different registry hostname. The auth chain underneath is much
+# simpler — Harbor uses long-lived robot-account Basic auth, so there is no
+# token expiry to worry about and no ESO ClusterGenerator in the picture.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: harbor-pull-injection
+  annotations:
+    policies.kyverno.io/title: Inject harbor-pull imagePullSecret
+    policies.kyverno.io/category: Image Pull Credentials
+    policies.kyverno.io/subject: Pod, Secret
+    policies.kyverno.io/description: >-
+      For Pods referencing the Harbor registry (harbor.shion1305.com or
+      harbor.i.shion1305.com), clones the dockerconfigjson Secret from
+      harbor-pull-source into the Pod's namespace and adds it to the Pod's
+      imagePullSecrets.
+spec:
+  webhookConfiguration:
+    failurePolicy: Ignore
+  rules:
+    - name: add-harbor-pull-imagepullsecret
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      preconditions:
+        # `images.containers.*.registry` / `images.initContainers.*.registry`
+        # are Kyverno's parsed image variables (hostname only, no scheme). The
+        # `|| `[]`` fallback prevents AnyIn from evaluating against null when
+        # a Pod has no initContainers. Two hostnames are checked because
+        # Harbor is reachable via both the public and internal FQDNs and Pods
+        # may legitimately reference either.
+        any:
+          - key: harbor.shion1305.com
+            operator: AnyIn
+            value: "{{ images.containers.*.registry || `[]` }}"
+          - key: harbor.shion1305.com
+            operator: AnyIn
+            value: "{{ images.initContainers.*.registry || `[]` }}"
+          - key: harbor.i.shion1305.com
+            operator: AnyIn
+            value: "{{ images.containers.*.registry || `[]` }}"
+          - key: harbor.i.shion1305.com
+            operator: AnyIn
+            value: "{{ images.initContainers.*.registry || `[]` }}"
+      mutate:
+        patchStrategicMerge:
+          spec:
+            imagePullSecrets:
+              - name: harbor-pull
+    - name: generate-harbor-pull-secret
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      preconditions:
+        any:
+          - key: harbor.shion1305.com
+            operator: AnyIn
+            value: "{{ images.containers.*.registry || `[]` }}"
+          - key: harbor.shion1305.com
+            operator: AnyIn
+            value: "{{ images.initContainers.*.registry || `[]` }}"
+          - key: harbor.i.shion1305.com
+            operator: AnyIn
+            value: "{{ images.containers.*.registry || `[]` }}"
+          - key: harbor.i.shion1305.com
+            operator: AnyIn
+            value: "{{ images.initContainers.*.registry || `[]` }}"
+      generate:
+        apiVersion: v1
+        kind: Secret
+        name: harbor-pull
+        namespace: "{{ request.namespace }}"
+        synchronize: true
+        clone:
+          namespace: harbor-pull-source
+          name: harbor-pull

--- a/postgres-shared/postgres-cluster.yaml
+++ b/postgres-shared/postgres-cluster.yaml
@@ -15,12 +15,14 @@ spec:
     keycloak: []
     mlflow: []
     nc_press_chotatsu_data: []
+    harbor: []
   databases:
     openwebui: openwebui
     langfuse: langfuse
     keycloak: keycloak
     mlflow: mlflow
     nc_press_chotatsu_data: nc_press_chotatsu_data
+    harbor: harbor
   postgresql:
     version: "17"
   resources:

--- a/vault/README.md
+++ b/vault/README.md
@@ -100,7 +100,9 @@ Each namespace has its own Vault policy and Kubernetes auth role, scoped to only
 | `eso-freqtrade` | namespace `freqtrade` | `eso` | `freqtrade/data/*` (read), `freqtrade/metadata/*` (read,list) |
 | `eso-cert-manager` | namespace `cert-manager` | `eso` | `system/data/cert-manager` (read), `system/metadata/cert-manager` (read,list) |
 | `eso-zot` | namespace `zot` | `eso` | `zot/data/*` (read), `zot/metadata/*` (read,list) |
+| `eso-harbor` | namespace `harbor` | `eso` | `harbor/data/*` (read), `harbor/metadata/*` (read,list) |
 | `eso-github-app` | **cluster-scoped** | `external-secrets/external-secrets` | `github-app-shared/data/*` (read), `github-app-shared/metadata/*` (read,list) |
+| `eso-harbor-pull` | **cluster-scoped** | `external-secrets/external-secrets` | `harbor/data/robot-puller` (read), metadata (read,list) — backs the cluster-wide `harbor-pull` Secret distribution |
 
 `eso-github-app` is the only cluster-scoped role: it binds to the ESO operator's own ServiceAccount (`external-secrets/external-secrets`) rather than a per-namespace `eso` SA, because it backs a `ClusterSecretStore` distributing one shared secret to multiple namespaces. See `../external-secrets/README.md` (pattern 3).
 

--- a/vault/scripts/setup-eso-policies.sh
+++ b/vault/scripts/setup-eso-policies.sh
@@ -106,6 +106,25 @@ path "zot/metadata/*" {
 EOF
 echo "✓ Created policy: eso-zot"
 
+# Policy for harbor namespace (separate KV v2 engine mounted at harbor/)
+vault policy write eso-harbor - <<EOF
+path "harbor/data/*" {
+  capabilities = ["read"]
+}
+path "harbor/metadata/*" {
+  capabilities = ["read", "list"]
+}
+EOF
+echo "✓ Created policy: eso-harbor"
+
+# NOTE: An `eso-harbor-broker` role for the Keycloak namespace to read
+# `harbor/broker-credentials` is intentionally NOT created here. There is no
+# precedent yet for ESO-managed broker client secrets in the keycloak ns
+# (the existing zot-broker IdP secret is written manually into the realm via
+# the Keycloak admin UI; see keycloak-operator/user-realm.yaml). If/when
+# broker-secret automation is wired up via a vault-secret-store in the
+# keycloak ns, add an `eso-harbor-broker` policy + role mirroring that pattern.
+
 # Policy for github-app shared credentials (cluster-scoped store, separate KV v2 engine mounted at github-app-shared/)
 vault policy write eso-github-app - <<EOF
 path "github-app-shared/data/*" {
@@ -142,6 +161,21 @@ path "zot/metadata/cluster-puller" {
 }
 EOF
 echo "✓ Created policy: eso-cluster-puller"
+
+# Policy for the cluster-wide harbor-pull automation. Reads only the Harbor
+# robot-account credentials at harbor/robot-puller. Consumed by the
+# ClusterSecretStore `vault-harbor-pull` (harbor-pull/cluster-secret-store.yaml)
+# which materializes a static dockerconfigjson Secret into harbor-pull-source
+# (no token-exchange — Harbor robot creds are long-lived).
+vault policy write eso-harbor-pull - <<EOF
+path "harbor/data/robot-puller" {
+  capabilities = ["read"]
+}
+path "harbor/metadata/robot-puller" {
+  capabilities = ["read", "list"]
+}
+EOF
+echo "✓ Created policy: eso-harbor-pull"
 
 echo ""
 echo "=== Creating namespace-scoped Kubernetes auth roles ==="
@@ -210,6 +244,14 @@ vault write auth/kubernetes/role/eso-zot \
   ttl=1h
 echo "✓ Created role: eso-zot"
 
+# harbor
+vault write auth/kubernetes/role/eso-harbor \
+  bound_service_account_names=eso \
+  bound_service_account_namespaces=harbor \
+  policies=eso-harbor \
+  ttl=1h
+echo "✓ Created role: eso-harbor"
+
 # github-app (cluster-scoped store; binds to the ESO operator SA, not a per-namespace SA)
 vault write auth/kubernetes/role/eso-github-app \
   bound_service_account_names=external-secrets \
@@ -236,6 +278,16 @@ vault write auth/kubernetes/role/eso-cluster-puller \
   ttl=1h
 echo "✓ Created role: eso-cluster-puller"
 
+# harbor-pull (cluster-scoped store; binds to the ESO operator SA so the
+# ClusterSecretStore `vault-harbor-pull` can read harbor/robot-puller from
+# any namespace context the controller runs in).
+vault write auth/kubernetes/role/eso-harbor-pull \
+  bound_service_account_names=external-secrets \
+  bound_service_account_namespaces=external-secrets \
+  policies=eso-harbor-pull \
+  ttl=1h
+echo "✓ Created role: eso-harbor-pull"
+
 echo ""
 echo "=== Removing old broad policy ==="
 vault policy delete eso-policy 2>/dev/null && echo "✓ Deleted old policy: eso-policy" || echo "ⓘ Policy eso-policy not found (already removed)"
@@ -252,6 +304,8 @@ echo "  eso-lumos-bot   → SA eso/lumos-bot       → lumos-bot/data/*"
 echo "  eso-freqtrade   → SA eso/freqtrade       → freqtrade/data/*"
 echo "  eso-cert-manager→ SA eso/cert-manager    → system/data/cert-manager"
 echo "  eso-zot         → SA eso/zot             → zot/data/*"
+echo "  eso-harbor      → SA eso/harbor          → harbor/data/*"
 echo "  eso-github-app  → SA external-secrets/external-secrets → github-app-shared/data/*"
 echo "  eso-cloudflare-grafana → SA eso/monitoring     → cloudflare-grafana/data/*"
 echo "  eso-cluster-puller → SA external-secrets/external-secrets → zot/data/cluster-puller"
+echo "  eso-harbor-pull → SA external-secrets/external-secrets → harbor/data/robot-puller"


### PR DESCRIPTION
## Summary

Deploys Harbor v2.15 (Helm chart 1.19.0) as an additional OCI registry. **zot stays running** — this PR is for cluster-side verification before any zot decommissioning. End-to-end push/pull smoketest + GHA demo workflow land in a follow-up PR.

- `harbor.shion1305.com` (public): Registry-v2 only — `/v2/` + `/service/token`. Note: `/v2/` PathPrefix carries pulls too, so all projects must stay private (`project_creation_restriction=adminonly`).
- `harbor.i.shion1305.com` (WireGuard-only): full surface — portal, OIDC callback, `/api/`, `/c/`, `/chartrepo/`.

## Why Harbor over zot

zot v2.1.16's bearer-OIDC middleware short-circuits the SPA's `authConfig` flow (project-zot/zot#4033). Working around it via Envoy `SecurityPolicy.oidc` worked for happy-path login but kept hitting Lua-filter ordering issues for the containerd `Basic→Bearer` rewrite, plus `denyRedirect` semantics and SPA mgmt-response rewrites. Harbor speaks OIDC at the application layer and mints its own bearer tokens — both auth flows collapse to "Basic with robot creds."

## Components

- `harbor/` — Helm values, ESO, HTTPRoutes, post-sync OIDC config Job
- `harbor-pull/` — cluster-wide `ClusterExternalSecret` materializing the robot-puller dockerconfigjson
- `harbor-pull-source/` — source namespace for the Kyverno-cloned Secret
- `kyverno-policies/harbor-pull-injection.yaml` — `imagePullSecrets` fan-out on Pod admission
- `keycloak-operator/harbor-realm.yaml` — `KeycloakRealmImport` (`harbor` realm + `harbor-ui` confidential client)
- `postgres-shared/postgres-cluster.yaml` — adds `harbor` user/DB to the shared cluster
- `vault/scripts/setup-eso-policies.sh` — adds `eso-harbor` (per-ns) + `eso-harbor-pull` (cluster-scoped) roles

## Notable design choices

- **`externalURL=https://harbor.i.shion1305.com`** — Harbor binds OIDC `redirect_uri` to `externalURL` (no per-request override), but the registry token realm is built from `req.Host`. So pushes to the public hostname still work while OIDC stays on the internal host.
- **PostSync hook Job for `oidc_client_secret`** — Harbor's `CONFIG_OVERWRITE_JSON` does NOT expand `$VAR`, so committing a literal `${HARBOR_OIDC_CLIENT_SECRET}` would store that string verbatim as the secret. The Job calls `PUT /api/v2.0/configurations` with the value mounted from the `harbor-oidc-credentials` Secret. Idempotent across re-runs; readonly rootfs, dropped caps, digest-pinned image, `automountServiceAccountToken: false`, and the response body is sed-redacted before being printed on failure.
- **AES-key length enforced at ESO-template time** (Sprig `fail`) so a misconfigured Vault entry never reaches harbor-core.
- **`sync-wave: "1"`** on `harbor-app` so postgres-shared (default wave 0) creates the `harbor` user/DB first.

## Verification (5 review agents, all passed)

- code-reviewer: APPROVE WITH NITS after heredoc fix (now uses `printf` to a temp file).
- architect-review: APPROVE WITH CONCERNS — concerns addressed.
- security-auditor: PASS WITH CONCERNS — H1/H2/M1/M2 all addressed (sanitised error echo, no SA token mount, hardened securityContext, digest-pinned image).
- Service-name verification: chart-rendered names confirmed (`harbor-core`, `harbor-portal`).
- PostSync Job correctness: API contract, hook semantics, Service DNS all verified.

## Test plan

- [ ] ArgoCD shows `harbor-app` Synced + Healthy after sync-wave 1
- [ ] `kubectl get svc -n harbor` shows `harbor-core` and `harbor-portal`
- [ ] `kubectl get externalsecret -n harbor` shows all 5 in Ready=True (including `harbor-secret-key` after a 16-byte value is in Vault)
- [ ] `harbor-configure-oidc` Job completes successfully (PostSync hook)
- [ ] Browser: `https://harbor.i.shion1305.com` loads portal, admin login works
- [ ] OIDC: login redirects through Keycloak `harbor` realm and brokers via `user` realm passkey
- [ ] `harbor.shion1305.com/v2/` returns `401 Bearer realm=...` (push-only handshake)
- [ ] Follow-up PR's demo workflow successfully pushes and the smoketest Job pulls