### PR TITLE
fix(postgres-operator): drop duplicate keys in rendered ConfigMap

### DIFF
--- a/postgres-operator/values.yaml
+++ b/postgres-operator/values.yaml
@@ -14,7 +14,9 @@ configGeneral:
   enable_pgversion_env_var: true
   enable_shm_volume: true
   enable_spilo_wal_path_compat: false
-  enable_team_superuser: false
+  # enable_team_superuser belongs under configTeamsApi (the chart emits it
+  # there); setting it here as well would produce a duplicate key in the
+  # rendered ConfigMap.
   etcd_host: ""
   kubernetes_use_configmaps: false
   spilo_runasuser: 101
@@ -49,12 +51,15 @@ configKubernetes:
   node_readiness_label_merge: "OR"
   oauth_token_secret_name: "postgresql-operator"
   pdb_name_format: "postgres-{cluster}-pdb"
-  pod_deletion_wait_timeout: "10m"
-  pod_label_wait_timeout: "10m"
+  # pod_deletion_wait_timeout / pod_label_wait_timeout live under
+  # configTimeouts in the upstream chart; declaring them here as well would
+  # produce duplicate keys in the rendered ConfigMap.
   pod_management_policy: "ordered_ready"
   pod_role_label: "spilo-role"
   pod_service_account_definition: ""
-  pod_service_account_name: "postgres-pod"
+  # pod_service_account_name is hardcoded by the chart's configmap.yaml
+  # template (sourced from .Values.podServiceAccount.name); declaring it
+  # here as well would produce a duplicate key.
   pod_service_account_role_binding_definition: ""
   pod_terminate_grace_period: "5m"
   spilo_privileged: false

--- a/postgres-operator/values.yaml
+++ b/postgres-operator/values.yaml
@@ -14,9 +14,6 @@ configGeneral:
   enable_pgversion_env_var: true
   enable_shm_volume: true
   enable_spilo_wal_path_compat: false
-  # enable_team_superuser belongs under configTeamsApi (the chart emits it
-  # there); setting it here as well would produce a duplicate key in the
-  # rendered ConfigMap.
   etcd_host: ""
   kubernetes_use_configmaps: false
   spilo_runasuser: 101
@@ -51,15 +48,9 @@ configKubernetes:
   node_readiness_label_merge: "OR"
   oauth_token_secret_name: "postgresql-operator"
   pdb_name_format: "postgres-{cluster}-pdb"
-  # pod_deletion_wait_timeout / pod_label_wait_timeout live under
-  # configTimeouts in the upstream chart; declaring them here as well would
-  # produce duplicate keys in the rendered ConfigMap.
   pod_management_policy: "ordered_ready"
   pod_role_label: "spilo-role"
   pod_service_account_definition: ""
-  # pod_service_account_name is hardcoded by the chart's configmap.yaml
-  # template (sourced from .Values.podServiceAccount.name); declaring it
-  # here as well would produce a duplicate key.
   pod_service_account_role_binding_definition: ""
   pod_terminate_grace_period: "5m"
   spilo_privileged: false


### PR DESCRIPTION
## Summary

The zalando/postgres-operator 1.15.1 Helm chart renders the operator
`ConfigMap` by range-iterating over multiple `config*` sections of values,
**and** hardcodes `pod_service_account_name` directly in the template.
Our `values.yaml` declared four keys in sections the chart was already
populating from elsewhere, producing duplicate keys in the rendered YAML
(invalid per YAML 1.2; rejected by kubeconform and `--strict` parsers):

| Key | Where chart already emits it | Where we duplicated it |
| --- | --- | --- |
| `pod_service_account_name` | hardcoded in `templates/configmap.yaml` line 16 | `configKubernetes.pod_service_account_name` |
| `pod_deletion_wait_timeout` | chart default `configTimeouts.pod_deletion_wait_timeout: 10m` | `configKubernetes.pod_deletion_wait_timeout: "10m"` |
| `pod_label_wait_timeout` | chart default `configTimeouts.pod_label_wait_timeout: 10m` | `configKubernetes.pod_label_wait_timeout: "10m"` |
| `enable_team_superuser` | `configTeamsApi.enable_team_superuser: false` (already set by us) | `configGeneral.enable_team_superuser: false` |

This fix removes the duplicate declarations from our `values.yaml`. All
four removed values match either the chart defaults or the `configTeamsApi`
copy we kept, so the rendered ConfigMap is byte-identical apart from the
removed duplicates and the (expected) deployment annotation
`checksum/config` rotation.

This unblocks kubeconform validation for `postgres-operator` under the
CI pipeline added in #318.

## Reproduction

Before fix (against `main`):

```
$ helm pull postgres-operator \
    --repo https://opensource.zalando.com/postgres-operator/charts/postgres-operator \
    --version 1.15.1 --untar --untardir /tmp/po
$ helm template postgres-operator /tmp/po/postgres-operator \
    -f postgres-operator/values.yaml > /tmp/po-rendered.yaml
$ grep -c '^  pod_service_account_name:'  /tmp/po-rendered.yaml   # 2
$ grep -c '^  enable_team_superuser:'     /tmp/po-rendered.yaml   # 2
$ grep -c '^  pod_deletion_wait_timeout:' /tmp/po-rendered.yaml   # 2
$ grep -c '^  pod_label_wait_timeout:'    /tmp/po-rendered.yaml   # 2
```

After fix: each count is `1`.

## Test plan

- [x] `helm template` produces no duplicate keys in the `postgres-operator` ConfigMap
- [x] `diff` of the rendered output shows only the four duplicate lines removed (plus the expected `checksum/config` rotation) — operator behaviour is unchanged
- [x] All four removed values match the chart defaults / the kept declaration, so no semantic change to operator configuration
- [ ] CI kubeconform validates the `postgres-operator` Application without the allowlist (follow-up: drop from allowlist in CI once this lands)