### PR TITLE
feat(harbor): reusable workflow + Vault JWT auth (drops long-lived robot creds)

### DIFF
--- a/.github/workflows/demo-push-to-harbor.yaml
+++ b/.github/workflows/demo-push-to-harbor.yaml
@@ -1,40 +1,23 @@
 # Demo workflow: build a small OCI image and push it to Harbor at
 # harbor.shion1305.com to prove the public-facing push path works end-to-end.
 #
-# Why robot accounts and not GitHub OIDC token-exchange (unlike the zot demo):
-# Harbor's /v2/ token endpoint does not accept GitHub OIDC tokens directly. It
-# mints its own bearer tokens after authenticating the caller via either basic
-# auth (username/password OR robot-account creds) or OIDC ID-token submission
-# to /c/login (browser flow only). The clean, supported CI path is a Harbor
-# robot account: a project-scoped, long-lived static credential created via
-# Harbor's admin UI/API and restricted to push/pull on a single project (here
-# `shion1305`). It's less elegant than zot's OIDC token-exchange, but it's the
-# model Harbor supports and matches every other Harbor deployment in the wild.
+# All actual logic — multi-arch buildx, Vault JWT login for the robot creds,
+# crane push, cosign keyless signing — lives in the reusable workflow at
+# .github/workflows/harbor-build-push.yaml. This file is just the demo's
+# trigger surface (path filter on `harbor/demo/**`) plus a thin caller.
 #
-# Required GitHub repo secrets:
-#   - HARBOR_ROBOT_USER  full username including the `robot$` prefix and the
-#                        project scope, e.g. `robot$shion1305+gha-pusher`
-#   - HARBOR_ROBOT_TOKEN the secret string returned at robot creation time;
-#                        Harbor does NOT let you recover it later
+# Robot credentials are not GitHub Secrets: the reusable workflow exchanges
+# this run's GitHub OIDC token for short-lived robot creds stored in Vault at
+# `harbor/data/robot-pusher` (KV v2). The Harbor robot account itself
+# (`robot$shion1305+gha-pusher`, push/pull on the `shion1305` project) is
+# created out-of-band via Harbor's UI, and its credentials are written into
+# Vault by hand at the same time. See the PR description for the one-time
+# setup runbook.
 #
-# One-time manual setup the user must do (Harbor robot accounts are not
-# managed declaratively from this repo):
-#   1. Login to Harbor portal at https://harbor.i.shion1305.com (WireGuard
-#      required — it's on the internal ingress class).
-#   2. Projects -> `shion1305` -> Robot Accounts -> New Robot Account.
-#   3. Name: `gha-pusher`, expiration: e.g. 365 days.
-#   4. Permissions: push and pull on Repository.
-#   5. Save the token (it's shown ONCE — Harbor cannot re-display it).
-#   6. Store the token in:
-#        - GitHub repo secrets HARBOR_ROBOT_USER and HARBOR_ROBOT_TOKEN
-#        - Vault `harbor/robot-pusher` (so kubelet can also use it for
-#          in-cluster image pulls via an imagePullSecret materialized by ESO)
-#
-# Why crane and not `docker push`: same reason as the zot demo. crane works
-# directly with OCI-layout dirs/tarballs (no docker daemon image-store
-# round-trip), sends Authorization: Bearer pre-emptively, and is more robust
-# under CI conditions. It reads ~/.docker/config.json and Just Works once the
-# auth blob is in place.
+# `id-token: write` and `contents: read` are set on the calling job, NOT
+# inherited from this workflow file, because GitHub does not propagate
+# job-level permissions into reusable workflows automatically. Vault JWT
+# login + cosign keyless signing both need `id-token: write`.
 
 name: demo - build & push to harbor.shion1305.com
 
@@ -44,114 +27,26 @@ on:
     paths:
       - "harbor/demo/**"
       - ".github/workflows/demo-push-to-harbor.yaml"
+      - ".github/workflows/harbor-build-push.yaml"
   pull_request:
     paths:
       - "harbor/demo/**"
       - ".github/workflows/demo-push-to-harbor.yaml"
+      - ".github/workflows/harbor-build-push.yaml"
   workflow_dispatch:
-
-# id-token: write is REQUIRED for cosign keyless signing — cosign exchanges
-# the workflow's GitHub OIDC token for a short-lived Fulcio certificate. The
-# resulting signature certificate is bound to this repo + ref + workflow
-# path, so a verifier can prove "this image came from
-# Shion1305/k8s-GitOps's demo-push-to-harbor.yaml on main" without any
-# long-lived signing key. See:
-# https://docs.sigstore.dev/cosign/signing/overview/#keyless-signing
-permissions:
-  contents: read
-  id-token: write
-  packages: write
 
 jobs:
   build-push:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      # QEMU registers arm64 emulation on the amd64 GitHub-hosted runner so
