### PR TITLE
feat(vault): migrate to vault.i / vault.shion1305.com (Envoy Gateway HTTPRoute)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ This cluster uses a layered secret management approach:
 ### Vault Configuration
 
 - Deployed in HA mode with 3 replicas (Raft storage)
-- UI: <https://vault.k.shion1305.com>
+- UI: <https://vault.i.shion1305.com>
 - Default mount path: `secret/` (KV v2); each app typically gets its own dedicated KV v2 mount
 
 ### External Secrets Operator

--- a/external-secrets/README.md
+++ b/external-secrets/README.md
@@ -211,7 +211,7 @@ kubectl logs -n external-secrets -l app.kubernetes.io/name=external-secrets
 ```bash
 # Test Vault connectivity from ESO pod
 kubectl exec -n external-secrets <eso-pod> -- \
-  curl -k https://vault.k.shion1305.com/v1/sys/health
+  curl -k https://vault.i.shion1305.com/v1/sys/health
 
 # Check ESO can authenticate to Vault (look for auth success in logs)
 kubectl logs -n external-secrets -l app.kubernetes.io/name=external-secrets | grep -i auth

--- a/vault/README.md
+++ b/vault/README.md
@@ -13,8 +13,8 @@ Vault is deployed in High Availability (HA) mode with Raft storage backend, prov
 Key configurations:
 
 - **HA Mode**: 3 replicas with Raft storage
-- **TLS**: Disabled at Vault level (terminated at ingress)
-- **Ingress**: Accessible at `http://vault.k.shion1305.com` via `nginx-internal`
+- **TLS**: Disabled at Vault level (terminated at the gateway)
+- **Routing**: Envoy Gateway HTTPRoutes (see `httproute-*.yaml`); the chart-rendered Ingress is disabled
 - **Storage**: 10Gi persistent volumes for data and audit logs (longhorn-hdd-ha with 2 replicas)
 - **Resources**: 256Mi/250m requests, 512Mi/500m limits
 - **Auto-Unseal**: KV-based sidecar auto-unseal via active node
@@ -22,9 +22,17 @@ Key configurations:
 
 ## Access
 
-- **UI**: <https://vault.k.shion1305.com>
-- **API**: <https://vault.k.shion1305.com/v1/>
-- **Internal**: <http://vault.vault.svc.cluster.local:8200>
+Vault is exposed on three hostnames, each with a different purpose:
+
+| Hostname | Network | Allowed Paths | Use Case |
+|----------|---------|---------------|----------|
+| `vault.i.shion1305.com` | Internal (WireGuard only) | All (full UI + API) | Admin/operator UI, all interactive use, `api_addr` |
+| `vault.shion1305.com` | Public internet | Allowlisted: `/v1/auth/jwt/login`, `/v1/auth/token/renew-self`, `/v1/auth/token/revoke-self` (KV-read paths to be added in the reusable-workflow PR) | CI (GitHub Actions) JWT login + token self-management |
+| `vault.k.shion1305.com` | Public (legacy) | 301 redirect → `vault.i.shion1305.com` | Bookmark migration only; will be removed in a future PR |
+
+- **UI**: <https://vault.i.shion1305.com>
+- **API**: <https://vault.i.shion1305.com/v1/>
+- **In-cluster**: <http://vault.vault.svc.cluster.local:8200>
 
 ## Operations
 

--- a/vault/httproute-external.yaml
+++ b/vault/httproute-external.yaml
@@ -1,0 +1,45 @@
+# Public Vault URL — auth + token-self-management only.
+#
+# The only intended callers we expose externally are CI runners (GitHub
+# Actions) doing JWT login against Vault and managing their own token's
+# lifecycle. Admin paths (sys/*), the UI, and arbitrary API access stay on
+# the internal hostname (httproute-internal.yaml). Keeping this surface
+# allowlisted means a leaked CI credential cannot reach admin endpoints
+# regardless of any policy mistakes inside Vault.
+#
+# KV-data paths (/v1/<mount>/data/*) for CI to read scoped secrets will be
+# appended in the follow-up reusable-workflow PR (Harbor robot creds and
+# similar). They are intentionally NOT included here yet because the set of
+# mounts CI is allowed to read is being designed alongside that workflow.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vault-external
+  namespace: vault
+spec:
+  parentRefs:
+    - name: external
+      namespace: envoy-gateway-system
+      sectionName: https
+  hostnames:
+    - vault.shion1305.com
+  rules:
+    # method: POST tightens the surface — these endpoints are POST-only in
+    # Vault, so blocking GET avoids future surface creep if Vault ever adds
+    # a GET variant that returns data.
+    - matches:
+        - path:
+            type: Exact
+            value: /v1/auth/jwt/login
+          method: POST
+        - path:
+            type: Exact
+            value: /v1/auth/token/renew-self
+          method: POST
+        - path:
+            type: Exact
+            value: /v1/auth/token/revoke-self
+          method: POST
+      backendRefs:
+        - name: vault
+          port: 8200

