### PR TITLE
fix(harbor): drop duplicate release label on ServiceMonitor

### DIFF
--- a/harbor/values.yaml
+++ b/harbor/values.yaml
@@ -217,22 +217,10 @@ exporter:
 # -----------------------------------------------------------------------------
 # metrics — Prometheus /metrics + ServiceMonitor (kube-prometheus-stack)
 # -----------------------------------------------------------------------------
-# NOTE: `metrics.serviceMonitor.additionalLabels` is intentionally NOT set.
-#
-# Upstream chart bug (goharbor/harbor-helm@1.19.0,
-# templates/metrics/metrics-svcmon.yaml): the ServiceMonitor template emits
-# the chart-default `release: <Release.Name>` label via `harbor.labels`, then
-# APPENDS any `additionalLabels` keys verbatim instead of merging — so passing
-# `additionalLabels: { release: kube-prometheus-stack }` produces a YAML map
-# with two `release:` keys, which is invalid YAML by strict schema and fails
-# kubeconform validation in CI.
-#
-# We don't need to override the label anyway: the in-cluster Prometheus
-# (`grafana/values.yaml`) is configured with `serviceMonitorSelector: {}` and
-# `serviceMonitorSelectorNilUsesHelmValues: false`, i.e. it scrapes every
-# ServiceMonitor in the cluster regardless of label. Leaving the chart-default
-# `release: harbor` label in place is therefore correct and avoids the
-# duplicate-key bug entirely.
+# `metrics.serviceMonitor.additionalLabels` is intentionally unset: upstream
+# chart appends instead of merging, producing duplicate `release:` keys (bug
+# in goharbor/harbor-helm@1.19.0 templates/metrics/metrics-svcmon.yaml). Our
+# Prometheus uses `serviceMonitorSelector: {}` so no label override is needed.
 metrics:
   enabled: true
   serviceMonitor:

--- a/harbor/values.yaml
+++ b/harbor/values.yaml
@@ -217,12 +217,26 @@ exporter:
 # -----------------------------------------------------------------------------
 # metrics — Prometheus /metrics + ServiceMonitor (kube-prometheus-stack)
 # -----------------------------------------------------------------------------
+# NOTE: `metrics.serviceMonitor.additionalLabels` is intentionally NOT set.
+#
+# Upstream chart bug (goharbor/harbor-helm@1.19.0,
+# templates/metrics/metrics-svcmon.yaml): the ServiceMonitor template emits
+# the chart-default `release: <Release.Name>` label via `harbor.labels`, then
+# APPENDS any `additionalLabels` keys verbatim instead of merging — so passing
+# `additionalLabels: { release: kube-prometheus-stack }` produces a YAML map
+# with two `release:` keys, which is invalid YAML by strict schema and fails
+# kubeconform validation in CI.
+#
+# We don't need to override the label anyway: the in-cluster Prometheus
+# (`grafana/values.yaml`) is configured with `serviceMonitorSelector: {}` and
+# `serviceMonitorSelectorNilUsesHelmValues: false`, i.e. it scrapes every
+# ServiceMonitor in the cluster regardless of label. Leaving the chart-default
+# `release: harbor` label in place is therefore correct and avoids the
+# duplicate-key bug entirely.
 metrics:
   enabled: true
   serviceMonitor:
     enabled: true
-    additionalLabels:
-      release: kube-prometheus-stack
 
 # -----------------------------------------------------------------------------
 # logging


### PR DESCRIPTION
## Summary

Fixes a duplicate `release:` map key emitted by the upstream
`goharbor/harbor-helm` 1.19.0 ServiceMonitor template — invalid YAML by
strict schema, would fail kubeconform validation in the CI pipeline
introduced by #318.

## Root cause

`templates/metrics/metrics-svcmon.yaml` emits the chart-default
`release: <Release.Name>` label via `harbor.labels`, then **appends**
any `metrics.serviceMonitor.additionalLabels` keys verbatim instead of
merging:

```yaml
labels: {{ include "harbor.labels" . | nindent 4 }}
{{- if .Values.metrics.serviceMonitor.additionalLabels }}
{{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
{{- end }}
```

Our `additionalLabels: { release: kube-prometheus-stack }` therefore
produced a YAML map with two `release:` keys.

## Fix

Removed the `additionalLabels` override. We don't need it: in-cluster
Prometheus (`grafana/values.yaml`) is configured with
`serviceMonitorSelector: {}` and
`serviceMonitorSelectorNilUsesHelmValues: false`, i.e. it scrapes every
ServiceMonitor regardless of label. The chart-default `release: harbor`
label is therefore fine and the rendered `selector.matchLabels`
(`release: harbor`, `app: harbor`) still matches the chart-rendered
`harbor-core`, `harbor-exporter`, `harbor-jobservice`, and
`harbor-registry` Services that expose `http-metrics`.

## Reproduction (before)

```
$ helm pull harbor --repo https://helm.goharbor.io --version 1.19.0 --untar --untardir /tmp/h
$ helm template harbor /tmp/h/harbor -f harbor/values.yaml | awk '/^kind: ServiceMonitor$/,/^---$/'
kind: ServiceMonitor
metadata:
  name: harbor
  namespace: "github-readme-stats-public"
  labels:
    heritage: Helm
    release: harbor              # <-- chart default
    chart: harbor
    app: "harbor"
    app.kubernetes.io/instance: harbor
    app.kubernetes.io/name: harbor
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: harbor
    app.kubernetes.io/version: "2.15.0"
    release: kube-prometheus-stack   # <-- our override, appended (DUPLICATE KEY)
spec:
  ...
```

## Verification (after)

```
$ helm template harbor /tmp/h/harbor -f harbor/values.yaml | awk '/^kind: ServiceMonitor$/,/^---$/'
kind: ServiceMonitor
metadata:
  name: harbor
  namespace: "github-readme-stats-public"
  labels:
    heritage: Helm
    release: harbor
    chart: harbor
    app: "harbor"
    app.kubernetes.io/instance: harbor
    app.kubernetes.io/name: harbor
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: harbor
    app.kubernetes.io/version: "2.15.0"
spec:
  jobLabel: app.kubernetes.io/name
  endpoints:
  - port:  http-metrics
    honorLabels: true
  selector:
    matchLabels:
      release: harbor
      app: "harbor"
```

Single `release:` key. The `selector.matchLabels` still matches every
metrics-exposing Service rendered by the chart (verified by inspecting
the rendered Services — all carry `release: harbor` + `app: harbor`).

## Follow-up

Once this PR and #318 both merge, the `harbor` entry in #318's CI
allowlist for upstream-chart-bug apps should be dropped. (Not touching
the allowlist here because it doesn't exist on `main` yet.)

## Test plan

- [x] Reproduce duplicate `release:` key with stock chart + current values
- [x] Confirm fix removes the duplicate
- [x] Confirm rendered `selector.matchLabels` still matches Harbor's
      metrics Services (`release: harbor`, `app: harbor`)
- [x] Confirm Prometheus instance is configured to scrape any
      ServiceMonitor regardless of label (`grafana/values.yaml` →
      `serviceMonitorSelector: {}`)
- [ ] After merge, watch Prometheus targets to verify Harbor's
      `http-metrics` endpoints are still being scraped