### PR TITLE
feat(harbor): build demo image multi-arch (amd64+arm64)

### DIFF
--- a/.github/workflows/demo-push-to-harbor.yaml
+++ b/.github/workflows/demo-push-to-harbor.yaml
@@ -56,6 +56,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # QEMU registers arm64 emulation on the amd64 GitHub-hosted runner so
+      # buildx can produce arm64 layers from the same Dockerfile.
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - uses: docker/setup-buildx-action@v3
 
       # crane is installed via aqua so the local toolchain (aqua.yaml) and CI
@@ -66,11 +72,14 @@ jobs:
 
       # Build to an OCI-layout tarball. crane push reads OCI-layout dirs and
       # pushes manifests with the OCI media type, which Harbor accepts.
+      # Multi-arch: buildx writes an OCI image index referencing one manifest
+      # per platform, and `crane push --index` propagates the whole index to
+      # Harbor in a single call.
       - name: Build OCI image
         run: |
           set -euo pipefail
           docker buildx build \
-            --platform linux/amd64 \
+            --platform linux/amd64,linux/arm64 \
             --output type=oci,dest=/tmp/image.tar \
             ./harbor/demo
 
@@ -92,7 +101,10 @@ jobs:
           jq -n --arg a "$auth" \
             '{auths: {"harbor.shion1305.com": {auth: $a}}}' > ~/.docker/config.json
 
-          crane push /tmp/oci \
+          # --index pushes the OCI image index (multi-arch manifest list)
+          # produced by buildx's --platform linux/amd64,linux/arm64. Without
+          # --index, crane would push only one of the per-arch manifests.
+          crane push --index /tmp/oci \
             harbor.shion1305.com/shion1305/demo:${{ github.sha }}
           crane tag \
             harbor.shion1305.com/shion1305/demo:${{ github.sha }} \


### PR DESCRIPTION
## Summary
- Add `docker/setup-qemu-action` so the amd64 GitHub-hosted runner can emulate arm64.
- Build with `--platform linux/amd64,linux/arm64`. buildx writes an OCI image index referencing one manifest per platform.
- Push with `crane push --index` so the whole index lands at the destination tag (without `--index`, crane would push a single per-arch manifest and the index would be lost).

## Why
Harbor's own components are pinned to amd64 (#310), but the **smoketest Job** runs on whichever node the scheduler picks — and the cluster is 3× arm64 + 1× amd64. With a single-arch demo image, the Job fails on arm64 with `exec format error`. A multi-arch index lets the kubelet on either arch pull a usable manifest.

## Test plan
- [ ] Workflow run on this PR succeeds (`actions/checkout` → QEMU → buildx → crane).
- [ ] After merge, `crane manifest harbor.shion1305.com/shion1305/demo:latest` shows an `application/vnd.oci.image.index.v1+json` with two manifests (amd64 + arm64).
- [ ] `harbor-pull-smoketest` Job goes Complete on its scheduled node regardless of arch.