### PR TITLE
fix(harbor): drop CONFIG_OVERWRITE_JSON; push full OIDC config via API

### DIFF
--- a/external-secrets/rbac-db-reader.yaml
+++ b/external-secrets/rbac-db-reader.yaml
@@ -104,3 +104,29 @@ subjects:
   - kind: ServiceAccount
     name: eso-db
     namespace: mlflow
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: eso-db-harbor
+  namespace: postgres-operator-deployment
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - harbor.postgres-shared.credentials.postgresql.acid.zalan.do
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: eso-db-harbor
+  namespace: postgres-operator-deployment
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: eso-db-harbor
+subjects:
+  - kind: ServiceAccount
+    name: eso-db
+    namespace: harbor

--- a/harbor/configure-oidc-job.yaml
+++ b/harbor/configure-oidc-job.yaml
@@ -147,6 +147,13 @@ spec:
             - |
               set -eu
 
+              # Cleanup trap covers every exit path — ordinary success,
+              # `set -e` aborts mid-script, OOM, etc. The scratch volume is
+              # tmpfs and pod-scoped, so the worst-case lifetime of any
+              # leaked file is the Pod itself, but cleaning up on exit
+              # eliminates the window entirely.
+              trap 'rm -f /tmp/oidc.json /tmp/auth.json /tmp/resp' EXIT
+
               # Wait for harbor-core to accept API calls. PostSync should
               # already imply readiness, but a short retry loop costs almost
               # nothing and avoids brittle race conditions on first sync.
@@ -221,23 +228,25 @@ spec:
               # even if the Pod is paused / inspected post-failure.
               rm -f /tmp/oidc.json
 
-              # Conservative redactor. Harbor 4xx bodies can echo the offending
-              # field name and value; redact a wide net of secret-looking keys.
-              redact() {
-                sed -E '
-                  s/("(oidc_client_secret(_old)?|client_secret|password|passwd|pwd|secret|token|credential[s]?|api[_-]?key|bearer|auth)"[[:space:]]*:[[:space:]]*)"[^"]*"/\1"REDACTED"/g;
-                  s/("value"[[:space:]]*:[[:space:]]*)"[^"]*"/\1"REDACTED"/g;
-                ' "$1" || true
+              # Conservative error reporter. Harbor 4xx bodies can echo the
+              # offending field VALUE inside an arbitrary "message" string
+              # (e.g. `"message":"oidc_client_secret value abc invalid"`),
+              # which a JSON-key-aware redactor can't catch. Rather than
+              # play whack-a-mole with regex, we keep only the top-level
+              # error code (which Harbor sets to a fixed enum like
+              # BAD_REQUEST/FORBIDDEN/INTERNAL_SERVER_ERROR) and discard
+              # the message string entirely. Operators with kubectl access
+              # can re-run the Job after temporarily mounting an
+              # unredacted print, if a real diagnosis ever needs it.
+              extract_code() {
+                grep -oE '"code"[[:space:]]*:[[:space:]]*"[A-Z_]+"' "$1" | head -1 || true
               }
 
               if [ "${http_status}" != "200" ]; then
-                echo "Harbor API returned HTTP ${http_status} on OIDC config; sanitised body:"
-                redact /tmp/resp
-                echo
-                rm -f /tmp/resp
+                echo "Harbor API returned HTTP ${http_status} on OIDC config push."
+                echo "  error code: $(extract_code /tmp/resp)"
                 exit 1
               fi
-              rm -f /tmp/resp
               echo "OIDC config pushed successfully"
 
               # Now that the OIDC keys are in place, flip auth_mode. Doing it
@@ -256,19 +265,18 @@ spec:
 
               if [ "${http_status}" != "200" ]; then
                 # 400 with "auth mode cannot be modified" is benign on
-                # re-runs after first OIDC user has been created.
-                echo "Harbor API returned HTTP ${http_status} on auth_mode flip; sanitised body:"
-                redact /tmp/resp
-                echo
+                # re-runs after first OIDC user has been created. Harbor
+                # v2.15.0 emits this exact substring from controller.go:127.
+                # The substring is safe to grep even unredacted because it
+                # is a fixed validator string with no embedded user input.
                 if [ "${http_status}" = "400" ] && grep -q "auth mode cannot be modified" /tmp/resp; then
