### PR TITLE
feat(harbor): add demo build/push pipeline + pull smoketest

### DIFF
--- a/.github/workflows/demo-push-to-harbor.yaml
+++ b/.github/workflows/demo-push-to-harbor.yaml
@@ -1,0 +1,99 @@
+# Demo workflow: build a small OCI image and push it to Harbor at
+# harbor.shion1305.com to prove the public-facing push path works end-to-end.
+#
+# Why robot accounts and not GitHub OIDC token-exchange (unlike the zot demo):
+# Harbor's /v2/ token endpoint does not accept GitHub OIDC tokens directly. It
+# mints its own bearer tokens after authenticating the caller via either basic
+# auth (username/password OR robot-account creds) or OIDC ID-token submission
+# to /c/login (browser flow only). The clean, supported CI path is a Harbor
+# robot account: a project-scoped, long-lived static credential created via
+# Harbor's admin UI/API and restricted to push/pull on a single project (here
+# `shion1305`). It's less elegant than zot's OIDC token-exchange, but it's the
+# model Harbor supports and matches every other Harbor deployment in the wild.
+#
+# Required GitHub repo secrets:
+#   - HARBOR_ROBOT_USER  full username including the `robot$` prefix and the
+#                        project scope, e.g. `robot$shion1305+gha-pusher`
+#   - HARBOR_ROBOT_TOKEN the secret string returned at robot creation time;
+#                        Harbor does NOT let you recover it later
+#
+# One-time manual setup the user must do (Harbor robot accounts are not
+# managed declaratively from this repo):
+#   1. Login to Harbor portal at https://harbor.i.shion1305.com (WireGuard
+#      required — it's on the internal ingress class).
+#   2. Projects -> `shion1305` -> Robot Accounts -> New Robot Account.
+#   3. Name: `gha-pusher`, expiration: e.g. 365 days.
+#   4. Permissions: push and pull on Repository.
+#   5. Save the token (it's shown ONCE — Harbor cannot re-display it).
+#   6. Store the token in:
+#        - GitHub repo secrets HARBOR_ROBOT_USER and HARBOR_ROBOT_TOKEN
+#        - Vault `harbor/robot-pusher` (so kubelet can also use it for
+#          in-cluster image pulls via an imagePullSecret materialized by ESO)
+#
+# Why crane and not `docker push`: same reason as the zot demo. crane works
+# directly with OCI-layout dirs/tarballs (no docker daemon image-store
+# round-trip), sends Authorization: Bearer pre-emptively, and is more robust
+# under CI conditions. It reads ~/.docker/config.json and Just Works once the
+# auth blob is in place.
+
+name: demo - build & push to harbor.shion1305.com
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "harbor/demo/**"
+      - ".github/workflows/demo-push-to-harbor.yaml"
+  pull_request:
+    paths:
+      - "harbor/demo/**"
+      - ".github/workflows/demo-push-to-harbor.yaml"
+  workflow_dispatch:
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v3
+
+      # crane is installed via aqua so the local toolchain (aqua.yaml) and CI
+      # use the exact same pinned version. Matches the zot demo workflow.
+      - uses: aquaproj/aqua-installer@v4.0.4
+        with:
+          aqua_version: v2.58.0
+
+      # Build to an OCI-layout tarball. crane push reads OCI-layout dirs and
+      # pushes manifests with the OCI media type, which Harbor accepts.
+      - name: Build OCI image
+        run: |
+          set -euo pipefail
+          docker buildx build \
+            --platform linux/amd64 \
+            --output type=oci,dest=/tmp/image.tar \
+            ./harbor/demo
+
+      - name: Push with crane
+        env:
+          HARBOR_ROBOT_USER: ${{ secrets.HARBOR_ROBOT_USER }}
+          HARBOR_ROBOT_TOKEN: ${{ secrets.HARBOR_ROBOT_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Extract OCI tarball so crane can read it as an OCI layout dir.
+          mkdir -p /tmp/oci
+          tar -xf /tmp/image.tar -C /tmp/oci
+
+          # crane auth uses ~/.docker/config.json. Build it from the robot
+          # creds: Harbor accepts basic auth on /v2/token and exchanges it for
+          # a short-lived bearer that crane then uses for the actual push.
+          mkdir -p ~/.docker
+          auth=$(printf '%s:%s' "$HARBOR_ROBOT_USER" "$HARBOR_ROBOT_TOKEN" | base64 -w0)
+          jq -n --arg a "$auth" \
+            '{auths: {"harbor.shion1305.com": {auth: $a}}}' > ~/.docker/config.json
+
+          crane push /tmp/oci \
+            harbor.shion1305.com/shion1305/demo:${{ github.sha }}
+          crane tag \
+            harbor.shion1305.com/shion1305/demo:${{ github.sha }} \
+            latest

--- a/apps/harbor-pull-smoketest-app.yaml
+++ b/apps/harbor-pull-smoketest-app.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: harbor-pull-smoketest
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Shion1305/k8s-GitOps.git
+    targetRevision: HEAD
+    path: harbor-pull-smoketest
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: harbor-pull-smoketest
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+      - ServerSideApply=true

--- a/harbor-pull-smoketest/job.yaml
+++ b/harbor-pull-smoketest/job.yaml
@@ -1,0 +1,43 @@
+# Smoketest Job that proves the cluster-wide harbor-pull automation works
+# end-to-end with no manual setup in the consumer namespace.
+#
+# Pull image: harbor.i.shion1305.com/shion1305/demo:latest — a small alpine
+# image that prints a line and exits, mirroring the zot-pull-smoketest payload.
+#
+# `imagePullSecrets` is intentionally omitted: Kyverno's `harbor-pull-injection`
+# ClusterPolicy injects it at admission and clones the source Secret into this
+# namespace. Seeing `imagePullSecrets: [{name: harbor-pull}]` on the running
+# Pod confirms the policy fired.
+#
+# Auth chain once the Secret is in place:
+#   - Source Secret `harbor-pull-source/harbor-pull`
+#     (kubernetes.io/dockerconfigjson) carries
+#     `auth = base64("<robot-username>:<robot-password>")`.
+#   - The credentials are read directly from Vault (`harbor/robot-puller`) by
+#     ESO. No token-exchange, no ClusterGenerator — Harbor robot accounts are
+#     long-lived static credentials.
+#   - kubelet sends `Authorization: Basic base64(<user>:<pass>)`; Harbor
+#     validates the robot account against its project ACLs.
+#
+# Argo reports Healthy when the Job's Complete condition is true.
+# ImagePullBackOff (robot revoked, project ACL drift, registry unreachable,
+# Kyverno not running) keeps the Job incomplete and Argo flags Degraded —
+# surfacing the regression.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: harbor-pull-smoketest
+  namespace: harbor-pull-smoketest
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: harbor-pull-smoketest
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: smoketest
+          image: harbor.i.shion1305.com/shion1305/demo:latest
+          imagePullPolicy: Always

--- a/harbor-pull-smoketest/kustomization.yaml
+++ b/harbor-pull-smoketest/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - job.yaml

--- a/harbor-pull-smoketest/namespace.yaml
+++ b/harbor-pull-smoketest/namespace.yaml
@@ -1,0 +1,20 @@
+# Smoketest namespace for the cluster-wide harbor-pull automation. Intentionally
+# bare so a Healthy state proves an arbitrary namespace can pull images from
+# the Harbor registry without manual preparation.
+#
+# Expected sequence at sync time:
+#   1. The Job creates a Pod with an image at `harbor.i.shion1305.com/...`.
+#   2. Kyverno `harbor-pull-injection` fires: mutate appends `harbor-pull` to
+#      spec.imagePullSecrets, generate clones the Secret from
+#      harbor-pull-source.
+#   3. kubelet authenticates with the robot-account dockerconfigjson and pulls.
+#      Job completes; Argo reports Healthy.
+#
+# Debugging ImagePullBackOff (in order):
+#   kubectl get clusterpolicy harbor-pull-injection -o yaml      # rule status
+#   kubectl get secret -n harbor-pull-source harbor-pull         # source materialised?
+#   kubectl get pod -n harbor-pull-smoketest -o yaml | grep imagePullSecrets
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: harbor-pull-smoketest

--- a/harbor/demo/Dockerfile
+++ b/harbor/demo/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:3.20
+RUN echo "hello from harbor smoke test" > /msg
+CMD ["cat", "/msg"]


### PR DESCRIPTION
## Summary

Mirrors the existing zot demo end-to-end so the Harbor stack proves the same guarantees: an in-cluster Job pulls a freshly-pushed image from `harbor.shion1305.com`, exercising both the public push path and the cluster-wide `harbor-pull` automation in a single ArgoCD-managed loop.

### Files

- `harbor/demo/Dockerfile` — alpine image that prints a single line and exits.
- `.github/workflows/demo-push-to-harbor.yaml` — buildx OCI export + crane push to `harbor.shion1305.com/shion1305/demo:{sha,latest}`.
- `harbor-pull-smoketest/{namespace,job,kustomization}.yaml` — Job that pulls `harbor.i.shion1305.com/shion1305/demo:latest` with no manually-provided imagePullSecret.
- `apps/harbor-pull-smoketest-app.yaml` — ArgoCD Application driving the smoketest namespace.

### Differences from the zot pipeline (documented in-file)

- CI auth uses a Harbor **robot account** (`HARBOR_ROBOT_USER`/`HARBOR_ROBOT_TOKEN`) instead of GitHub OIDC token-exchange. Harbor's `/v2/token` does not accept GitHub OIDC tokens; robot accounts are the supported model.
- Pull credentials come from **Vault `harbor/robot-puller` (static, long-lived)** rather than a Keycloak-token-exchange `ClusterGenerator`.
- Pod injection runs through the existing `harbor-pull-injection` Kyverno policy (already deployed and Ready in `kyverno-policies/`).

### Manual one-time setup (NOT declarative — Harbor robots cannot be GitOps'd)

After this PR merges, do the following so the smoketest goes Healthy:

1. **Harbor portal** → project `shion1305` → Robot Accounts:
   - `gha-pusher` (push+pull): copy generated token to GitHub repo secrets
     - `HARBOR_ROBOT_USER` = `robot$shion1305+gha-pusher`
     - `HARBOR_ROBOT_TOKEN` = generated token (shown once)
   - `puller` (pull only): copy `username` and `password` to Vault `harbor/robot-puller`
2. ESO will sync the dockerconfigjson Secret to `harbor-pull-source/harbor-pull` within ~5 min; smoketest Job then pulls successfully.

## Test plan

- [ ] PR merges and ArgoCD picks up `harbor-pull-smoketest` Application.
- [ ] After Vault `harbor/robot-puller` is populated, `harbor-pull-source/harbor-pull` Secret materialises (`kubectl get secret -n harbor-pull-source`).
- [ ] After GitHub repo secrets are set, manually dispatch `demo - build & push to harbor.shion1305.com` and confirm `crane push` succeeds.
- [ ] On next ArgoCD sync, `harbor-pull-smoketest` Job completes (Job `Complete=True`) and Application reports Healthy.
- [ ] Pod manifest shows `imagePullSecrets: [{name: harbor-pull}]` (Kyverno injection fired).