### PR TITLE
feat(harbor): sign demo image (cosign keyless)

### DIFF
--- a/.github/workflows/demo-push-to-harbor.yaml
+++ b/.github/workflows/demo-push-to-harbor.yaml
@@ -50,6 +50,18 @@ on:
       - ".github/workflows/demo-push-to-harbor.yaml"
   workflow_dispatch:
 
+# id-token: write is REQUIRED for cosign keyless signing — cosign exchanges
+# the workflow's GitHub OIDC token for a short-lived Fulcio certificate. The
+# resulting signature certificate is bound to this repo + ref + workflow
+# path, so a verifier can prove "this image came from
+# Shion1305/k8s-GitOps's demo-push-to-harbor.yaml on main" without any
+# long-lived signing key. See:
+# https://docs.sigstore.dev/cosign/signing/overview/#keyless-signing
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
 jobs:
   build-push:
     runs-on: ubuntu-latest
@@ -63,6 +75,19 @@ jobs:
           platforms: arm64
 
       - uses: docker/setup-buildx-action@v3
+
+      # cosign signs the image (keyless via Fulcio + Rekor) and attaches the
+      # syft-generated SBOM as a signed CycloneDX attestation.
+      - uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: v2.4.1
+
+      # syft generates the SBOM in CycloneDX JSON. We only need the syft
+      # binary on PATH; the action's "download-syft" mode does that without
+      # running a scan implicitly.
+      - uses: anchore/sbom-action/download-syft@v0
+        with:
+          syft-version: v1.18.1
 
       # crane is installed via aqua so the local toolchain (aqua.yaml) and CI
       # use the exact same pinned version. Matches the zot demo workflow.
@@ -83,29 +108,62 @@ jobs:
             --output type=oci,dest=/tmp/image.tar \
             ./harbor/demo
 
-      - name: Push with crane
+      - name: Push, sign, and attest SBOM
         env:
           HARBOR_ROBOT_USER: ${{ secrets.HARBOR_ROBOT_USER }}
           HARBOR_ROBOT_TOKEN: ${{ secrets.HARBOR_ROBOT_TOKEN }}
+          # COSIGN_YES suppresses cosign's interactive "are you sure"
+          # confirmation, required in non-TTY CI runners.
+          COSIGN_YES: "true"
         run: |
           set -euo pipefail
           # Extract OCI tarball so crane can read it as an OCI layout dir.
           mkdir -p /tmp/oci
           tar -xf /tmp/image.tar -C /tmp/oci
 
-          # crane auth uses ~/.docker/config.json. Build it from the robot
-          # creds: Harbor accepts basic auth on /v2/token and exchanges it for
-          # a short-lived bearer that crane then uses for the actual push.
+          # crane and cosign both read ~/.docker/config.json. Build it from
+          # the robot creds: Harbor accepts basic auth on /v2/token and
+          # exchanges it for a short-lived bearer that crane/cosign then use
+          # for the actual push.
           mkdir -p ~/.docker
           auth=$(printf '%s:%s' "$HARBOR_ROBOT_USER" "$HARBOR_ROBOT_TOKEN" | base64 -w0)
           jq -n --arg a "$auth" \
             '{auths: {"harbor.shion1305.com": {auth: $a}}}' > ~/.docker/config.json
 
+          IMAGE=harbor.shion1305.com/shion1305/demo
+          SHA_TAG=${{ github.sha }}
+
           # --index pushes the OCI image index (multi-arch manifest list)
           # produced by buildx's --platform linux/amd64,linux/arm64. Without
           # --index, crane would push only one of the per-arch manifests.
-          crane push --index /tmp/oci \
-            harbor.shion1305.com/shion1305/demo:${{ github.sha }}
-          crane tag \
-            harbor.shion1305.com/shion1305/demo:${{ github.sha }} \
-            latest
+          crane push --index /tmp/oci "${IMAGE}:${SHA_TAG}"
+          crane tag "${IMAGE}:${SHA_TAG}" latest
+
+          # Resolve the digest BEFORE signing. Tags can be remapped after the
+          # fact (latest can move), but a digest is the cryptographic hash of
+          # the manifest itself — signing by digest guarantees the signature
+          # binds to exactly this artifact. cosign will refuse a tag-only
+          # reference for sign/attest by design.
+          DIGEST=$(crane digest "${IMAGE}:${SHA_TAG}")
+          REF="${IMAGE}@${DIGEST}"
+          echo "Signing and attesting ${REF}"
+
+          # Keyless cosign sign — no key material on disk, the signature
+          # certificate is bound to this workflow's OIDC identity. Harbor
+          # v2.15 detects the resulting cosign artifact via the OCI 1.1
+          # referrers API and shows a "Signed" badge in the UI.
+          cosign sign "${REF}"
+
+          # Generate CycloneDX SBOM from the (already-pushed) image. syft
+          # walks the layers in the registry to enumerate packages — no need
+          # to reload the local OCI tarball.
+          syft "${REF}" -o cyclonedx-json=/tmp/sbom.cdx.json
+
+          # Attach the SBOM as a SIGNED in-toto CycloneDX attestation. This
+          # both stores the SBOM as an OCI referrer of the image AND signs
+          # it via the same Fulcio/Rekor flow used above. Harbor's UI
+          # surfaces this under the "SBOM" tab on the artifact page.
+          cosign attest \
+            --type cyclonedx \
+            --predicate /tmp/sbom.cdx.json \
+            "${REF}"