-                  echo "(benign — auth mode already locked by existing users)"
-                  rm -f /tmp/resp
+                  echo "auth_mode already locked by existing users — benign, continuing."
                   exit 0
                 fi
-                rm -f /tmp/resp
+                echo "Harbor API returned HTTP ${http_status} on auth_mode flip."
+                echo "  error code: $(extract_code /tmp/resp)"
                 exit 1
               fi
-              rm -f /tmp/resp
               echo "auth_mode set to oidc_auth"
       volumes:
         - name: scratch

--- a/harbor/configure-oidc-job.yaml
+++ b/harbor/configure-oidc-job.yaml
@@ -1,28 +1,32 @@
-# Post-sync Job that injects the OIDC client secret into Harbor.
+# Post-sync Job that pushes ALL Harbor OIDC settings (including the secret)
+# via Harbor's REST API.
 #
 # WHY THIS JOB EXISTS
 # -------------------
-# The Harbor chart's `core.configureUserSettings` value is rendered into the
-# `CONFIG_OVERWRITE_JSON` env var on the core Deployment and is parsed by
-# Harbor as plain JSON — there is NO `$VAR` interpolation. Anything that looks
-# like an env reference (e.g. `$HARBOR_OIDC_CLIENT_SECRET`) would be stored
-# verbatim in the DB. Therefore the OIDC client secret cannot live in
-# committed values.yaml.
+# Harbor v2.15 has two ways to set user-scope config (auth_mode, oidc_*, …):
 #
-# Instead:
-#   1. values.yaml seeds every OIDC setting EXCEPT `oidc_client_secret` via
-#      `configureUserSettings`. Harbor reapplies these on every core start
-#      (seed-and-pin).
-#   2. After first sync, this Job authenticates as the built-in `admin` user
-#      (the `harbor-admin-password` Secret) and PUTs `oidc_client_secret`
-#      from the `harbor-oidc-credentials` Secret to Harbor's
-#      `/api/v2.0/configurations` endpoint. Harbor encrypts the value with
-#      its AES key (`harbor-secret-key`) and stores it in the `properties`
-#      table.
-#   3. The Job is annotated `argocd.argoproj.io/hook: PostSync` so ArgoCD
-#      runs it after the rest of the application materialises. It is
-#      idempotent — re-running it just re-PUTs the same value, which is a
-#      no-op for Harbor.
+#   (a) `CONFIG_OVERWRITE_JSON` env var on harbor-core (rendered by the chart
+#       from `core.configureUserSettings`). When this env var is set, Harbor
+#       sets a package-level `readOnlyForAll = true` flag and rejects EVERY
+#       `PUT /api/v2.0/configurations` call with 403 FORBIDDEN — the lock is
+#       global, not per-key (src/controller/config/controller.go).
+#   (b) Authenticate as `admin` and `PUT /api/v2.0/configurations`.
+#
+# We need (b) because `oidc_client_secret` is sensitive and must be sourced
+# from Vault at runtime, not committed to values.yaml. Mixing (a) for
+# non-secret keys and (b) for the secret is impossible because (a) locks (b).
+# So we drop (a) entirely and push everything via (b) here.
+#
+# This Job:
+#   1. Runs at PostSync (after harbor-core is healthy).
+#   2. Authenticates as the built-in `admin` user, using the password
+#      materialised from Vault path `harbor/admin-password` via ESO.
+#   3. PUTs the full OIDC config — non-secret keys are inlined verbatim in
+#      this manifest, `oidc_client_secret` comes from the
+#      `harbor-oidc-credentials` Secret (Vault `harbor/openid-credentials`).
+#   4. Idempotent: re-PUTs the same payload on every ArgoCD sync. Harbor
+#      stores the values in the `properties` table; the AES key
+#      `harbor-secret-key` encrypts the secret value at rest.
 #
 # ROTATION
 # --------
@@ -30,6 +34,9 @@
 # wait for ESO refresh (5m), then delete this Job (`kubectl delete job
 # -n harbor harbor-configure-oidc`) so ArgoCD re-runs it on next sync.
 # Or trigger an out-of-band re-sync of the harbor-app to force the hook.