--- a/vault/httproute-internal.yaml
+++ b/vault/httproute-internal.yaml
@@ -1,0 +1,28 @@
+# Internal Vault URL — reachable only via WireGuard (the *.i.shion1305.com
+# DNS A record points to the in-cluster ingress IP). This is the FULL-ACCESS
+# hostname: UI, full HTTP API (sys/*, auth/*, KV reads/writes), admin
+# operations — everything Vault exposes lives here.
+#
+# This is the primary admin/operator/UI hostname and the value used for
+# api_addr in the Vault server config (so any URL Vault echoes back to clients
+# resolves to the WireGuard-only network).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vault-internal
+  namespace: vault
+spec:
+  parentRefs:
+    - name: internal
+      namespace: envoy-gateway-system
+      sectionName: https
+  hostnames:
+    - vault.i.shion1305.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: vault
+          port: 8200

--- a/vault/httproute-legacy-redirect.yaml
+++ b/vault/httproute-legacy-redirect.yaml
@@ -1,0 +1,28 @@
+# Backward-compat for the old hostname (vault.k.shion1305.com).
+# Issues a 301 Permanent Redirect to vault.i.shion1305.com so existing browser
+# bookmarks keep working during the transition. This is the same pattern as
+# keycloak-operator/httproute-legacy-redirect.yaml.
+#
+# Server-to-server callers (ESO, CI) should NOT rely on this — they must be
+# pointed at vault.i (internal full-API) or vault (external auth-only)
+# directly. This route exists only as a bookmark courtesy and will be removed
+# in a future PR.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vault-legacy-redirect
+  namespace: vault
+spec:
+  parentRefs:
+    - name: external
+      namespace: envoy-gateway-system
+      sectionName: https-legacy-k
+  hostnames:
+    - vault.k.shion1305.com
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            hostname: vault.i.shion1305.com
+            statusCode: 301

--- a/vault/kustomization.yaml
+++ b/vault/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - httproute-internal.yaml
+  - httproute-external.yaml
+  - httproute-legacy-redirect.yaml

--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -25,13 +25,10 @@ server:
     initialDelaySeconds: 60
     periodSeconds: 10
     failureThreshold: 5
+  # Ingress disabled; HTTPRoutes in vault/httproute-*.yaml attach the per-host
+  # routing to Envoy Gateway (matches harbor/zot/keycloak pattern).
   ingress:
-    enabled: true
-    ingressClassName: nginx-internal
-    hosts:
-      - host: vault.k.shion1305.com
-        paths:
-          - /
+    enabled: false
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -116,7 +113,10 @@ server:
       setNodeId: true
       config: |
         ui = true