-      # buildx can produce arm64 layers from the same Dockerfile.
-      - uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-
-      - uses: docker/setup-buildx-action@v3
-
-      # cosign signs the image keyless via Fulcio + Rekor. SBOM generation
-      # is intentionally NOT done in CI — Harbor v2.15's UI does not surface
-      # client-attached SBOM accessories (verified empirically: both
-      # `cosign attach sbom` and `cosign attest --type cyclonedx` produce
-      # accessory artifacts that Harbor stores but doesn't display in the
-      # SBOM column). Worse, those accessories appear as standalone rows
-      # that the "GENERATE SBOM" button can mis-target, causing Trivy to
-      # fail with "invalid tar header" while trying to extract a manifest
-      # JSON as if it were an image layer. So: signing only here; SBOM is
-      # produced by Harbor's own Trivy via the GENERATE SBOM action on the
-      # image artifact.
-      - uses: sigstore/cosign-installer@v3
-        with:
-          cosign-release: v2.4.1
-
-      # crane is installed via aqua so the local toolchain (aqua.yaml) and CI
-      # use the exact same pinned version. Matches the zot demo workflow.
-      - uses: aquaproj/aqua-installer@v4.0.4
-        with:
-          aqua_version: v2.58.0
-
-      # Build to an OCI-layout tarball. crane push reads OCI-layout dirs and
-      # pushes manifests with the OCI media type, which Harbor accepts.
-      # Multi-arch: buildx writes an OCI image index referencing one manifest
-      # per platform, and `crane push --index` propagates the whole index to
-      # Harbor in a single call.
-      - name: Build OCI image
-        run: |
-          set -euo pipefail
-          docker buildx build \
-            --platform linux/amd64,linux/arm64 \
-            --output type=oci,dest=/tmp/image.tar \
-            ./harbor/demo
-
-      - name: Push and sign
-        env:
-          HARBOR_ROBOT_USER: ${{ secrets.HARBOR_ROBOT_USER }}
-          HARBOR_ROBOT_TOKEN: ${{ secrets.HARBOR_ROBOT_TOKEN }}
-          # COSIGN_YES suppresses cosign's interactive "are you sure"
-          # confirmation, required in non-TTY CI runners.
-          COSIGN_YES: "true"
-        run: |
-          set -euo pipefail
-          # Extract OCI tarball so crane can read it as an OCI layout dir.
-          mkdir -p /tmp/oci
-          tar -xf /tmp/image.tar -C /tmp/oci
-
-          # crane and cosign both read ~/.docker/config.json. Build it from
-          # the robot creds: Harbor accepts basic auth on /v2/token and
-          # exchanges it for a short-lived bearer that crane/cosign then use
-          # for the actual push.
-          mkdir -p ~/.docker
-          auth=$(printf '%s:%s' "$HARBOR_ROBOT_USER" "$HARBOR_ROBOT_TOKEN" | base64 -w0)
-          jq -n --arg a "$auth" \
-            '{auths: {"harbor.shion1305.com": {auth: $a}}}' > ~/.docker/config.json
-
-          IMAGE=harbor.shion1305.com/shion1305/demo
-          SHA_TAG=${{ github.sha }}
-
-          # --index pushes the OCI image index (multi-arch manifest list)
-          # produced by buildx's --platform linux/amd64,linux/arm64. Without
-          # --index, crane would push only one of the per-arch manifests.
-          crane push --index /tmp/oci "${IMAGE}:${SHA_TAG}"
-          crane tag "${IMAGE}:${SHA_TAG}" latest
-
-          # Resolve the digest BEFORE signing. Tags can be remapped after the
-          # fact (latest can move), but a digest is the cryptographic hash of
-          # the manifest itself — signing by digest guarantees the signature
-          # binds to exactly this artifact. cosign will refuse a tag-only
-          # reference for sign/attest by design.
-          DIGEST=$(crane digest "${IMAGE}:${SHA_TAG}")
-          REF="${IMAGE}@${DIGEST}"
-          echo "Signing ${REF}"
-
-          # Keyless cosign sign — no key material on disk, the signature
-          # certificate is bound to this workflow's OIDC identity. Harbor
-          # v2.15 detects the resulting cosign artifact via the OCI 1.1
-          # referrers API and shows a "Signed" badge in the UI.
-          cosign sign "${REF}"
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/harbor-build-push.yaml
+    with:
+      image: harbor.shion1305.com/shion1305/demo
+      context: ./harbor/demo
+      # The demo intentionally moves `latest` so a `docker pull
+      # harbor.shion1305.com/shion1305/demo` always pulls the most recent
+      # smoke-test image. Production callers should NOT pass extra-tags
+      # unless they have a deliberate reason — the reusable workflow
+      # defaults extra-tags to empty for that reason.
+      extra-tags: latest