+#
+# To change a non-secret OIDC setting (e.g. admin group, scope): edit the
+# `OIDC_*` env values below, commit, and let ArgoCD re-run the Job.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -102,6 +109,28 @@ spec:
                 secretKeyRef:
                   name: harbor-admin-password
                   key: HARBOR_ADMIN_PASSWORD
+            # Non-secret OIDC settings — declarative source of truth lives
+            # here. Edit + commit to change.
+            - name: OIDC_NAME
+              value: keycloak
+            - name: OIDC_ENDPOINT
+              value: https://keycloak.shion1305.com/realms/harbor
+            - name: OIDC_CLIENT_ID
+              value: harbor-ui
+            - name: OIDC_SCOPE
+              value: openid,profile,email,groups
+            - name: OIDC_VERIFY_CERT
+              value: "true"
+            - name: OIDC_AUTO_ONBOARD
+              value: "true"
+            - name: OIDC_USER_CLAIM
+              value: preferred_username
+            - name: OIDC_GROUPS_CLAIM
+              value: groups
+            - name: OIDC_ADMIN_GROUP
+              value: harbor-admin
+            # Secret value — comes from Vault `harbor/openid-credentials`
+            # via ESO.
             - name: OIDC_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
@@ -133,46 +162,114 @@ spec:
                 sleep 5
               done
 
-              # PUT only the OIDC client secret. Every other OIDC setting is
-              # already managed by `core.configureUserSettings` (seeded on
-              # each core start), so we touch the absolute minimum here.
+              # PUT the full OIDC config in one request. Every key here is a
+              # `Scope: UserScope` setting in
+              # src/lib/config/metadata/metadatalist.go; Harbor's PUT handler
+              # accepts a partial body and only updates the keys present
+              # (verified against v2.15.0 src/pkg/config/store/store.go:132).
               #
-              # Body is built with `printf` into a temp file rather than an
-              # inline heredoc — sh heredoc terminators must sit at column 0,
-              # and YAML's literal-block indent makes that error-prone. Using
-              # a temp file is also more robust to special characters in the
-              # secret (Keycloak client secrets are normally [A-Za-z0-9_-]+,
-              # but we avoid relying on that assumption).
-              echo "Setting oidc_client_secret via Harbor API..."
+              # auth_mode is left out of the body deliberately: it is set
+              # AFTER the OIDC keys are written, in a follow-up PUT, so the
+              # validator sees a fully-populated OIDC config in the DB
+              # before evaluating the mode change. Harbor's
+              # authModeCanBeModified gate only counts non-admin users, so a
+              # fresh deploy can flip the mode safely; once the first OIDC
+              # user logs in, the flip becomes irreversible — that is fine
+              # for our deployment because OIDC IS the intended mode.
+              #
+              # JSON-escape the OIDC client secret before embedding it. We
+              # don't have jq in this image; instead we apply the minimal sh
+              # quoting required for a JSON string: backslash → \\ then
+              # double-quote → \". Other control characters (newline, tab)
+              # cannot legitimately appear in a Keycloak-generated secret, so
+              # we don't try to handle them.
+              # All other values are committed YAML — we control their
+              # content and escape isn't needed.
+              echo "Building OIDC config payload..."
               umask 077
-              printf '{"oidc_client_secret":"%s"}' "${OIDC_CLIENT_SECRET}" > /tmp/body.json
+              escape_json() {
+                printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+              }
+              client_secret_escaped=$(escape_json "${OIDC_CLIENT_SECRET}")
+              {
+                printf '{'
+                printf '"oidc_name":"%s",' "${OIDC_NAME}"
+                printf '"oidc_endpoint":"%s",' "${OIDC_ENDPOINT}"
+                printf '"oidc_client_id":"%s",' "${OIDC_CLIENT_ID}"
+                printf '"oidc_client_secret":"%s",' "${client_secret_escaped}"
+                printf '"oidc_scope":"%s",' "${OIDC_SCOPE}"
+                printf '"oidc_verify_cert":%s,' "${OIDC_VERIFY_CERT}"
+                printf '"oidc_auto_onboard":%s,' "${OIDC_AUTO_ONBOARD}"
+                printf '"oidc_user_claim":"%s",' "${OIDC_USER_CLAIM}"
+                printf '"oidc_groups_claim":"%s",' "${OIDC_GROUPS_CLAIM}"
+                printf '"oidc_admin_group":"%s",' "${OIDC_ADMIN_GROUP}"
+                printf '"oidc_extra_redirect_parms":"{}"'
+                printf '}'
+              } > /tmp/oidc.json
+              unset client_secret_escaped
+
+              echo "Pushing OIDC config to Harbor..."
               http_status=$(curl -sS -o /tmp/resp -w '%{http_code}' \
                 -X PUT \
                 -u "admin:${HARBOR_ADMIN_PASSWORD}" \
                 -H 'Content-Type: application/json' \
-                --data-binary @/tmp/body.json \
+                --data-binary @/tmp/oidc.json \
                 "${HARBOR_URL}/api/v2.0/configurations")
 
               # Wipe the body before doing anything else — guarantees the
               # cleartext secret is unrecoverable from the scratch volume
               # even if the Pod is paused / inspected post-failure.
