### PR TITLE
fix(cloudflare-exporter): drop duplicate prometheus.io/scrape annotation

### DIFF
--- a/cloudflare-exporter/values.yaml
+++ b/cloudflare-exporter/values.yaml
@@ -17,8 +17,10 @@ env:
 service:
   type: ClusterIP
   port: 8080
+  # Note: prometheus.io/scrape is added by the chart via
+  # `addPrometheusScrapeAnnotation: true` (default). Re-adding it here
+  # produces a duplicate map key that fails strict YAML/JSON validation.
   annotations:
-    prometheus.io/scrape: "true"
     prometheus.io/port: "8080"
     prometheus.io/path: "/metrics"
 # Resource limits


### PR DESCRIPTION
## Summary

The lablabs/cloudflare-exporter Helm chart (0.2.3) renders a duplicate `prometheus.io/scrape: "true"` annotation on the Service: once hardcoded in `templates/service.yaml` (gated by `service.addPrometheusScrapeAnnotation`, which defaults to `true`), and once merged in from our `service.annotations` override. Last-key-wins makes this work at runtime, but it's invalid by the JSON schema (duplicate map key) and `kubeconform -strict` rejects it.

This change drops `prometheus.io/scrape: "true"` from `cloudflare-exporter/values.yaml`. The chart's default `addPrometheusScrapeAnnotation: true` continues to emit it. `prometheus.io/port` and `prometheus.io/path` are kept (not hardcoded upstream).

## Repro

```
helm pull cloudflare-exporter --repo https://lablabs.github.io/cloudflare-exporter --version 0.2.3 --untar --untardir /tmp/cf-test
helm template cloudflare-exporter /tmp/cf-test/cloudflare-exporter -f cloudflare-exporter/values.yaml | awk '/^kind: Service$/,/^---$/'
```

Before this fix:
```yaml
annotations:
  prometheus.io/scrape: "true"
  prometheus.io/path: /metrics
  prometheus.io/port: "8080"
  prometheus.io/scrape: "true"   # <-- duplicate
```

After:
```yaml
annotations:
  prometheus.io/scrape: "true"
  prometheus.io/path: /metrics
  prometheus.io/port: "8080"
```

## Relation to PR #318 (render-validate CI)

PR #318 introduces a CI pipeline that renders every ArgoCD Application and validates the output with `kubeconform -strict`. `cloudflare-monitoring` is currently allowlisted in `scripts/render-validate.allowlist` precisely because of this bug. The allowlist does not exist on `main` yet, so this PR intentionally does NOT modify it. Once #318 merges, a follow-up commit on that branch (or a separate cleanup PR) should remove `cloudflare-monitoring` from the allowlist so strict validation begins to enforce.

## Test plan

- [x] Confirmed the chart hardcodes the annotation in `templates/service.yaml` (gated by `addPrometheusScrapeAnnotation`, default `true`).
- [x] Re-rendered with the new values.yaml: `prometheus.io/scrape: "true"` appears exactly once.
- [ ] Runtime check post-merge: ArgoCD sync of `cloudflare-monitoring` shows no diff churn (Service annotation set is unchanged in effect).