### PR TITLE
chore(renovate): track aqua packages in *.aqua.yaml via customManagers

### DIFF
--- a/.github/workflows/harbor.aqua.yaml
+++ b/.github/workflows/harbor.aqua.yaml
@@ -15,9 +15,10 @@
 # callers to download unrelated tooling like vault or kustomize.
 #
 # Versions are kept in sync with aqua.yaml at the repo root for any package
-# this file shares with it. The `*.aqua.yaml` suffix matches one of Renovate's
-# built-in aqua manager patterns, so the package list below gets version
-# updates without any extra renovate.json wiring.
+# this file shares with it. Renovate has no built-in aqua manager, so version
+# updates here are wired up via a customManagers regex entry in renovate.json
+# that matches `*.aqua.yaml` files and extracts `packages[].name` as
+# `<owner>/<repo>@<version>` from the github-tags datasource.
 registries:
   - type: standard
     ref: v4.479.0 # renovate: depName=aquaproj/aqua-registry

--- a/renovate.json
+++ b/renovate.json
@@ -126,6 +126,28 @@
         "image:\\s+(?<depName>[^:\\s]+):(?<currentValue>[^\\s]+)"
       ],
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Update aqua packages in *.aqua.yaml (Renovate has no built-in aqua manager)",
+      "managerFilePatterns": [
+        "/(^|/)[^/]*\\.aqua\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "-\\s+name:\\s+(?<depName>[^@\\s]+)@(?<currentValue>v?[^\\s#]+)"
+      ],
+      "datasourceTemplate": "github-tags"
+    },
+    {
+      "customType": "regex",
+      "description": "Update aqua-registry ref in *.aqua.yaml",
+      "managerFilePatterns": [
+        "/(^|/)[^/]*\\.aqua\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "ref:\\s+(?<currentValue>v?[^\\s#]+)\\s+#\\s*renovate:\\s*depName=(?<depName>\\S+)"
+      ],
+      "datasourceTemplate": "github-tags"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Follow-up to #322. Renovate has no built-in `aqua` manager, so the rename to `harbor.aqua.yaml` in #322 did not actually wire up version tracking — it just looked like it would (verified via the renovate source: no `lib/modules/manager/aqua/` directory, and `aqua` is rejected by `renovate-config-validator --strict` as an invalid top-level key).

This PR adds two `customManagers` regex entries that match `*.aqua.yaml` files and extract:

- `packages[].name` as `<owner>/<repo>@<version>` (datasource: github-tags)
- the registry `ref:` annotated with `# renovate: depName=...` (datasource: github-tags)

Also corrects the misleading comment in `harbor.aqua.yaml` that claimed the filename was self-tracking.

## Verification

- `renovate-config-validator --strict --no-global renovate.json` → exit 0.
- Local regex check: both `name: google/go-containerregistry@v0.21.5` and the annotated `ref: v4.479.0` line are extracted from `harbor.aqua.yaml`.
- Filename pattern verified to match `*.aqua.yaml` only — it does NOT match the root `aqua.yaml` (which is handled separately).

## Test plan

- [ ] Renovate dependency dashboard refreshes and lists `google/go-containerregistry` and `aquaproj/aqua-registry` updates from `harbor.aqua.yaml` (in addition to the existing entries from root `aqua.yaml`).