-              rm -f /tmp/body.json
+              rm -f /tmp/oidc.json
+
+              # Conservative redactor. Harbor 4xx bodies can echo the offending
+              # field name and value; redact a wide net of secret-looking keys.
+              redact() {
+                sed -E '
+                  s/("(oidc_client_secret(_old)?|client_secret|password|passwd|pwd|secret|token|credential[s]?|api[_-]?key|bearer|auth)"[[:space:]]*:[[:space:]]*)"[^"]*"/\1"REDACTED"/g;
+                  s/("value"[[:space:]]*:[[:space:]]*)"[^"]*"/\1"REDACTED"/g;
+                ' "$1" || true
+              }
 
               if [ "${http_status}" != "200" ]; then
-                # NEVER print /tmp/resp directly — Harbor's 4xx responses can
-                # echo offending field VALUES (including secrets) back in the
-                # error body. Strip any token-like substrings before
-                # surfacing. We use a conservative redactor: anything
-                # resembling a JSON value paired with a sensitive-looking
-                # key gets replaced with REDACTED.
-                echo "Harbor API returned HTTP ${http_status}; sanitised body:"
-                sed -E 's/("(oidc_client_secret|password|secret|token)"[[:space:]]*:[[:space:]]*)"[^"]*"/\1"REDACTED"/g' /tmp/resp || true
+                echo "Harbor API returned HTTP ${http_status} on OIDC config; sanitised body:"
+                redact /tmp/resp
                 echo
                 rm -f /tmp/resp
                 exit 1
               fi
               rm -f /tmp/resp
-              echo "OIDC client secret configured successfully"
+              echo "OIDC config pushed successfully"
+
+              # Now that the OIDC keys are in place, flip auth_mode. Doing it
+              # in a second PUT keeps validation simple. Idempotent: on
+              # re-runs (e.g. ArgoCD sync), Harbor returns 200 even though
+              # the value is unchanged.
+              echo "Switching auth_mode to oidc_auth..."
+              printf '{"auth_mode":"oidc_auth"}' > /tmp/auth.json
+              http_status=$(curl -sS -o /tmp/resp -w '%{http_code}' \
+                -X PUT \
+                -u "admin:${HARBOR_ADMIN_PASSWORD}" \
+                -H 'Content-Type: application/json' \
+                --data-binary @/tmp/auth.json \
+                "${HARBOR_URL}/api/v2.0/configurations")
+              rm -f /tmp/auth.json
+
+              if [ "${http_status}" != "200" ]; then
+                # 400 with "auth mode cannot be modified" is benign on
+                # re-runs after first OIDC user has been created.
+                echo "Harbor API returned HTTP ${http_status} on auth_mode flip; sanitised body:"
+                redact /tmp/resp
+                echo
+                if [ "${http_status}" = "400" ] && grep -q "auth mode cannot be modified" /tmp/resp; then
+                  echo "(benign — auth mode already locked by existing users)"
+                  rm -f /tmp/resp
+                  exit 0
+                fi
+                rm -f /tmp/resp
+                exit 1
+              fi
+              rm -f /tmp/resp
+              echo "auth_mode set to oidc_auth"
       volumes:
         - name: scratch
           emptyDir:

--- a/harbor/values.yaml
+++ b/harbor/values.yaml
@@ -148,50 +148,24 @@ internalTLS:
 # -----------------------------------------------------------------------------
 # core / portal / registry / jobservice / trivy / exporter
 # -----------------------------------------------------------------------------
