### PR TITLE
fix(eso): add per-ns DB-secret RBAC for harbor

### DIFF
--- a/external-secrets/rbac-db-reader.yaml
+++ b/external-secrets/rbac-db-reader.yaml
@@ -104,3 +104,29 @@ subjects:
   - kind: ServiceAccount
     name: eso-db
     namespace: mlflow
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: eso-db-harbor
+  namespace: postgres-operator-deployment
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - harbor.postgres-shared.credentials.postgresql.acid.zalan.do
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: eso-db-harbor
+  namespace: postgres-operator-deployment
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: eso-db-harbor
+subjects:
+  - kind: ServiceAccount
+    name: eso-db
+    namespace: harbor


### PR DESCRIPTION
## Summary
- Adds `eso-db-harbor` Role + RoleBinding in `postgres-operator-deployment`, mirroring the existing per-namespace pattern (langfuse / openwebui / keycloak / mlflow).
- Unblocks the `k8s-postgres` SecretStore in the `harbor` namespace so `harbor-db-credentials` can sync from the postgres-operator-generated Secret.

## Why this is needed
Without this RBAC, the harbor SecretStore validates as `InvalidProviderConfig` ("client is not allowed to get secrets") and `harbor-core` / `jobservice` / `exporter` cannot connect to Postgres. Verified in-cluster: applying this rolebinding flips the SecretStore to `Valid` and brings all 8 harbor pods to `1/1 Ready`.

## Scope
- Role uses `resourceNames` to pin to `harbor.postgres-shared.credentials.postgresql.acid.zalan.do` only — no broader read on the postgres-operator namespace.
- Bound to `harbor/eso-db` ServiceAccount only.

## Test plan
- [x] ArgoCD `external-secrets` Application syncs cleanly (single-source kustomize)
- [x] `kubectl get secretstore -n harbor k8s-postgres -o jsonpath='{.status}'` reports `Valid`
- [x] `kubectl get externalsecret -n harbor harbor-db-credentials` reports `SecretSynced`
- [x] Harbor pods reach Ready