### PR TITLE
fix(argocd): cap application-controller memory to prevent host OOM

### DIFF
--- a/argocd/values.yaml
+++ b/argocd/values.yaml
@@ -148,6 +148,12 @@ controller:
   readinessProbe:
     timeoutSeconds: 5
   priorityClassName: argocd-critical
+  resources:
+    requests:
+      cpu: 250m
+      memory: 1Gi
+    limits:
+      memory: 1536Mi
 # Repo server
 repoServer:
   replicas: 1


### PR DESCRIPTION
## Summary
- Add memory `requests: 1Gi` / `limits: 1.5Gi` to `argocd-application-controller`
- Prevents the host-wide OOM cascade that took `instance-k8s-proxy` NotReady on 2026-05-09

## Why
The controller had `resources: {}`, so cgroup OOM never gated it. RSS reached ~858 MiB before the kernel global OOM killer fired and wedged kubelet/sshd. With this limit, a future leak kills only the pod, not the node.

Steady-state RSS after a 4 h soak is ~960 MiB and growing ~1 MiB/min, so 1 GiB request matches reality and 1.5 GiB limit gives reconcile-burst headroom.

Full incident analysis: `docs/k8s-proxy-oom-incident-2026-05-09.md`

## Test plan
- [ ] Merge → ArgoCD self-syncs and recreates the controller pod
- [ ] `kubectl -n argocd get pod argocd-application-controller-0` shows `Running` with new resources
- [ ] `kubectl -n argocd describe pod argocd-application-controller-0 | grep -A4 Limits` shows `memory: 1536Mi`
- [ ] Watch RSS for 24 h to confirm it plateaus below the limit (or, if it hits limit, confirms only the pod restarts and the node stays Ready)