--- a/.github/workflows/demo-push-to-harbor.yaml
+++ b/.github/workflows/demo-push-to-harbor.yaml
@@ -159,10 +159,22 @@ jobs:
           # to reload the local OCI tarball.
           syft "${REF}" -o cyclonedx-json=/tmp/sbom.cdx.json
 
-          # Attach the SBOM as a SIGNED in-toto CycloneDX attestation. This
-          # both stores the SBOM as an OCI referrer of the image AND signs
-          # it via the same Fulcio/Rekor flow used above. Harbor's UI
-          # surfaces this under the "SBOM" tab on the artifact page.
+          # Two SBOM artifacts get attached, intentionally:
+          #
+          # (1) `cosign attach sbom` — Harbor v2.15's UI auto-detects the
+          #     resulting `sbom.cosign` accessory and populates the "SBOM"
+          #     column / artifact tab. This path is deprecated upstream but
+          #     remains the only form Harbor renders today; the deprecation
+          #     warning is harmless.
+          # (2) `cosign attest --type cyclonedx` — wraps the same SBOM in a
+          #     signed in-toto attestation, which is what supply-chain
+          #     verifiers (admission controllers etc.) expect. Not currently
+          #     surfaced by Harbor UI, but stored as a referrer and
+          #     verifiable via `cosign verify-attestation`.
+          cosign attach sbom \
+            --sbom /tmp/sbom.cdx.json \
+            --type cyclonedx \
+            "${REF}"
           cosign attest \
             --type cyclonedx \
             --predicate /tmp/sbom.cdx.json \

--- a/.github/workflows/demo-push-to-harbor.yaml
+++ b/.github/workflows/demo-push-to-harbor.yaml
@@ -76,18 +76,20 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
-      # cosign signs the image (keyless via Fulcio + Rekor) and attaches the
-      # syft-generated SBOM as a signed CycloneDX attestation.
+      # cosign signs the image keyless via Fulcio + Rekor. SBOM generation
+      # is intentionally NOT done in CI — Harbor v2.15's UI does not surface
+      # client-attached SBOM accessories (verified empirically: both
+      # `cosign attach sbom` and `cosign attest --type cyclonedx` produce
+      # accessory artifacts that Harbor stores but doesn't display in the
+      # SBOM column). Worse, those accessories appear as standalone rows
+      # that the "GENERATE SBOM" button can mis-target, causing Trivy to
+      # fail with "invalid tar header" while trying to extract a manifest
+      # JSON as if it were an image layer. So: signing only here; SBOM is
+      # produced by Harbor's own Trivy via the GENERATE SBOM action on the
+      # image artifact.
       - uses: sigstore/cosign-installer@v3
         with:
           cosign-release: v2.4.1
-
-      # syft generates the SBOM in CycloneDX JSON. We only need the syft
-      # binary on PATH; the action's "download-syft" mode does that without
-      # running a scan implicitly.
-      - uses: anchore/sbom-action/download-syft@v0
-        with:
-          syft-version: v1.18.1
 
       # crane is installed via aqua so the local toolchain (aqua.yaml) and CI
       # use the exact same pinned version. Matches the zot demo workflow.
@@ -108,7 +110,7 @@ jobs:
             --output type=oci,dest=/tmp/image.tar \
             ./harbor/demo
 
-      - name: Push, sign, and attest SBOM
+      - name: Push and sign
         env:
           HARBOR_ROBOT_USER: ${{ secrets.HARBOR_ROBOT_USER }}
           HARBOR_ROBOT_TOKEN: ${{ secrets.HARBOR_ROBOT_TOKEN }}
