### PR TITLE
chore(vault): upgrade 1.21.4 -> 2.0.0 (CVE-2026-5807)

### DIFF
--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -6,7 +6,7 @@ injector:
 server:
   image:
     repository: hashicorp/vault
-    tag: 1.21.4
+    tag: 2.0.0
   resources:
     requests:
       memory: 256Mi
@@ -57,7 +57,7 @@ server:
     name: "vault-unsealer"
   extraContainers:
     - name: unseal-sidecar
-      image: hashicorp/vault:1.21.4
+      image: hashicorp/vault:2.0.0
       securityContext:
         runAsNonRoot: true
         runAsUser: 100


### PR DESCRIPTION
## Summary

- Bump Vault server image and the in-Pod unseal-sidecar CLI image from `1.21.4` to `2.0.0` in lockstep.
- Closes [HCSEC-2026-08 / CVE-2026-5807](https://discuss.hashicorp.com/t/hcsec-2026-08-vault-vulnerable-to-denial-of-service-via-unauthenticated-root-token-generation-rekey-operations/77345): unauthenticated `/sys/rekey`, `/sys/generate-root`, and `/sys/replication/dr/secondary/generate-operation-token` could be DoS'd by perpetually occupying the single in-flight slot. Vault 2.0.0 makes those endpoints authenticated by default.
- Helm chart `hashicorp/vault-helm` 0.32.0 is unchanged (no hard server-version pin; renders cleanly with 2.0.0).

## Why this is scoped to image-only

Two follow-up PRs build on a known-good 2.0.0 baseline:
1. Vault hostname migration (`vault.i.shion1305.com` internal + `vault.shion1305.com` external + 301 from `vault.k`).
2. Reusable GitHub Actions workflow that auths to Vault via JWT to fetch short-lived Harbor robot tokens.

Bundling those into this PR would conflate three independent rollback axes (image / ingress / OIDC consumer contract).

## Confirmed compatibility (1.21.4 -> 2.0.0)

- Direct upgrade is documented; only release-notes "Breaking change" is internal SDK (`docker -> moby`) - does not affect the server runtime.
- `service_registration "kubernetes"`, `retry_join`, KV v2, `auth/kubernetes/login`, `/v1/sys/health?standbyok=...&sealedcode=204&uninitcode=204` all unchanged.
- The unseal-sidecar (`vault/values.yaml` lines 58-108) only calls `auth/kubernetes/login`, `kv get`, and `operator unseal` - none of the newly-authenticated endpoints. No regression.
- `vault/scripts/*` and `external-secrets/` clients do not call `/sys/rekey`, `/sys/generate-root`, or DR replication endpoints. No regression.

## Pre-flight checklist (REQUIRED before sync)

Operator must run from a machine with WireGuard + admin Vault token:

1. **Take a Raft snapshot** (rollback safety; HashiCorp does not guarantee on-disk format compatibility back to 1.21.4):
   ```
   vault operator raft snapshot save pre-2.0.0.snap
   ```
   Copy off-cluster.
2. **Verify Autopilot health** and identify the leader:
   ```
   vault operator raft autopilot state
   vault status   # note: HA Mode: active is the leader
   ```
3. **Confirm both pinned nodes are Ready** (`shion-ubuntu-2505`, `instance-k8s-proxy`). nodeAffinity in `values.yaml:35-44` pins 3 replicas to 2 hostnames - losing one node during the upgrade window = losing quorum. Pre-existing topology, not introduced by this PR; flagged so the operator can pick a quiet window.
4. **Roll order** (chart's StatefulSet `updateStrategy: OnDelete` - pods do NOT roll automatically):
   ```
   kubectl -n vault delete pod vault-2          # standby first
   # wait for unseal-sidecar to unseal it; vault-2 rejoins Raft as voter
   kubectl -n vault delete pod vault-1          # next standby
   # wait again
   kubectl -n vault delete pod vault-0          # leader last; remaining 2.0.0 standby is elected
   ```
   No `step-down` (per HashiCorp HA upgrade guidance).

## Rollback

If a 2.0.0 pod fails to start cleanly:
1. Revert this PR (or change tags back to `1.21.4` in `values.yaml`).
2. ArgoCD reconciles the StatefulSet spec back; `OnDelete` means no auto-roll.
3. `kubectl delete pod vault-N` to roll the bad pod back to 1.21.4.
4. 3-node Raft tolerates 1 down - quorum survives a single mid-upgrade failure.

## Reviews

5 specialist reviewer agents were run on the diff:
- code-reviewer: APPROVED
- security-auditor: APPROVED-WITH-COMMENTS (image-pin-by-digest is pre-existing posture; out of scope here)
- architect-review: APPROVED (correctly scoped as standalone PR)
- kubernetes-architect: APPROVED (after confirming runbook + nodeAffinity caveats live in PR description, not YAML)
- deployment-engineer: APPROVED (after re-reading the diff and confirming sidecar IS bumped in lockstep)

## Test plan

- [ ] Take Raft snapshot per pre-flight checklist
- [ ] Confirm Autopilot healthy + leader identified
- [ ] Both pinned nodes Ready
- [ ] Manually roll standbys then leader; verify each rejoins as voter and is unsealed by sidecar
- [ ] After upgrade, confirm `vault status` shows version 2.0.0 on all 3 pods
- [ ] Spot-check ESO sync + Harbor login still work post-upgrade