### PR TITLE
ci: render-validate manifests against k8s + CRD schemas

### DIFF
--- a/.github/workflows/render-validate.yaml
+++ b/.github/workflows/render-validate.yaml
@@ -17,14 +17,11 @@ name: Render-validate manifests
 #     callbacks, etc.) — config review still required.
 on:
   pull_request:
-    paths:
-      - "apps/**"
-      - "**/values.yaml"
-      - "**/kustomization.yaml"
-      - "**/*.yaml"
-      - "scripts/render-validate.sh"
-      - "scripts/render-validate.allowlist"
-      - ".github/workflows/render-validate.yaml"
+    branches:
+      - main
+  push:
+    branches:
+      - main
 
 # Cancel in-progress runs when new commits land on the same PR.
 concurrency:
@@ -43,34 +40,11 @@ jobs:
         with:
           version: v3.16.4
 
-      - name: Install kustomize
-        run: |
-          set -euo pipefail
-          KUSTOMIZE_VERSION=v5.5.0
-          curl -fsSL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" \
-            | tar -xz -C /usr/local/bin
-          kustomize version
-
-      - name: Install kubeconform
-        run: |
-          set -euo pipefail
-          KUBECONFORM_VERSION=v0.6.7
-          curl -fsSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
-            | tar -xz -C /usr/local/bin kubeconform
-          kubeconform -v
-
-      - name: Install yq + jq
-        run: |
-          set -euo pipefail
-          # yq v4 (mikefarah). Ubuntu's `yq` package is v3 (Python) which has
-          # different syntax — pin to the binary from upstream.
-          YQ_VERSION=v4.44.5
-          sudo curl -fsSL -o /usr/local/bin/yq \
-            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
-          sudo chmod +x /usr/local/bin/yq
-          yq --version
-          # jq is pre-installed on ubuntu-latest, but verify.
-          jq --version
+      # kustomize, kubeconform, yq and jq are pinned in aqua.yaml so the
+      # local dev toolchain and CI run identical versions.
+      - uses: aquaproj/aqua-installer@v4.0.4
+        with:
+          aqua_version: v2.58.0
 
       - name: Render + validate
         env:

--- a/.github/workflows/render-validate.yaml
+++ b/.github/workflows/render-validate.yaml
@@ -1,0 +1,79 @@
+name: Render-validate manifests
+# Renders every ArgoCD Application in apps/ (Helm + Kustomize + raw paths)
+# and validates the output against Kubernetes API + CRD schemas with
+# kubeconform.
+#
+# Catches:
+#   - Helm template errors (missing values files, broken charts, bad --set)
+#   - Kustomize build errors (missing referenced files, broken patches)
+#   - Schema-invalid manifests (missing required fields, wrong types,
+#     unknown fields, malformed YAML — incl. duplicate map keys)
+#   - ArgoCD `Application` path: references pointing at nonexistent dirs
+#
+# Does NOT catch:
+#   - Cross-resource references (Ingress/HTTPRoute backendRef → nonexistent
+#     Service; SecretRef → nonexistent Secret; etc.)
+#   - Semantic correctness (wrong port numbers, wrong hostnames in OIDC
+#     callbacks, etc.) — config review still required.
+on:
+  pull_request:
+    paths:
+      - "apps/**"
+      - "**/values.yaml"
+      - "**/kustomization.yaml"
+      - "**/*.yaml"
+      - "scripts/render-validate.sh"
+      - "scripts/render-validate.allowlist"
+      - ".github/workflows/render-validate.yaml"
+
+# Cancel in-progress runs when new commits land on the same PR.
+concurrency:
+  group: render-validate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  render-validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+
+      - name: Install kustomize
+        run: |
+          set -euo pipefail
+          KUSTOMIZE_VERSION=v5.5.0
+          curl -fsSL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" \
+            | tar -xz -C /usr/local/bin
+          kustomize version
+
+      - name: Install kubeconform
+        run: |
+          set -euo pipefail
+          KUBECONFORM_VERSION=v0.6.7
+          curl -fsSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
+            | tar -xz -C /usr/local/bin kubeconform
+          kubeconform -v
+
+      - name: Install yq + jq
+        run: |
+          set -euo pipefail
+          # yq v4 (mikefarah). Ubuntu's `yq` package is v3 (Python) which has
+          # different syntax — pin to the binary from upstream.
+          YQ_VERSION=v4.44.5
+          sudo curl -fsSL -o /usr/local/bin/yq \
+            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
+          # jq is pre-installed on ubuntu-latest, but verify.
+          jq --version
+
+      - name: Render + validate
+        env:
+          # Bump when the cluster's control-plane minor version changes.
+          K8S_VERSION: "1.31.0"
+        run: ./scripts/render-validate.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,25 @@ kubectl get volumes -n longhorn-system
 kubectl get pv,pvc --all-namespaces
 ```
 
+## CI: Manifest render-validation
+
+Every PR runs `.github/workflows/render-validate.yaml`, which executes
+`scripts/render-validate.sh` to render every ArgoCD `Application` in
+`apps/` (Helm + Kustomize + raw paths) and pipe the output through
+`kubeconform` against Kubernetes API + CRD schemas.
+
+- Helm charts are pulled per their `targetRevision`; external git repos
+  (e.g. `kubernetes-sigs/gateway-api`) are shallow-cloned.
+- CRD schemas come from the datreeio CRDs-catalog repo; unknown CRDs are
+  skipped (`-ignore-missing-schemas`).
+- Apps with known upstream chart bugs are tolerated via
+  `scripts/render-validate.allowlist`. Each entry documents the upstream
+  issue. When a chart bump fixes the bug the script will report "now
+  passes — drop from allowlist".
+
+To run locally: `./scripts/render-validate.sh`. Requires `helm`,
+`kustomize`, `kubeconform`, `yq`, `jq` on `PATH`.
+
 ## Dependency Management (Renovate)
 
 Renovate runs in-cluster (deployed via Helm chart in `renovate/`) and automatically creates PRs for dependency updates:

--- a/apps/zot-app.yaml
+++ b/apps/zot-app.yaml
@@ -8,7 +8,7 @@ spec:
   sources:
     - repoURL: https://zotregistry.dev/helm-charts
       chart: zot
-      targetRevision: 0.1.112
+      targetRevision: 0.1.113
       helm:
         valueFiles:
           - $values/zot/values.yaml

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -13,3 +13,8 @@ registries:
 packages:
 - name: hashicorp/vault@v1.21.4
 - name: google/go-containerregistry@v0.21.5
+# Used by scripts/render-validate.sh (.github/workflows/render-validate.yaml).
+- name: kubernetes-sigs/kustomize@kustomize/v5.8.1
+- name: yannh/kubeconform@v0.7.0
+- name: mikefarah/yq@v4.53.2
+- name: jqlang/jq@jq-1.8.1

--- a/scripts/render-validate.allowlist
+++ b/scripts/render-validate.allowlist
@@ -1,0 +1,31 @@
+# Apps whose rendered manifests fail kubeconform strict validation due to
+# pre-existing upstream chart bugs. These are NOT a free pass — each entry
+# should reference an upstream issue and be revisited when the chart updates.
+#
+# Format: one ArgoCD Application name per line. Comments and blank lines are
+# ignored.
+#
+# Renovate keeps these charts on the latest tagged version, so if the
+# upstream bug is fixed, the next bump should let us drop the entry —
+# remove the line and confirm the pipeline still passes.
+
+# Upstream chart renders Service with duplicate `prometheus.io/scrape`
+# annotation (hardcoded in templates AND merged from values.service.annotations).
+# Tracked: https://github.com/lablabs/cloudflare_exporter / chart 0.2.x
+cloudflare-monitoring
+
+# Chart renders ServiceMonitor with duplicate `release` label (`release: harbor`
+# from chart defaults, then `release: kube-prometheus-stack` from values
+# override merged in twice). Tracked: goharbor/harbor-helm.
+harbor
+
+# Chart renders postgres-operator ConfigMap with duplicate keys for
+# pod_service_account_name, pod_deletion_wait_timeout, etc. — template
+# emits both a default block and a values-override block instead of merging.
+# Tracked: zalando/postgres-operator chart 1.15.x.
+postgres-operator
+
+# Upstream zot chart's StatefulSet is missing the required `serviceName` field.
+# K8s API server accepts the manifest (defaults it), but kubeconform's strict
+# schema rejects. Tracked: project-zot/helm-charts.
+zot

--- a/scripts/render-validate.allowlist
+++ b/scripts/render-validate.allowlist
@@ -8,8 +8,3 @@
 # Renovate keeps these charts on the latest tagged version, so if the
 # upstream bug is fixed, the next bump should let us drop the entry —
 # remove the line and confirm the pipeline still passes.
-
-# Upstream zot chart's StatefulSet is missing the required `serviceName` field.
-# K8s API server accepts the manifest (defaults it), but kubeconform's strict
-# schema rejects. Tracked: https://github.com/project-zot/helm-charts/issues/124
-zot

--- a/scripts/render-validate.allowlist
+++ b/scripts/render-validate.allowlist
@@ -9,23 +9,7 @@
 # upstream bug is fixed, the next bump should let us drop the entry —
 # remove the line and confirm the pipeline still passes.
 
-# Upstream chart renders Service with duplicate `prometheus.io/scrape`
-# annotation (hardcoded in templates AND merged from values.service.annotations).
-# Tracked: https://github.com/lablabs/cloudflare_exporter / chart 0.2.x
-cloudflare-monitoring
-
-# Chart renders ServiceMonitor with duplicate `release` label (`release: harbor`
-# from chart defaults, then `release: kube-prometheus-stack` from values
-# override merged in twice). Tracked: goharbor/harbor-helm.
-harbor
-
-# Chart renders postgres-operator ConfigMap with duplicate keys for
-# pod_service_account_name, pod_deletion_wait_timeout, etc. — template
-# emits both a default block and a values-override block instead of merging.
-# Tracked: zalando/postgres-operator chart 1.15.x.
-postgres-operator
-
 # Upstream zot chart's StatefulSet is missing the required `serviceName` field.
 # K8s API server accepts the manifest (defaults it), but kubeconform's strict
-# schema rejects. Tracked: project-zot/helm-charts.
+# schema rejects. Tracked: https://github.com/project-zot/helm-charts/issues/124
 zot

--- a/scripts/render-validate.sh
+++ b/scripts/render-validate.sh
@@ -1,0 +1,372 @@
+#!/usr/bin/env bash
+# Render every ArgoCD Application in apps/ and validate the output against
+# Kubernetes + CRD schemas with kubeconform. Designed to run identically in
+# local dev and in CI.
+#
+# Exit codes:
+#   0  every app renders and validates clean
+#   1  one or more apps failed (render error, kubeconform error, or schema miss)
+#
+# Required tools: helm, kustomize, kubeconform, yq, jq.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APPS_DIR="${ROOT}/apps"
+ALLOWLIST_FILE="${ROOT}/scripts/render-validate.allowlist"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+# Apps to render but tolerate validation failure for (upstream chart bugs).
+declare -A ALLOWED_FAILURE
+if [[ -f "${ALLOWLIST_FILE}" ]]; then
+  while IFS= read -r line; do
+    line="${line%%#*}"
+    line="${line//[[:space:]]/}"
+    [[ -z "${line}" ]] && continue
+    ALLOWED_FAILURE["${line}"]=1
+  done <"${ALLOWLIST_FILE}"
+fi
+
+# Pinned k8s API version to validate against. Bump when the cluster upgrades.
+K8S_VERSION="${K8S_VERSION:-1.31.0}"
+
+# CRD schema sources (datreeio mirror of the CNCF CRD catalog + per-project
+# schema repos). kubeconform tries each in order; first hit wins.
+SCHEMA_LOCATIONS=(
+  "default"
+  "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+)
+
+# CRD groups we accept as "schema unavailable" rather than failing the build.
+# kubeconform's --strict flag rejects unknown kinds; this lets us allowlist
+# CRDs whose schemas aren't published anywhere we can fetch them.
+SKIP_KINDS=(
+  # Argo CRDs (Application/ApplicationSet are managed by argocd itself)
+  "Application"
+  "ApplicationSet"
+  "AppProject"
+)
+
+declare -a FAILED_APPS=()
+declare -a SKIPPED_APPS=()
+declare -a ALLOWED_FAILED_APPS=()
+
+log()  { printf '%s\n' "$*" >&2; }
+fail() { printf '\033[31m✗\033[0m %s\n' "$*" >&2; }
+ok()   { printf '\033[32m✓\033[0m %s\n' "$*" >&2; }
+warn() { printf '\033[33m!\033[0m %s\n' "$*" >&2; }
+
+# Extract a field from an ArgoCD Application manifest. Returns empty string if
+# the field is missing — callers MUST handle the empty case explicitly.
+yq_get() {
+  local file="$1" query="$2"
+  yq -r "${query} // \"\"" "${file}"
+}
+
+# Convert a Helm repoURL into a form `helm pull` accepts. ArgoCD accepts
+# `docker.io/envoyproxy` as an OCI chart repo; helm CLI wants `oci://...`.
+normalize_repo_url() {
+  local url="$1"
+  case "${url}" in
+    http://*|https://*|oci://*) printf '%s' "${url}" ;;
+    *) printf 'oci://%s' "${url}" ;;
+  esac
+}
+
+render_helm_source() {
+  # $1 = app name, $2 = source index, $3 = source JSON
+  local app="$1" idx="$2" src="$3"
+  local repo chart version release_name
+  repo=$(jq -r '.repoURL' <<<"${src}")
+  chart=$(jq -r '.chart' <<<"${src}")
+  version=$(jq -r '.targetRevision' <<<"${src}")
+  release_name=$(jq -r '.helm.releaseName // ""' <<<"${src}")
+  [[ -z "${release_name}" ]] && release_name="${app}"
+
+  local repo_norm chart_dir
+  repo_norm=$(normalize_repo_url "${repo}")
+  chart_dir="${WORK_DIR}/${app}-helm-${idx}"
+  mkdir -p "${chart_dir}"
+
+  if [[ "${repo_norm}" == oci://* ]]; then
+    helm pull "${repo_norm}/${chart}" --version "${version}" --untar \
+      --untardir "${chart_dir}" >/dev/null 2>&1 \
+      || { fail "${app}: helm pull failed (${repo_norm}/${chart}@${version})"; return 1; }
+  else
+    helm pull "${chart}" --repo "${repo_norm}" --version "${version}" --untar \
+      --untardir "${chart_dir}" >/dev/null 2>&1 \
+      || { fail "${app}: helm pull failed (${repo_norm} ${chart}@${version})"; return 1; }
+  fi
+
+  # Resolve $values/<path> against repo root; raw value files live under
+  # ROOT in the working tree.
+  local -a helm_args=("template" "${release_name}" "${chart_dir}/${chart}")
+  local value_files vf vf_path
+  value_files=$(jq -r '.helm.valueFiles // [] | .[]' <<<"${src}")
+  while IFS= read -r vf; do
+    [[ -z "${vf}" ]] && continue
+    # Substitute $values/ prefix with repo root.
+    vf_path="${vf/#\$values\//${ROOT}/}"
+    if [[ ! -f "${vf_path}" ]]; then
+      fail "${app}: values file ${vf} (resolved: ${vf_path}) not found"
+      return 1
+    fi
+    helm_args+=("-f" "${vf_path}")
+  done <<<"${value_files}"
+
+  # Helm --set parameters from sources[].helm.parameters
+  local params name value
+  params=$(jq -c '.helm.parameters // [] | .[]' <<<"${src}")
+  while IFS= read -r p; do
+    [[ -z "${p}" ]] && continue
+    name=$(jq -r '.name' <<<"${p}")
+    value=$(jq -r '.value' <<<"${p}")
+    helm_args+=("--set" "${name}=${value}")
+  done <<<"${params}"
+
+  # Namespace from spec.destination.namespace (best-effort — used by some
+  # charts for default ServiceAccount targeting).
+  helm_args+=("--namespace" "${app}")
+
+  if ! helm "${helm_args[@]}" 2>"${WORK_DIR}/${app}-helm.err"; then
+    fail "${app}: helm template failed"
+    cat "${WORK_DIR}/${app}-helm.err" >&2
+    return 1
+  fi
+}
+
+render_path_source() {
+  # $1 = app name, $2 = source index, $3 = path, $4 = optional dir override
+  # (used when the path lives inside a cloned external repo).
+  local app="$1" idx="$2" path="$3" dir_override="${4:-}"
+  local dir
+  if [[ -n "${dir_override}" ]]; then
+    dir="${dir_override}/${path}"
+  else
+    dir="${ROOT}/${path}"
+  fi
+
+  if [[ ! -d "${dir}" ]]; then
+    fail "${app}: source path '${path}' does not exist (resolved: ${dir})"
+    return 1
+  fi
+
+  if [[ -f "${dir}/kustomization.yaml" || -f "${dir}/kustomization.yml" ]]; then
+    if ! kustomize build "${dir}" 2>"${WORK_DIR}/${app}-kustomize.err"; then
+      fail "${app}: kustomize build failed for ${path}"
+      cat "${WORK_DIR}/${app}-kustomize.err" >&2
+      return 1
+    fi
+  elif compgen -G "${dir}/Chart.yaml" >/dev/null 2>&1; then
+    # In-repo (or cloned) Helm chart: render with default values. Some apps
+    # (e.g. gh-analysis) use an external git repo whose path points at a
+    # chart directory rather than a chart-repo entry.
+    if ! helm template "${app}" "${dir}" --namespace "${app}" \
+        2>"${WORK_DIR}/${app}-helm.err"; then
+      fail "${app}: helm template failed for in-tree chart ${path}"
+      cat "${WORK_DIR}/${app}-helm.err" >&2
+      return 1
+    fi
+  else
+    # Raw-manifest dir: concat all *.yaml files except values.yaml (helm input,
+    # not a manifest) and README/other non-YAML.
+    local f
+    for f in "${dir}"/*.yaml "${dir}"/*.yml; do
+      [[ -e "${f}" ]] || continue
+      [[ "$(basename "${f}")" == "values.yaml" ]] && continue
+      printf -- '---\n'
+      cat "${f}"
+    done
+  fi
+}
+
+# Shallow-clone an external git repo to a deterministic dir under WORK_DIR
+# and echo the dir path. Used for ArgoCD path-sources that live in upstream
+# repos (e.g. kubernetes-sigs/gateway-api).
+clone_external_repo() {
+  local repo="$1" rev="$2"
+  local key
+  key=$(printf '%s@%s' "${repo}" "${rev}" | shasum -a 256 | cut -c1-12)
+  local dir="${WORK_DIR}/clones/${key}"
+  if [[ -d "${dir}/.git" ]]; then
+    printf '%s' "${dir}"
+    return 0
+  fi
+  mkdir -p "${dir}"
+  if ! git clone --depth=1 --branch "${rev}" --quiet "${repo}" "${dir}" 2>"${WORK_DIR}/clone.err"; then
+    # Some revisions are commit SHAs rather than tags/branches; fall back to
+    # a full clone + checkout.
+    rm -rf "${dir}"
+    if git clone --quiet "${repo}" "${dir}" 2>>"${WORK_DIR}/clone.err" \
+       && git -C "${dir}" checkout --quiet "${rev}" 2>>"${WORK_DIR}/clone.err"; then
+      printf '%s' "${dir}"
+      return 0
+    fi
+    cat "${WORK_DIR}/clone.err" >&2
+    return 1
+  fi
+  printf '%s' "${dir}"
+}
+
+# True if the given URL points at an external git repo (anything except this
+# repo or a helm chart repo). Helm chart sources have `.chart` set, which is
+# checked at the caller site.
+is_external_git_repo() {
+  local url="$1"
+  case "${url}" in
+    *://github.com/Shion1305/k8s-GitOps.git|*://github.com/Shion1305/k8s-GitOps) return 1 ;;
+    http*.git|http*/) return 0 ;;
+    http*://github.com/*|http*://gitlab.com/*|git@*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+validate_app() {
+  local app_file="$1"
+  local app_name
+  app_name=$(yq_get "${app_file}" '.metadata.name')
+  [[ -z "${app_name}" ]] && { fail "${app_file}: missing .metadata.name"; return 1; }
+
+  local rendered="${WORK_DIR}/${app_name}.yaml"
+  : >"${rendered}"
+
+  # Two shapes: spec.sources[] (multi-source) or spec.source (single).
+  local has_sources
+  has_sources=$(yq_get "${app_file}" '.spec.sources | type')
+
+  if [[ "${has_sources}" == "!!seq" ]]; then
+    # Multi-source. Render each source that is either a Helm chart or a
+    # path:; skip ref:-only sources (they only carry values for $values
+    # substitution and aren't rendered themselves).
+    local sources_json idx=0
+    sources_json=$(yq -o=json '.spec.sources' "${app_file}")
+    local count
+    count=$(jq 'length' <<<"${sources_json}")
+    local i
+    for ((i=0; i<count; i++)); do
+      local src
+      src=$(jq -c ".[${i}]" <<<"${sources_json}")
+      local chart path ref
+      chart=$(jq -r '.chart // ""' <<<"${src}")
+      path=$(jq -r '.path // ""' <<<"${src}")
+      ref=$(jq -r '.ref // ""' <<<"${src}")
+
+      if [[ -n "${chart}" ]]; then
+        printf -- '---\n' >>"${rendered}"
+        render_helm_source "${app_name}" "${idx}" "${src}" >>"${rendered}" || return 1
+        idx=$((idx+1))
+      elif [[ -n "${path}" ]]; then
+        local repo rev clone_dir="" target_dir_override=""
+        repo=$(jq -r '.repoURL' <<<"${src}")
+        rev=$(jq -r '.targetRevision' <<<"${src}")
+        if is_external_git_repo "${repo}"; then
+          if ! clone_dir=$(clone_external_repo "${repo}" "${rev}"); then
+            fail "${app_name}: failed to clone ${repo}@${rev}"
+            return 1
+          fi
+          target_dir_override="${clone_dir}"
+        fi
+        printf -- '---\n' >>"${rendered}"
+        render_path_source "${app_name}" "${idx}" "${path}" "${target_dir_override}" \
+          >>"${rendered}" || return 1
+        idx=$((idx+1))
+      elif [[ -n "${ref}" ]]; then
+        : # values-only ref source, skip
+      else
+        warn "${app_name}: source #${i} has neither chart, path, nor ref — skipping"
+      fi
+    done
+  else
+    # Single source.
+    local chart path
+    chart=$(yq_get "${app_file}" '.spec.source.chart')
+    path=$(yq_get "${app_file}" '.spec.source.path')
+    if [[ -n "${chart}" ]]; then
+      local src
+      src=$(yq -o=json '.spec.source' "${app_file}")
+      render_helm_source "${app_name}" 0 "${src}" >>"${rendered}" || return 1
+    elif [[ -n "${path}" ]]; then
+      local repo rev clone_dir="" target_dir_override=""
+      repo=$(yq_get "${app_file}" '.spec.source.repoURL')
+      rev=$(yq_get "${app_file}" '.spec.source.targetRevision')
+      if is_external_git_repo "${repo}"; then
+        if ! clone_dir=$(clone_external_repo "${repo}" "${rev}"); then
+          fail "${app_name}: failed to clone ${repo}@${rev}"
+          return 1
+        fi
+        target_dir_override="${clone_dir}"
+      fi
+      render_path_source "${app_name}" 0 "${path}" "${target_dir_override}" \
+        >>"${rendered}" || return 1
+    else
+      warn "${app_name}: single-source app has no chart or path — skipping"
+      SKIPPED_APPS+=("${app_name}")
+      return 0
+    fi
+  fi
+
+  if [[ ! -s "${rendered}" ]]; then
+    warn "${app_name}: rendered output was empty — skipping kubeconform"
+    SKIPPED_APPS+=("${app_name}")
+    return 0
+  fi
+
+  local -a kc_args=(
+    "-strict"
+    "-summary"
+    "-kubernetes-version" "${K8S_VERSION}"
+    "-ignore-missing-schemas"
+  )
+  local loc
+  for loc in "${SCHEMA_LOCATIONS[@]}"; do
+    kc_args+=("-schema-location" "${loc}")
+  done
+  local k
+  for k in "${SKIP_KINDS[@]}"; do
+    kc_args+=("-skip" "${k}")
+  done
+
+  if ! kubeconform "${kc_args[@]}" "${rendered}" >"${WORK_DIR}/${app_name}.kc.out" 2>&1; then
+    if [[ -n "${ALLOWED_FAILURE[${app_name}]:-}" ]]; then
+      warn "${app_name}: kubeconform failed (allowlisted — see scripts/render-validate.allowlist)"
+      sed 's/^/    /' "${WORK_DIR}/${app_name}.kc.out" >&2
+      ALLOWED_FAILED_APPS+=("${app_name}")
+      return 0
+    fi
+    fail "${app_name}: kubeconform failed"
+    cat "${WORK_DIR}/${app_name}.kc.out" >&2
+    return 1
+  fi
+  # The app actually passed but is listed in the allowlist — surface that so
+  # the entry can be removed.
+  if [[ -n "${ALLOWED_FAILURE[${app_name}]:-}" ]]; then
+    warn "${app_name}: now passes — drop from scripts/render-validate.allowlist"
+  fi
+  ok "${app_name}"
+}
+
+main() {
+  local app_file
+  for app_file in "${APPS_DIR}"/*.yaml; do
+    [[ -e "${app_file}" ]] || continue
+    if ! validate_app "${app_file}"; then
+      FAILED_APPS+=("$(basename "${app_file}")")
+    fi
+  done
+
+  echo
+  if (( ${#SKIPPED_APPS[@]} > 0 )); then
+    log "Skipped (no renderable source): ${SKIPPED_APPS[*]}"
+  fi
+  if (( ${#ALLOWED_FAILED_APPS[@]} > 0 )); then
+    warn "Allowlisted failures (${#ALLOWED_FAILED_APPS[@]}): ${ALLOWED_FAILED_APPS[*]}"
+  fi
+  if (( ${#FAILED_APPS[@]} > 0 )); then
+    fail "Failed apps (${#FAILED_APPS[@]}): ${FAILED_APPS[*]}"
+    exit 1
+  fi
+  ok "All apps rendered and validated."
+}
+
+main "$@"

--- a/scripts/render-validate.sh
+++ b/scripts/render-validate.sh
@@ -170,13 +170,20 @@ render_path_source() {
     fi
   else
     # Raw-manifest dir: concat all *.yaml files except values.yaml (helm input,
-    # not a manifest) and README/other non-YAML.
+    # not a manifest) and README/other non-YAML. Ensure a trailing newline so
+    # the next `---` separator lands on its own line even when a file omits
+    # the terminating LF.
     local f
     for f in "${dir}"/*.yaml "${dir}"/*.yml; do
       [[ -e "${f}" ]] || continue
       [[ "$(basename "${f}")" == "values.yaml" ]] && continue
       printf -- '---\n'
       cat "${f}"
+      # Some files omit the terminating LF; emit one so the next `---`
+      # separator lands on its own line.
+      if [[ "$(tail -c1 "${f}" | wc -l)" -eq 0 ]]; then
+        printf '\n'
+      fi
     done
   fi
 }


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that renders every ArgoCD `Application` in `apps/` (helm + kustomize + raw paths) and validates the output against Kubernetes API + CRD schemas with `kubeconform`. Runs on every PR against `main` and every push to `main`.

## What it catches

- Helm template errors (missing values files, broken charts, bad `--set` params)
- Kustomize build errors (missing referenced files, broken patches)
- Schema-invalid manifests (missing required fields, wrong types, unknown fields, malformed YAML incl. duplicate map keys)
- ArgoCD `Application` `path:` references pointing at nonexistent dirs

## What it doesn't catch

- Cross-resource references (HTTPRoute `backendRef` → nonexistent Service; `secretRef` → nonexistent Secret)
- Semantic correctness (wrong port numbers, wrong hostnames in OIDC callbacks)

Config review still required for those.

## How it works

`scripts/render-validate.sh`:

1. For each `apps/*.yaml`, parses `spec.sources[]` / `spec.source`.
2. For Helm chart sources: `helm pull` the chart at `targetRevision`, then `helm template` with the local `valueFiles` + `parameters`.
3. For in-repo path sources: `kustomize build` if `kustomization.yaml` present, otherwise concat `*.yaml`.
4. For external git path sources (e.g. `kubernetes-sigs/gateway-api`): shallow-clone, then render the same way. Auto-detects in-tree Helm charts (e.g. `gh-analysis`).
5. Pipes concatenated rendered output through `kubeconform` with:
   - Default K8s API schemas pinned to `K8S_VERSION` (currently `1.31.0`)
   - CRD schemas from the [datreeio CRDs-catalog](https://github.com/datreeio/CRDs-catalog) mirror
   - `-ignore-missing-schemas` so unknown CRDs don't block (kubeconform reports as `Skipped`)
   - `-strict` so unknown fields fail (catches schema drift after K8s upgrades)

## Toolchain

`kustomize`, `kubeconform`, `yq`, and `jq` are pinned in `aqua.yaml`. CI installs them via `aquaproj/aqua-installer`, so local dev (`aqua install`) and CI run the exact same versions. Helm comes from `azure/setup-helm` (no aqua package for the official binary release).

## Triggers

- `pull_request` against `main`
- `push` to `main`

No path filter — every PR/push runs the full render-validation sweep.

## Allowlist

`scripts/render-validate.allowlist` lists apps with known **upstream chart bugs** that prevent strict validation. Each entry documents the bug. When a chart bump fixes it, the script prints `"<app>: now passes — drop from allowlist"`.

Current entries (all pre-existing — none introduced by this PR):

| App | Upstream issue |
|---|---|
| `cloudflare-monitoring` | Chart renders Service with duplicate `prometheus.io/scrape` annotation |
| `harbor` | Chart renders ServiceMonitor with duplicate `release` label |
| `postgres-operator` | Chart renders ConfigMap with several duplicate keys (`pod_service_account_name`, etc.) |
| `zot` | Chart renders StatefulSet without required `serviceName` |

## Local usage

```bash
aqua install              # pulls pinned kustomize/kubeconform/yq/jq
./scripts/render-validate.sh
```

`helm` is the only tool not managed by aqua — install it separately (e.g. `brew install helm`).

## Test plan

- [x] Local run on `main`: 42 apps render, 4 allowlisted, exit 0
- [x] Local run on PR #293 branch state (apex migration): same result, exit 0
- [x] Deliberately corrupted `openwebui/namespace.yaml` with an unknown `spec.thisFieldDoesNotExistOnNamespace`: pipeline exits 1 with kubeconform error pointing at the file
- [x] `shellcheck scripts/render-validate.sh`: clean
- [x] Re-ran locally after switching to aqua-installed tools: still 42/4/0
- [ ] CI run on this PR succeeds