-# `configureUserSettings` is rendered into the `CONFIG_OVERWRITE_JSON` env on
-# the core Deployment. Harbor reads it on EVERY startup and overwrites matching
-# keys in the `properties` table — so this is a true seed-and-pin mechanism,
-# not first-boot-only. Value MUST be a JSON STRING — Harbor parses it with
-# `encoding/json` directly. There is NO `$VAR` interpolation: anything looking
-# like an env reference would be stored verbatim in the DB.
+# IMPORTANT — `configureUserSettings` is INTENTIONALLY NOT SET.
 #
-# That is why `oidc_client_secret` is intentionally absent from this JSON: a
-# secret value cannot live in committed YAML. The OIDC client secret is set
-# AFTER first sync by the post-sync Job in harbor/configure-oidc-job.yaml,
-# which calls Harbor's `PUT /api/v2.0/configurations` with the value mounted
-# from the `harbor-oidc-credentials` Secret. All other OIDC settings here are
-# safe in git and serve as the seed-and-pin source of truth.
+# That field is rendered into the `CONFIG_OVERWRITE_JSON` env var on the core
+# Deployment. When that env var is set, Harbor v2.15 unconditionally flips a
+# package-level `readOnlyForAll = true` flag (see
+# src/controller/config/controller.go) and rejects EVERY subsequent
+# `PUT /api/v2.0/configurations` call with 403 FORBIDDEN — the lock is global,
+# not per-key. That makes a hybrid "seed non-secret keys via env var, inject
+# `oidc_client_secret` via API" design impossible: the API path is locked the
+# moment the env var is in play.
 #
-# OIDC settings (declarative, seeded on every core start):
-#   - oidc_endpoint:  Keycloak realm `harbor` issuer
-#   - oidc_client_id: `harbor-ui` (matches the client in keycloak-operator/harbor-realm.yaml)
-#   - oidc_groups_claim=groups — Harbor reads project-level RBAC from the
-#       `groups` claim emitted by the harbor-ui client's group-membership
-#       protocol mapper.
-#   - oidc_admin_group=harbor-admin — members of this Keycloak group get
-#       Harbor admin privileges automatically on first login.
-#   - oidc_auto_onboard=true — first-time OIDC users are created in Harbor
-#       without an explicit admin invite. Trust boundary is the Keycloak
-#       `user` realm (passkey-only).
-#   - oidc_user_claim=preferred_username — uses Keycloak's username (matches
-#       user-realm passkey-bound usernames brokered through the user IdP).
+# Instead, ALL OIDC settings (including the non-secret ones) are pushed by the
+# post-sync Job in harbor/configure-oidc-job.yaml, which authenticates as the
+# built-in `admin` user and PUTs the full payload. The Job is idempotent and
+# re-runs on every ArgoCD sync.
 core:
   replicas: 1
   existingSecret: harbor-core-secret
-  configureUserSettings: |
-    {
-      "auth_mode": "oidc_auth",
-      "oidc_name": "keycloak",
-      "oidc_endpoint": "https://keycloak.shion1305.com/realms/harbor",
-      "oidc_client_id": "harbor-ui",
-      "oidc_scope": "openid,profile,email,groups",
-      "oidc_verify_cert": "true",
-      "oidc_auto_onboard": "true",
-      "oidc_user_claim": "preferred_username",
-      "oidc_groups_claim": "groups",
-      "oidc_admin_group": "harbor-admin",
-      "oidc_extra_redirect_parms": "{}"
-    }
 
 portal:
   replicas: 1

--- a/keycloak-operator/user-realm.yaml
+++ b/keycloak-operator/user-realm.yaml
@@ -4,7 +4,7 @@
 #
 # This file is reconciled by the Keycloak Operator (KeycloakRealmImport CRD).
 # It declares the `user` realm, which is the central human-user pool brokered
-# into other realms (today: `zot`) via Identity Brokering / OIDC.
+# into other realms (today: `zot`, `harbor`) via Identity Brokering / OIDC.
 #
 # Authentication policy:
 #   - Passkey / WebAuthn only (NO password, NO IdP login).
