### PR TITLE
fix(harbor-action): propagate AQUA_GLOBAL_CONFIG to all job steps

### DIFF
--- a/.github/actions/harbor-build-push/action.yml
+++ b/.github/actions/harbor-build-push/action.yml
@@ -151,21 +151,21 @@ runs:
       with:
         cosign-release: v2.4.1
 
-    # crane is installed via aqua so the pinned version travels with this
-    # action. github.action_path resolves to the directory this action was
-    # downloaded into (the repo+ref the caller's `uses:` line points at),
-    # so aqua.yaml is always the version that matches this action.yml.
-    #
-    # `aqua_opts: -l -a` is load-bearing: aqua-installer's default of `-l`
-    # alone runs in lazy mode and only links aqua-proxy without consuming
-    # AQUA_GLOBAL_CONFIG, so `crane` would never be installed. Adding `-a`
-    # triggers installAll, which actually reads the config file.
+    # crane is installed via aqua. AQUA_GLOBAL_CONFIG is exported via
+    # $GITHUB_ENV (not the installer step's `env:`) so it persists for
+    # the later push step — aqua-proxy re-reads it at every crane
+    # invocation to dispatch to the pinned package version.
+    - name: Export AQUA_GLOBAL_CONFIG
+      shell: bash
+      run: echo "AQUA_GLOBAL_CONFIG=${{ github.action_path }}/aqua.yaml" >> "$GITHUB_ENV"
+
+    # aqua_opts `-l -a`: `-a` triggers installAll which actually consumes
+    # AQUA_GLOBAL_CONFIG; `-l` alone (the installer default) only links
+    # aqua-proxy and skips package installs.
     - uses: aquaproj/aqua-installer@v4.0.4
       with:
         aqua_version: v2.58.0
         aqua_opts: -l -a
-      env:
-        AQUA_GLOBAL_CONFIG: ${{ github.action_path }}/aqua.yaml
 
     # Exchange the workflow's GitHub OIDC token for the Harbor robot
     # credentials kept in Vault at `harbor/data/robot-pusher` (KV v2). The


### PR DESCRIPTION
## Summary

PR #324 set \`AQUA_GLOBAL_CONFIG\` only on the aqua-installer step's \`env:\` block. That's enough to get \`crane\` installed (with \`-l -a\` the installer creates the aqua-proxy symlink at \`\$AQUA_ROOT_DIR/bin/crane\`), but step-level \`env:\` doesn't persist to later steps. When the "Push and sign" step then invokes \`crane\`, aqua-proxy is re-invoked via the symlink and reads \`AQUA_GLOBAL_CONFIG\` again to know which package version to dispatch to — with the var unset, it falls back to walking up from CWD for an \`aqua.yaml\`, finds nothing, and exits with \`aqua failed ... command is not found\`.

Move the variable to \`\$GITHUB_ENV\` via a one-line step before aqua-installer runs. \`\$GITHUB_ENV\` writes propagate to every subsequent step in the same job, so every \`crane\` (and \`cosign\`) invocation downstream of aqua-installer can resolve the config.

## Reproduction

Caller-repo run https://github.com/Shion1305/nc-press-chotatsu-crawl-agent/actions/runs/25650021328 — both \`frontend\` and \`backend\` jobs hit \`ERR aqua failed program=aqua ... exe_name=crane error="command is not found"\` after the install logs showed \`command=crane\` symlink creation succeeded.

## Test plan

- [ ] Trigger \`demo-push-to-harbor.yaml\` on this branch and confirm the push step completes (crane push + cosign sign).
- [ ] After merge, retrigger \`nc-press-chotatsu-crawl-agent\` workflows and confirm both frontend and backend image builds succeed.