-        api_addr = "https://vault.k.shion1305.com"
+        # Internal hostname is the source of truth for any URL Vault echoes to
+        # clients (e.g. UI redirects). External hostname is path-restricted and
+        # auth-only — not suitable as api_addr.
+        api_addr = "https://vault.i.shion1305.com"
 
         listener "tcp" {
           tls_disable = true


### PR DESCRIPTION
## Summary

Migrate Vault from a single legacy hostname (`vault.k.shion1305.com`, chart-rendered nginx-internal Ingress) to a tri-hostname Envoy Gateway HTTPRoute setup matching the existing Harbor / Keycloak / Zot pattern in this repo.

| Hostname | Reach | Path scope | Use |
|---|---|---|---|
| `vault.i.shion1305.com` | WireGuard-only | full API + UI | new admin/operator URL; api_addr |
| `vault.shion1305.com` | public internet | path-allowlisted | CI auth flows (JWT login + token self-mgmt) |
| `vault.k.shion1305.com` | public internet | 301 → `vault.i` | bookmark migration only |

This enables PR #3 (next): a reusable GitHub Actions workflow that authenticates to Vault via JWT to fetch short-lived secrets (e.g. Harbor robot tokens), removing long-lived credentials from GitHub Secrets.

## Changes

- `vault/values.yaml`:
  - `ingress.enabled: true` → `false` (drops chart-rendered nginx-internal Ingress).
  - `api_addr` HCL: `https://vault.k.shion1305.com` → `https://vault.i.shion1305.com`.
  - Added concise inline comments explaining both decisions.
- New `vault/httproute-internal.yaml` — full-API on Gateway `internal`/`https`.
- New `vault/httproute-external.yaml` — `Exact` path + `method: POST` matchers for `/v1/auth/jwt/login`, `/v1/auth/token/renew-self`, `/v1/auth/token/revoke-self` on Gateway `external`/`https`.
- New `vault/httproute-legacy-redirect.yaml` — 301 to `vault.i` on Gateway `external`/`https-legacy-k` (mirrors `keycloak-operator/httproute-legacy-redirect.yaml`).
- New `vault/kustomization.yaml` (Vault was chart-only before).
- Doc updates: `vault/README.md`, `CLAUDE.md` (line 99), `external-secrets/README.md` (line 214).

KV-data paths (`/v1/<mount>/data/*`) are deliberately NOT in the external allowlist yet — they'll be added in PR #3 alongside the reusable workflow that consumes them, since the set of mounts CI may read is decided there.

## Why path-allowlist + method match externally

`/v1/sys/health` and `/v1/sys/seal-status` are unauthenticated and leak Vault version + cluster id; admin paths (`/sys/*`) and the UI are admin-only. Even though Vault 2.0.0 (just merged in #313) requires auth on `/sys/rekey` etc., the principle of least exposure means we keep the public surface to exactly what CI runners need, hardened with `method: POST` so a future Vault GET variant of any of these endpoints doesn't silently widen the surface.

## Operator pre-flight runbook (REQUIRED before sync)

1. **DNS A records**:
   - `vault.i.shion1305.com` → internal Envoy Gateway IP (`10.130.5.21`)
   - `vault.shion1305.com` → external Envoy Gateway IP (`141.147.189.36`)
   - `vault.k.shion1305.com` → can stay on the existing nginx-internal IP during the cutover; the redirect HTTPRoute on `external/https-legacy-k` handles new public traffic. Move it to `141.147.189.36` after sync if you want the redirect to work uniformly from any source.

2. **Verify wildcard certs are issued** (already exist; no action expected):
   ```
   kubectl get secret wildcard-i-shion1305-com-tls wildcard-shion1305-com-tls wildcard-k-shion1305-com-tls -n envoy-gateway-system
   ```

3. **Merge + ArgoCD sync**. ArgoCD will:
   - Prune the legacy `vault` Ingress.
   - Create the 3 new HTTPRoutes.
   - Update the `vault-config` ConfigMap with the new `api_addr`.

4. **Manually roll Vault pods to pick up the new `api_addr`** (chart uses `OnDelete` updateStrategy — pods don't bounce automatically):
   ```
   # standby first
   kubectl -n vault delete pod vault-2     # wait for unseal + Ready
   kubectl -n vault delete pod vault-1     # wait again
   # leader last
   vault operator step-down                # then:
   kubectl -n vault delete pod vault-0
   ```
   Unseal sidecar handles re-unsealing automatically.

5. **Verify HTTPRoute admission**:
   ```
   kubectl get httproute -n vault -o jsonpath='{range .items[*]}{.metadata.name}{": "}{.status.parents[0].conditions[?(@.type=="Accepted")].status}{"\n"}{end}'
   ```
   Expect `True` for all three.

6. **Smoke tests**:
   - `curl -I https://vault.k.shion1305.com/` → expect `HTTP/2 301` with `location: https://vault.i.shion1305.com/`.
   - `curl -X POST https://vault.shion1305.com/v1/auth/jwt/login -d '{}'` → expect 400 (bad payload, but reached Vault, not a 404).
   - `curl https://vault.shion1305.com/v1/sys/health` → expect 404 from gateway (NOT in allowlist).
   - Browser: https://vault.i.shion1305.com/ → Vault UI.

## Rollback

Revert this PR. ArgoCD reconciles back: legacy Ingress recreated by chart, 3 HTTPRoutes pruned. ESO is unaffected throughout (uses cluster-internal Service DNS `vault.vault.svc.cluster.local:8200`).

## Reviews

5 specialist reviewer agents were run on the diff:
- code-reviewer: APPROVED
- security-auditor: APPROVED-WITH-COMMENTS → addressed by adding `method: POST` to the 3 external matchers.
- architect-review: APPROVED (pattern + sequencing + decommission path all correct).
- kubernetes-architect: APPROVED-WITH-COMMENTS → manual pod-roll documented in runbook above.
- deployment-engineer: APPROVED-WITH-COMMENTS → DNS pre-flight documented in runbook above.

## Test plan

- [ ] DNS A records added (vault.i, vault)
- [ ] Wildcard certs verified
- [ ] Sync ArgoCD
- [ ] HTTPRoutes show `Accepted=True` on all three parents
- [ ] Roll vault-2 → vault-1 → vault-0; confirm each rejoins as voter and is unsealed by sidecar
- [ ] Confirm `vault status` shows new `api_addr` (https://vault.i.shion1305.com)
- [ ] Browser smoke: https://vault.i (full UI), https://vault.k (301 → vault.i), https://vault (404 on /sys/*, reachable on /v1/auth/jwt/login)
- [ ] ESO sync still working (`kubectl get externalsecret -A` healthy)