@@ -35,10 +35,11 @@
 #    required action set below.
 #
 # 3. Retrieve the auto-generated client secret for each per-child-realm broker
-#    client (today: `zot-broker`) from the Keycloak admin UI:
-#      realm `user` -> Clients -> zot-broker -> Credentials -> "Client secret".
+#    client (today: `zot-broker`, `harbor-broker`) from the Keycloak admin UI:
+#      realm `user` -> Clients -> <broker-client> -> Credentials -> "Client secret".
 #    Copy that value into the matching `keycloak-oidc` IdP config on the child
 #    realm side (e.g. realm `zot` -> Identity Providers -> user ->
+#    Client Secret; realm `harbor` -> Identity Providers -> user ->
 #    Client Secret). Do NOT commit the value to git.
 #
 # -----------------------------------------------------------------------------
@@ -153,5 +154,23 @@ spec:
         serviceAccountsEnabled: false
         redirectUris:
           - https://keycloak.shion1305.com/realms/zot/broker/user/endpoint
+        webOrigins:
+          - https://keycloak.shion1305.com
+      - clientId: harbor-broker
+        name: "harbor realm broker"
+        description: "Broker client used by the `harbor` realm to authenticate users via this realm."
+        protocol: openid-connect
+        publicClient: false
+        clientAuthenticatorType: client-secret
+        # NOTE: This placeholder is replaced by a Keycloak-generated secret on
+        # first import. Copy the real value from the admin UI into the `harbor`
+        # realm's IdP config (Identity Providers -> user -> Client Secret).
+        # Do NOT commit the actual secret to git.
+        secret: PLACEHOLDER_REPLACE_AFTER_REALM_IMPORT
+        standardFlowEnabled: true
+        directAccessGrantsEnabled: false
+        serviceAccountsEnabled: false
+        redirectUris:
+          - https://keycloak.shion1305.com/realms/harbor/broker/user/endpoint
         webOrigins:
           - https://keycloak.shion1305.com


### PR DESCRIPTION
## Summary

Fixes Harbor OIDC login failing with `unauthorized_client / Invalid client credentials`.

Root cause: Harbor v2.15 sets a package-level `readOnlyForAll = true` flag whenever `CONFIG_OVERWRITE_JSON` is set on `harbor-core`, which makes EVERY `PUT /api/v2.0/configurations` return 403 — the lock is global, not per-key (`src/controller/config/controller.go`). The previous `configure-oidc` Job tried to PUT only `oidc_client_secret` while the chart set the rest via `CONFIG_OVERWRITE_JSON`; that PUT always 403'd, so the secret was never written and Harbor was using a stale/empty value when authenticating to Keycloak.

Verified live: every OIDC key on the running Harbor reports `editable: false`, the tell-tale sign of the lock.

### Changes

- **`harbor/values.yaml`** — drop `core.configureUserSettings`. Comment explains why it cannot coexist with API-driven config.
- **`harbor/configure-oidc-job.yaml`** — push the FULL OIDC config (name, endpoint, client_id, scope, claims, admin group, client_secret) in one PUT, then flip `auth_mode` in a second PUT. Idempotent across syncs. Hardened: digest-pinned image, `automountServiceAccountToken=false`, `readOnlyRootFilesystem`, drop ALL caps, tmpfs scratch, `seccompProfile: RuntimeDefault`. Body file removed before any error reporting; error reporter prints only the top-level Harbor error code (no `message` field, which can echo the secret).
- **`keycloak-operator/user-realm.yaml`** — declare `harbor-broker` client mirroring `zot-broker`, so the IdP brokering chain `harbor` → `user` is fully declarative. Real secret stays out of git (Keycloak generates on import; copied into `harbor` realm IdP + Vault `harbor/broker-credentials` post-import).

## Test plan

- [ ] ArgoCD `harbor` Application reaches Synced/Healthy (PostSync Job completes).
- [ ] `kubectl logs -n harbor -l job-name=harbor-configure-oidc --tail=20` shows `OIDC config pushed successfully` and `auth_mode set to oidc_auth`.
- [ ] `GET /api/v2.0/configurations` returns OIDC keys with `editable: true` (lock cleared).
- [ ] Browser login to https://harbor.i.shion1305.com via Keycloak `harbor` realm completes without `unauthorized_client`.