--- a/.github/workflows/harbor-build-push.yaml
+++ b/.github/workflows/harbor-build-push.yaml
@@ -1,0 +1,285 @@
+# Reusable workflow: build a multi-arch OCI image, push it to
+# harbor.shion1305.com, and (optionally) keyless-sign it with cosign. Other
+# repos consume this with `uses:
+# Shion1305/k8s-GitOps/.github/workflows/harbor-build-push.yaml@<ref>` and pass
+# `image:` / `context:` etc. via `with:`.
+#
+# Why Vault JWT auth instead of long-lived robot-account GitHub Secrets:
+# Harbor's /v2/ token endpoint does not accept GitHub OIDC tokens directly
+# (unlike zot, which we wired up in demo-push-to-zot.yaml). The supported CI
+# path is a Harbor robot account — a project-scoped static credential. The
+# naive implementation is to drop those creds into per-repo
+# `HARBOR_ROBOT_USER` / `HARBOR_ROBOT_TOKEN` GitHub Secrets, but that has
+# real downsides:
+#   - The credential is long-lived; rotation requires touching every consumer
+#     repo.
+#   - Anyone with write access to a consuming repo's Settings can read the
+#     secret-name back into a workflow they control.
+#   - There is no central audit trail of who/what fetched the credential.
+# Instead we let each workflow exchange its short-lived (~10 min) GitHub OIDC
+# token for the robot creds at job start: GitHub mints the OIDC JWT, Vault's
+# `auth/jwt` method validates it, and Vault hands back the robot creds. The
+# robot creds themselves still exist (Harbor requires them) but they live in
+# Vault and never leave the runner's job context.
+#
+# Vault binding scope:
+# Vault role `harbor-robot-pusher` is configured with
+# `bound_audiences=https://github.com/Shion1305,https://github.com/Shion1305Dev`
+# and a `bound_claims` filter on `repository_owner ∈ {Shion1305,
+# Shion1305Dev}`. So this reusable workflow can only obtain robot creds when
+# called from a repo under one of those two GitHub orgs/users. A fork in some
+# unrelated namespace will fail at the Vault login step. `bound_audiences`
+# matches the GitHub default `aud` claim (`https://github.com/<owner>`), so
+# callers do NOT need to override `jwtGithubAudience` on the Vault action —
+# leaving it unset is correct.
+#
+# Why `id-token: write` is required (twice):
+# 1. To request the GitHub OIDC token that Vault validates for the robot-cred
+#    fetch (this workflow's primary auth).
+# 2. cosign keyless signing also exchanges the workflow's GitHub OIDC token,
+#    but for a short-lived Fulcio cert (a separate audience: `sigstore`).
+# Both flows mint OIDC tokens via the same `id-token: write` permission;
+# callers that forget to grant this on the calling job will fail at step 6.
+# See: https://docs.sigstore.dev/cosign/signing/overview/#keyless-signing
+#
+# Why crane and not `docker push`: crane works directly with OCI-layout
+# dirs/tarballs (no docker-daemon image-store round-trip), sends
+# `Authorization: Bearer` pre-emptively, and is more robust under CI
+# conditions. It reads ~/.docker/config.json and Just Works once the auth
+# blob is in place. Same reasoning as the zot demo workflow.
+
+name: harbor - build & push (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: >-
+          Full image reference WITHOUT tag, e.g.
+          `harbor.shion1305.com/shion1305/demo`. The robot account scoped to
+          the `shion1305` Harbor project can only push under that project's
+          namespace.
+        required: true
+        type: string
+      context:
+        description: Docker build context path (relative to repo root).
+        required: false
+        type: string
+        default: "."
+      dockerfile:
+        description: Dockerfile path relative to `context`.
+        required: false
+        type: string
+        default: Dockerfile
+      platforms:
+        description: >-
+          Comma-separated buildx target platforms. Default builds amd64 and
+          arm64 — matches the `harbor/demo` baseline.
+        required: false
+        type: string
+        default: linux/amd64,linux/arm64
+      sign:
+        description: >-
+          Whether to keyless-sign the pushed image with cosign. Off-by-default
+          would silently allow unsigned images, so we default ON; callers that
+          genuinely don't want signatures must opt out explicitly.
+        required: false
+        type: boolean
+        default: true
+      tag:
+        description: >-
+          Primary tag pushed for this image. Defaults to the calling repo's
+          commit SHA so every build is uniquely addressable.
+        required: false
+        type: string
+        default: ${{ github.sha }}
+      extra-tags:
+        description: >-
+          Comma-separated additional tags applied to the pushed image (e.g.
+          `latest,v1.2.3`). Empty string means no extras. Tags are remapped
+          against the digest, so they all point at the exact same artifact
+          as `tag`. Defaults to empty: callers that want a moving `latest`
+          must opt in explicitly so PR builds don't silently shift it.
+        required: false
+        type: string
+        default: ""
+    outputs:
+      digest:
+        description: >-
+          Digest of the pushed manifest (e.g. sha256:abc...). Use
+          `${IMAGE}@${digest}` to address the artifact unambiguously in
+          downstream deploy/attest steps — tags can move, digests cannot.
+        value: ${{ jobs.build-push.outputs.digest }}
+      ref:
+        description: >-
+          Full pinned image reference (image@digest). Convenience output so
+          callers don't have to re-concatenate inputs.image and the digest.
+        value: ${{ jobs.build-push.outputs.ref }}
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+      ref: ${{ steps.push.outputs.ref }}
+    permissions:
+      # Both Vault JWT login (step 6) and cosign keyless signing (step 8)
+      # require minting a fresh GitHub OIDC token from the runner. Without
+      # this, the OIDC request returns 403 and the job fails before any push.
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      # QEMU registers arm64 emulation on the amd64 GitHub-hosted runner so
+      # buildx can produce arm64 layers from the same Dockerfile.
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - uses: docker/setup-buildx-action@v3
+
+      # cosign signs the image keyless via Fulcio + Rekor. SBOM generation
+      # is intentionally NOT done in CI — Harbor v2.15's UI does not surface
+      # client-attached SBOM accessories (verified empirically: both
+      # `cosign attach sbom` and `cosign attest --type cyclonedx` produce
+      # accessory artifacts that Harbor stores but doesn't display in the
+      # SBOM column). Worse, those accessories appear as standalone rows
+      # that the "GENERATE SBOM" button can mis-target, causing Trivy to
+      # fail with "invalid tar header" while trying to extract a manifest
+      # JSON as if it were an image layer. So: signing only here; SBOM is
+      # produced by Harbor's own Trivy via the GENERATE SBOM action on the
+      # image artifact.
+      - uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: v2.4.1
+
+      # crane is installed via aqua so the local toolchain (aqua.yaml) and CI
+      # use the exact same pinned version. Matches the zot demo workflow.
+      - uses: aquaproj/aqua-installer@v4.0.4
+        with:
+          aqua_version: v2.58.0
+
+      # Exchange the workflow's GitHub OIDC token for the Harbor robot
+      # credentials kept in Vault at `harbor/data/robot-pusher` (KV v2). The
+      # vault-action does the OIDC mint + JWT login + KV read in one step
+      # and exposes the results as masked env vars. We rely on the GitHub
+      # default audience (`https://github.com/<owner>`) which matches the
+      # Vault role's `bound_audiences` — overriding `jwtGithubAudience` here
+      # would cause a 400 at the Vault side.
+      - name: Fetch Harbor robot credentials from Vault
+        uses: hashicorp/vault-action@v3
+        with:
+          url: https://vault.shion1305.com
+          method: jwt
+          role: harbor-robot-pusher
+          exportEnv: true
+          secrets: |
+            harbor/data/robot-pusher username | HARBOR_ROBOT_USER ;
+            harbor/data/robot-pusher password | HARBOR_ROBOT_TOKEN
+
+      # Guard against the silent-failure case where the vault-action step
+      # "succeeds" but the KV path is missing one of the expected fields
+      # (Vault returns 404 → action fails loud, but a renamed field would
+      # bind an empty string to the env var and crane would 401 with a
+      # generic message). Failing fast here surfaces the real cause.
+      - name: Verify robot credentials are non-empty
+        run: |
+          set -euo pipefail
+          if [ -z "${HARBOR_ROBOT_USER:-}" ] || [ -z "${HARBOR_ROBOT_TOKEN:-}" ]; then
+            echo "::error::Vault returned empty Harbor robot credentials." \
+                 "Check that harbor/data/robot-pusher contains both" \
+                 "'username' and 'password' fields."
+            exit 1
+          fi
+
+      # Build to an OCI-layout tarball. crane push reads OCI-layout dirs and
+      # pushes manifests with the OCI media type, which Harbor accepts.
+      # Multi-arch: buildx writes an OCI image index referencing one manifest
+      # per platform, and `crane push --index` propagates the whole index to
+      # Harbor in a single call.
+      - name: Build OCI image
+        env:
+          PLATFORMS: ${{ inputs.platforms }}
+          CONTEXT: ${{ inputs.context }}
+          DOCKERFILE: ${{ inputs.dockerfile }}
+        run: |
+          set -euo pipefail
+          docker buildx build \
+            --platform "${PLATFORMS}" \
+            --file "${CONTEXT}/${DOCKERFILE}" \
+            --output type=oci,dest=/tmp/image.tar \
+            "${CONTEXT}"
+
+      - name: Push and sign
+        id: push
+        env:
+          IMAGE: ${{ inputs.image }}
+          TAG: ${{ inputs.tag }}
+          EXTRA_TAGS: ${{ inputs.extra-tags }}
+          SIGN: ${{ inputs.sign }}
+          # COSIGN_YES suppresses cosign's interactive "are you sure"
+          # confirmation, required in non-TTY CI runners.
+          COSIGN_YES: "true"
+        run: |
+          set -euo pipefail
+          # Extract OCI tarball so crane can read it as an OCI layout dir.
+          mkdir -p /tmp/oci
+          tar -xf /tmp/image.tar -C /tmp/oci
+
+          # crane and cosign both read ~/.docker/config.json. Build it from
+          # the robot creds Vault just handed us: Harbor accepts basic auth
+          # on /v2/token and exchanges it for a short-lived bearer that
+          # crane/cosign then use for the actual push. HARBOR_ROBOT_USER
+          # and HARBOR_ROBOT_TOKEN come from the vault-action step above
+          # and are already registered as masks, so they will not leak in
+          # logs even if `set -x` were enabled.
+          mkdir -p ~/.docker
+          auth=$(printf '%s:%s' "$HARBOR_ROBOT_USER" "$HARBOR_ROBOT_TOKEN" | base64 -w0)
+          jq -n --arg a "$auth" \
+            '{auths: {"harbor.shion1305.com": {auth: $a}}}' > ~/.docker/config.json
+
+          # --index pushes the OCI image index (multi-arch manifest list)
+          # produced by buildx's --platform=...,... build. Without --index,
+          # crane would push only one of the per-arch manifests.
+          crane push --index /tmp/oci "${IMAGE}:${TAG}"
+
+          # Apply any extra tags by remapping them against the just-pushed
+          # primary tag. Empty input is a no-op (no extras requested).
+          if [ -n "${EXTRA_TAGS}" ]; then
+            IFS=',' read -ra TAGS <<< "${EXTRA_TAGS}"
+            for EXTRA_TAG in "${TAGS[@]}"; do
+              # Trim surrounding whitespace so callers can write
+              # `latest, v1.2.3` without breakage.
+              EXTRA_TAG="${EXTRA_TAG#"${EXTRA_TAG%%[![:space:]]*}"}"
+              EXTRA_TAG="${EXTRA_TAG%"${EXTRA_TAG##*[![:space:]]}"}"
+              [ -z "${EXTRA_TAG}" ] && continue
+              crane tag "${IMAGE}:${TAG}" "${EXTRA_TAG}"
+            done
+          fi
+
+          # Resolve the digest BEFORE signing. Tags can be remapped after the
+          # fact (latest can move), but a digest is the cryptographic hash of
+          # the manifest itself — signing by digest guarantees the signature
+          # binds to exactly this artifact. cosign will refuse a tag-only
+          # reference for sign/attest by design.
+          DIGEST=$(crane digest "${IMAGE}:${TAG}")
+          REF="${IMAGE}@${DIGEST}"
+          echo "Pushed ${REF}"
+
+          # Expose digest + full ref as step outputs so caller workflows can
+          # chain to deploy/attest jobs that need the digest-pinned reference
+          # (e.g. updating a Helm values file for ArgoCD GitOps sync).
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+
+          # Keyless cosign sign — no key material on disk, the signature
+          # certificate is bound to this workflow's OIDC identity. Harbor
+          # v2.15 detects the resulting cosign artifact via the OCI 1.1
+          # referrers API and shows a "Signed" badge in the UI.
+          if [ "${SIGN}" = "true" ]; then
+            echo "Signing ${REF}"
+            cosign sign "${REF}"
+          else
+            echo "Skipping cosign signing (sign=false)"
+          fi

--- a/vault/README.md
+++ b/vault/README.md
@@ -27,7 +27,7 @@ Vault is exposed on three hostnames, each with a different purpose:
 | Hostname | Network | Allowed Paths | Use Case |
 |----------|---------|---------------|----------|
 | `vault.i.shion1305.com` | Internal (WireGuard only) | All (full UI + API) | Admin/operator UI, all interactive use, `api_addr` |
-| `vault.shion1305.com` | Public internet | Allowlisted: `/v1/auth/jwt/login`, `/v1/auth/token/renew-self`, `/v1/auth/token/revoke-self` (KV-read paths to be added in the reusable-workflow PR) | CI (GitHub Actions) JWT login + token self-management |
+| `vault.shion1305.com` | Public internet | Allowlisted: `/v1/auth/jwt/login`, `/v1/auth/token/renew-self`, `/v1/auth/token/revoke-self`, `GET /v1/harbor/data/robot-pusher` | CI (GitHub Actions) JWT login + token self-management + scoped KV reads |
 | `vault.k.shion1305.com` | Public (legacy) | 301 redirect → `vault.i.shion1305.com` | Bookmark migration only; will be removed in a future PR |
 
 - **UI**: <https://vault.i.shion1305.com>

--- a/vault/httproute-external.yaml
+++ b/vault/httproute-external.yaml
@@ -1,16 +1,12 @@
-# Public Vault URL — auth + token-self-management only.
+# Public Vault URL — auth + token-self-management + scoped KV reads only.
 #
 # The only intended callers we expose externally are CI runners (GitHub
-# Actions) doing JWT login against Vault and managing their own token's
-# lifecycle. Admin paths (sys/*), the UI, and arbitrary API access stay on
-# the internal hostname (httproute-internal.yaml). Keeping this surface
-# allowlisted means a leaked CI credential cannot reach admin endpoints
-# regardless of any policy mistakes inside Vault.
-#
-# KV-data paths (/v1/<mount>/data/*) for CI to read scoped secrets will be
-# appended in the follow-up reusable-workflow PR (Harbor robot creds and
-# similar). They are intentionally NOT included here yet because the set of
-# mounts CI is allowed to read is being designed alongside that workflow.
+# Actions) doing JWT login against Vault, managing their own token's
+# lifecycle, and reading the specific KV paths their policy allows. Admin
+# paths (sys/*), the UI, and arbitrary API access stay on the internal
+# hostname (httproute-internal.yaml). Keeping this surface allowlisted means
+# a leaked CI credential cannot reach admin endpoints regardless of any
+# policy mistakes inside Vault.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -40,6 +36,19 @@ spec:
             type: Exact
             value: /v1/auth/token/revoke-self
           method: POST
+      backendRefs:
+        - name: vault
+          port: 8200
+    # KV v2 read paths exposed for CI. Each path is allowlisted explicitly
+    # (Exact + GET-only) so the surface stays minimal — a leaked CI token
+    # restricted by Vault policy still can't probe paths beyond this list.
+    # New CI-readable secrets MUST be appended here AND backed by a Vault
+    # policy that scopes the JWT role to that specific path.
+    - matches:
+        - path:
+            type: Exact
+            value: /v1/harbor/data/robot-pusher
+          method: GET
       backendRefs:
         - name: vault
           port: 8200

--- a/vault/scripts/setup-eso-policies.sh
+++ b/vault/scripts/setup-eso-policies.sh
@@ -289,6 +289,78 @@ vault write auth/kubernetes/role/eso-harbor-pull \
 echo "✓ Created role: eso-harbor-pull"
 
 echo ""
+echo "=== Configuring GitHub Actions OIDC (JWT auth) for CI pushes ==="
+
+# JWT auth method for GitHub Actions OIDC tokens. This is separate from the
+# Kubernetes auth method above — Kubernetes auth is for in-cluster ESO,
+# JWT auth is for external CI runners (GitHub-hosted) that mint short-lived
+# OIDC tokens via id-token: write. Vault verifies the token signature against
+# GitHub's JWKS (oidc_discovery_url), confirms the issuer, then matches the
+# token's claims against a per-role bound_claims allowlist.
+#
+# Reachable externally via https://vault.shion1305.com (path-allowlisted in
+# vault/httproute-external.yaml). The internal hostname stays unreachable
+# from GitHub Actions.
+vault auth enable -path=jwt jwt 2>/dev/null && echo "✓ Enabled auth method: jwt" || echo "ⓘ JWT auth method already enabled"
+
+vault write auth/jwt/config \
+  oidc_discovery_url="https://token.actions.githubusercontent.com" \
+  bound_issuer="https://token.actions.githubusercontent.com"
+echo "✓ Configured JWT auth: oidc_discovery_url=token.actions.githubusercontent.com"
+
+# Policy: read-only on harbor/robot-pusher (the dynamic Harbor robot password
+# lives at this single KV v2 path; the leaf is wrapped per KV v2 conventions
+# under /data/). Scope is intentionally a single Exact path — leaking the
+# CI token must not let the caller wander other harbor/* keys.
+vault policy write harbor-robot-pusher-reader - <<EOF
+path "harbor/data/robot-pusher" {
+  capabilities = ["read"]
+}
+EOF
+echo "✓ Created policy: harbor-robot-pusher-reader"
+
+# Role: accepts GitHub OIDC tokens minted for runs that invoke the reusable
+# workflow at .github/workflows/harbor-build-push.yaml in THIS repo. The
+# `repository_owner` filter allows callers under both `Shion1305` and
+# `Shion1305Dev`. Inside a reusable-workflow call, ALL standard claims
+# (`aud`, `repository`, `repository_owner`, `sub`, etc.) describe the
+# CALLING repo; only `job_workflow_ref` reflects the called workflow file.
+# That's why we have to list both owners in `bound_audiences` AND in
+# `bound_claims.repository_owner` — the called file's owner (Shion1305) is
+# only tracked via `job_workflow_ref`.
+# Reference: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/using-openid-connect-with-reusable-workflows
+#
+# bound_audiences: GitHub's @actions/core.getIDToken() defaults the `aud`
+# claim to `https://github.com/<repository_owner>` (caller's owner) when no
+# audience is passed. Listing both owners here means caller workflows do
+# NOT need to set `jwtGithubAudience`.
+#
+# user_claim=repository → audit logs identify the CALLING repo as
+# `owner/repo`, which is the readable form Vault operators want.
+#
+# bound_claims pins `job_workflow_ref` to runs that go through THIS repo's
+# harbor-build-push.yaml reusable workflow. Without that pin, any new repo
+# created under Shion1305 / Shion1305Dev would automatically be able to mint
+# Harbor push creds — far too wide a blast radius. The glob suffix `@*`
+# covers branches, tags, and SHAs (job_workflow_ref takes the form
+# `<owner>/<repo>/.../<file>@<ref>`); bound_claims_type=glob enables it.
+#
+# token_ttl=600s (10 min): plenty for a CI image build+push. No renewal —
+# the JWT is single-use, and short TTL means a leaked token expires before
+# anyone can exfiltrate it.
+vault write auth/jwt/role/harbor-robot-pusher \
+  role_type="jwt" \
+  user_claim="repository" \
+  bound_audiences="https://github.com/Shion1305,https://github.com/Shion1305Dev" \
+  bound_claims_type="glob" \
+  bound_claims='{"repository_owner":["Shion1305","Shion1305Dev"],"job_workflow_ref":"Shion1305/k8s-GitOps/.github/workflows/harbor-build-push.yaml@*"}' \
+  token_policies="harbor-robot-pusher-reader" \
+  token_ttl="600" \
+  token_max_ttl="600" \
+  token_explicit_max_ttl="600"
+echo "✓ Created JWT role: harbor-robot-pusher"
+
+echo ""
 echo "=== Removing old broad policy ==="
 vault policy delete eso-policy 2>/dev/null && echo "✓ Deleted old policy: eso-policy" || echo "ⓘ Policy eso-policy not found (already removed)"
 
@@ -309,3 +381,6 @@ echo "  eso-github-app  → SA external-secrets/external-secrets → github-app-
 echo "  eso-cloudflare-grafana → SA eso/monitoring     → cloudflare-grafana/data/*"
 echo "  eso-cluster-puller → SA external-secrets/external-secrets → zot/data/cluster-puller"
 echo "  eso-harbor-pull → SA external-secrets/external-secrets → harbor/data/robot-puller"
+echo ""
+echo "GitHub Actions JWT roles:"
+echo "  harbor-robot-pusher → repository_owner ∈ {Shion1305, Shion1305Dev} → harbor/data/robot-pusher"

--- a/vault/scripts/setup-eso-policies.sh
+++ b/vault/scripts/setup-eso-policies.sh
@@ -348,16 +348,26 @@ echo "✓ Created policy: harbor-robot-pusher-reader"
 # token_ttl=600s (10 min): plenty for a CI image build+push. No renewal —
 # the JWT is single-use, and short TTL means a leaked token expires before
 # anyone can exfiltrate it.
-vault write auth/jwt/role/harbor-robot-pusher \
-  role_type="jwt" \
-  user_claim="repository" \
-  bound_audiences="https://github.com/Shion1305,https://github.com/Shion1305Dev" \
-  bound_claims_type="glob" \
-  bound_claims='{"repository_owner":["Shion1305","Shion1305Dev"],"job_workflow_ref":"Shion1305/k8s-GitOps/.github/workflows/harbor-build-push.yaml@*"}' \
-  token_policies="harbor-robot-pusher-reader" \
-  token_ttl="600" \
-  token_max_ttl="600" \
-  token_explicit_max_ttl="600"
+# NOTE on the `vault write -` form: `bound_claims` is a map type. Passing it
+# as a flag (`bound_claims='{"...":"..."}'`) makes the CLI treat the value
+# as a string, and Vault rejects with `expected a map, got 'string'`. Piping
+# JSON via stdin (`vault write -`) is the canonical way to send map fields.
+vault write auth/jwt/role/harbor-robot-pusher - <<'EOF'
+{
+  "role_type": "jwt",
+  "user_claim": "repository",
+  "bound_audiences": ["https://github.com/Shion1305", "https://github.com/Shion1305Dev"],
+  "bound_claims_type": "glob",
+  "bound_claims": {
+    "repository_owner": ["Shion1305", "Shion1305Dev"],
+    "job_workflow_ref": "Shion1305/k8s-GitOps/.github/workflows/harbor-build-push.yaml@*"
+  },
+  "token_policies": ["harbor-robot-pusher-reader"],
+  "token_ttl": "600",
+  "token_max_ttl": "600",
+  "token_explicit_max_ttl": "600"
+}
+EOF
 echo "✓ Created JWT role: harbor-robot-pusher"
 
 echo ""


### PR DESCRIPTION
## Summary

- Replace `HARBOR_ROBOT_USER` / `HARBOR_ROBOT_TOKEN` GitHub Secrets with on-demand fetch from Vault via GitHub OIDC (JWT auth). Robot creds now live exclusively in Vault.
- Add reusable workflow `.github/workflows/harbor-build-push.yaml` that other repos under `Shion1305` and `Shion1305Dev` can call to push to `harbor.shion1305.com/shion1305/*`.
- Refactor `demo-push-to-harbor.yaml` from 158 lines of inline logic to a 47-line thin caller.

## Why

Long-lived robot creds in repo Settings have three real problems:
1. Rotation requires touching every consumer repo.
2. Anyone with repo Settings access can read the secret name back into a workflow they author.
3. No central audit trail of who/what fetched the credential.

Now: each run exchanges its short-lived (~10 min) GitHub OIDC token for the robot creds at job start. Vault validates the JWT (issuer, audience, `repository_owner`, `job_workflow_ref`) before handing back the creds. Vault audit log gives a single place to see which repo/run pulled the credential.

## Trust boundary

Vault role `harbor-robot-pusher` accepts tokens that satisfy ALL of:
- `iss = https://token.actions.githubusercontent.com`
- `aud ∈ { https://github.com/Shion1305, https://github.com/Shion1305Dev }`
- `repository_owner ∈ { Shion1305, Shion1305Dev }`
- `job_workflow_ref` matches `Shion1305/k8s-GitOps/.github/workflows/harbor-build-push.yaml@*`

The `job_workflow_ref` pin is the load-bearing constraint: a new repo created under either owner cannot mint Harbor push creds unless it actually `uses:` the reusable workflow file from this repo. That's a code-review-visible action, not a settings click.

`token_ttl = 600s`. JWTs are single-use — no renewal path needed.

## Pre-flight runbook (one-time, manual)

This PR ships GitOps-managed config but Vault state itself is bootstrapped imperatively. Order of operations:

1. **Confirm the `harbor` KV-v2 mount exists** in Vault (it was created during PR #305). If not: `vault secrets enable -path=harbor kv-v2`.
2. **Create the Harbor robot account** in Harbor's UI:
   - Login to https://harbor.i.shion1305.com (WireGuard required)
   - Projects → `shion1305` → Robot Accounts → New Robot Account
   - Name: `gha-pusher`, expiration: 365 days
   - Permissions: push and pull on Repository
   - Save the token (shown ONCE — Harbor cannot re-display it)
3. **Write the robot creds to Vault**:
   ```bash
   vault kv put harbor/robot-pusher \
     username='robot$shion1305+gha-pusher' \
     password='<the-token-from-step-2>'
   ```
4. **Run the updated `vault/scripts/setup-eso-policies.sh`** to enable JWT auth + create the role/policy. The script is idempotent.
5. **Verify** by triggering the demo: `gh workflow run demo-push-to-harbor.yaml` (or push a change under `harbor/demo/`).

After this, the previously-required GitHub repo secrets `HARBOR_ROBOT_USER` and `HARBOR_ROBOT_TOKEN` can be deleted.

## Reviews obtained

| Reviewer | Verdict |
|---|---|
| architect-review | APPROVE (after `job_workflow_ref` + outputs added) |
| code-reviewer | APPROVE (initial CHANGES-REQUESTED was based on incorrect claim about vault-action default audience; verified against source code) |
| security-auditor | APPROVE-WITH-NITS (blocker `job_workflow_ref` resolved; remaining nits about `bound_audiences` redundancy were based on incorrect claim about reusable-workflow OIDC claim semantics — verified against GitHub docs that all standard claims describe the CALLING repo) |
| deployment-engineer | APPROVE-WITH-NITS (outputs added; Renovate already covers action pins) |
| kubernetes-architect | APPROVE-WITH-NITS (HTTPRoute structurally correct; README updated; mount confirmation moved into this runbook) |

## Test plan

- [ ] `harbor` KV mount exists in Vault and `harbor/robot-pusher` is seeded with `username` + `password` fields
- [ ] `setup-eso-policies.sh` re-run successfully (`vault read auth/jwt/role/harbor-robot-pusher` returns the expected bindings)
- [ ] `vault read auth/jwt/config` shows `oidc_discovery_url=https://token.actions.githubusercontent.com`
- [ ] `kubectl get httproute vault-external -n vault -o yaml` shows the new `/v1/harbor/data/robot-pusher` GET match
- [ ] `curl -i https://vault.shion1305.com/v1/harbor/data/robot-pusher` returns 403 (unauthenticated, but reachable)
- [ ] Demo workflow triggers successfully on a push to `harbor/demo/**` and:
  - vault-action step succeeds (JWT login + KV read)
  - `crane push` succeeds against `harbor.shion1305.com`
  - `cosign sign` succeeds (Fulcio cert SAN includes `job_workflow_ref`)
  - Step outputs `digest` and `ref` are populated
- [ ] After verifying success, delete `HARBOR_ROBOT_USER` and `HARBOR_ROBOT_TOKEN` from this repo's GitHub Secrets