@@ -146,36 +148,10 @@ jobs:
           # reference for sign/attest by design.
           DIGEST=$(crane digest "${IMAGE}:${SHA_TAG}")
           REF="${IMAGE}@${DIGEST}"
-          echo "Signing and attesting ${REF}"
+          echo "Signing ${REF}"
 
           # Keyless cosign sign — no key material on disk, the signature
           # certificate is bound to this workflow's OIDC identity. Harbor
           # v2.15 detects the resulting cosign artifact via the OCI 1.1
           # referrers API and shows a "Signed" badge in the UI.
           cosign sign "${REF}"
-
-          # Generate CycloneDX SBOM from the (already-pushed) image. syft
-          # walks the layers in the registry to enumerate packages — no need
-          # to reload the local OCI tarball.
-          syft "${REF}" -o cyclonedx-json=/tmp/sbom.cdx.json
-
-          # Two SBOM artifacts get attached, intentionally:
-          #
-          # (1) `cosign attach sbom` — Harbor v2.15's UI auto-detects the
-          #     resulting `sbom.cosign` accessory and populates the "SBOM"
-          #     column / artifact tab. This path is deprecated upstream but
-          #     remains the only form Harbor renders today; the deprecation
-          #     warning is harmless.
-          # (2) `cosign attest --type cyclonedx` — wraps the same SBOM in a
-          #     signed in-toto attestation, which is what supply-chain
-          #     verifiers (admission controllers etc.) expect. Not currently
-          #     surfaced by Harbor UI, but stored as a referrer and
-          #     verifiable via `cosign verify-attestation`.
-          cosign attach sbom \
-            --sbom /tmp/sbom.cdx.json \
-            --type cyclonedx \
-            "${REF}"
-          cosign attest \
-            --type cyclonedx \
-            --predicate /tmp/sbom.cdx.json \
-            "${REF}"


### PR DESCRIPTION
## Summary
Add cosign keyless signing to the demo workflow. After merge, Harbor's artifact page for `shion1305/demo` will show a green "Signed" badge.

## Why signing only (SBOM removed)
Initial revision of this PR also generated a CycloneDX SBOM and attached it via both `cosign attach sbom` and `cosign attest --type cyclonedx`. Empirically on Harbor v2.15:
- Neither form is surfaced in the UI's "SBOM" column.
- Both forms appear as standalone accessory artifacts in the repository listing.
- Harbor's "GENERATE SBOM" button mis-targets those accessories, causing Trivy to crash with `archive/tar: invalid tar header` while trying to extract a manifest JSON as if it were an image layer.

So SBOM generation is moved to Harbor's own Trivy via the **GENERATE SBOM** action on the image artifact — the only path the UI actually renders. CI keeps just the supply-chain-critical bit: out-of-the-box signing.

## How signing works
1. `permissions: id-token: write` lets cosign exchange the workflow's GitHub OIDC token for a short-lived **Fulcio** certificate.
2. `cosign sign <image>@<digest>` signs the artifact and uploads the signature to both Harbor (as an OCI 1.1 referrer) and the public **Rekor** transparency log.
3. The signature certificate is bound to this workflow's identity, so verifiers can prove the image came from this repo's `demo-push-to-harbor.yaml`.

Critical detail: signing is by `image@<digest>`, not a tag — tags can be remapped (`latest` moves on every build) but the digest is the cryptographic hash of the manifest itself.

## Manual cleanup after merge
The PR's earlier revisions already pushed accessory artifacts to `harbor.shion1305.com/shion1305/demo` that this PR no longer creates. Those orphans should be deleted by hand once via the Harbor UI (project `shion1305` → repository `demo` → delete the rows that show only a digest with no real tag).

## Verification
1. Workflow run succeeds.
2. Harbor UI shows the green "Signed" badge on the new digest, and no extraneous accessory rows are added.
3. Click GENERATE SBOM on the image row — Trivy succeeds and the SBOM column populates.
4. CLI:
   ```bash
   cosign verify harbor.shion1305.com/shion1305/demo:latest \
     --certificate-identity-regexp "https://github.com/Shion1305/k8s-GitOps/.*" \
     --certificate-oidc-issuer https://token.actions.githubusercontent.com
   ```

## Test plan
- [ ] PR run finishes green.
- [ ] Harbor UI shows "Signed" badge on the new digest.
- [ ] No new accessory rows appear in the demo repository listing.
- [ ] GENERATE SBOM on the image row succeeds (no Trivy "invalid tar header").
- [ ] `cosign verify ...` succeeds against the pushed image.