### PR TITLE
feat(nc-press-chotatsu): deploy crawler CronJob + frontend viewer

### DIFF
--- a/apps/nc-press-chotatsu-app.yaml
+++ b/apps/nc-press-chotatsu-app.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nc-press-chotatsu
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Shion1305/k8s-GitOps.git
+    targetRevision: HEAD
+    path: nc-press-chotatsu
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: nc-press-chotatsu
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/external-secrets/rbac-db-reader.yaml
+++ b/external-secrets/rbac-db-reader.yaml
@@ -130,3 +130,29 @@ subjects:
   - kind: ServiceAccount
     name: eso-db
     namespace: harbor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: eso-db-nc-press-chotatsu
+  namespace: postgres-operator-deployment
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - nc-press-chotatsu.postgres-shared.credentials.postgresql.acid.zalan.do
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: eso-db-nc-press-chotatsu
+  namespace: postgres-operator-deployment
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: eso-db-nc-press-chotatsu
+subjects:
+  - kind: ServiceAccount
+    name: eso-db
+    namespace: nc-press-chotatsu

--- a/nc-press-chotatsu/crawler-cronjob.yaml
+++ b/nc-press-chotatsu/crawler-cronjob.yaml
@@ -1,0 +1,88 @@
+# Daily crawler run at 09:00 JST (= 00:00 UTC). `--max 500` pulls up to 500
+# new procurement records per invocation; the entrypoint always runs
+# `alembic upgrade head` first, so migrations apply automatically.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: nc-press-chotatsu-crawler
+  namespace: nc-press-chotatsu
+spec:
+  schedule: "0 0 * * *"
+  timeZone: "UTC"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 21600
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: crawler
+              image: harbor.i.shion1305.com/shion1305/nc-press-chotatsu-crawl-agent-backend:latest
+              args:
+                - run
+                - --max
+                - "500"
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: nc-press-chotatsu-db-credentials
+                      key: DATABASE_URL
+                - name: GDRIVE_SERVICE_ACCOUNT_JSON
+                  value: /app/secret/sa.json
+                - name: OPENAI_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: nc-press-chotatsu-config
+                      key: OPENAI_API_KEY
+                - name: GDRIVE_PARENT_FOLDER_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: nc-press-chotatsu-config
+                      key: GDRIVE_PARENT_FOLDER_ID
+                - name: CONTACT_COMPANY
+                  valueFrom:
+                    secretKeyRef:
+                      name: nc-press-chotatsu-config
+                      key: CONTACT_COMPANY
+                - name: CONTACT_NAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: nc-press-chotatsu-config
+                      key: CONTACT_NAME
+                - name: CONTACT_PHONE
+                  valueFrom:
+                    secretKeyRef:
+                      name: nc-press-chotatsu-config
+                      key: CONTACT_PHONE
+                - name: CONTACT_EMAIL
+                  valueFrom:
+                    secretKeyRef:
+                      name: nc-press-chotatsu-config
+                      key: CONTACT_EMAIL
+              resources:
+                requests:
+                  cpu: 200m
+                  memory: 1Gi
+                limits:
+                  cpu: 2000m
+                  memory: 4Gi
+              volumeMounts:
+                - name: gdrive-sa
+                  mountPath: /app/secret
+                  readOnly: true
+                - name: data
+                  mountPath: /app/data
+          volumes:
+            - name: gdrive-sa
+              secret:
+                secretName: nc-press-chotatsu-gdrive-sa
+                items:
+                  - key: sa.json
+                    path: sa.json
+            - name: data
+              emptyDir: {}

--- a/nc-press-chotatsu/crawler-cronjob.yaml
+++ b/nc-press-chotatsu/crawler-cronjob.yaml
@@ -19,6 +19,8 @@ spec:
       template:
         spec:
           restartPolicy: Never
+          nodeSelector:
+            kubernetes.io/arch: amd64
           containers:
             - name: crawler
               image: harbor.i.shion1305.com/shion1305/nc-press-chotatsu-crawl-agent-backend:latest
@@ -67,10 +69,12 @@ spec:
               resources:
                 requests:
                   cpu: 200m
-                  memory: 1Gi
+                  memory: 1536Mi
+                  ephemeral-storage: 1Gi
                 limits:
                   cpu: 2000m
-                  memory: 4Gi
+                  memory: 6Gi
+                  ephemeral-storage: 10Gi
               volumeMounts:
                 - name: gdrive-sa
                   mountPath: /app/secret
@@ -85,4 +89,5 @@ spec:
                   - key: sa.json
                     path: sa.json
             - name: data
-              emptyDir: {}
+              emptyDir:
+                sizeLimit: 10Gi

--- a/nc-press-chotatsu/db-external-secret.yaml
+++ b/nc-press-chotatsu/db-external-secret.yaml
@@ -13,11 +13,12 @@ spec:
     creationPolicy: Owner
     template:
       type: Opaque
+      engineVersion: v2
       metadata:
         labels:
           managed-by: external-secrets
       data:
-        DATABASE_URL: "postgresql+psycopg://{{ .username }}:{{ .password }}@postgres-shared.postgres-operator-deployment.svc.cluster.local:5432/nc_press_chotatsu"
+        DATABASE_URL: "postgresql+psycopg://{{ .username | urlquery }}:{{ .password | urlquery }}@postgres-shared.postgres-operator-deployment.svc.cluster.local:5432/nc_press_chotatsu"
   data:
     - secretKey: username
       remoteRef:

--- a/nc-press-chotatsu/db-external-secret.yaml
+++ b/nc-press-chotatsu/db-external-secret.yaml
@@ -17,13 +17,13 @@ spec:
         labels:
           managed-by: external-secrets
       data:
-        DATABASE_URL: "postgresql+psycopg://{{ .username }}:{{ .password }}@postgres-shared.postgres-operator-deployment.svc.cluster.local:5432/nc_press_chotatsu_data"
+        DATABASE_URL: "postgresql+psycopg://{{ .username }}:{{ .password }}@postgres-shared.postgres-operator-deployment.svc.cluster.local:5432/nc_press_chotatsu"
   data:
     - secretKey: username
       remoteRef:
-        key: nc-press-chotatsu-data.postgres-shared.credentials.postgresql.acid.zalan.do
+        key: nc-press-chotatsu.postgres-shared.credentials.postgresql.acid.zalan.do
         property: username
     - secretKey: password
       remoteRef:
-        key: nc-press-chotatsu-data.postgres-shared.credentials.postgresql.acid.zalan.do
+        key: nc-press-chotatsu.postgres-shared.credentials.postgresql.acid.zalan.do
         property: password

--- a/nc-press-chotatsu/db-external-secret.yaml
+++ b/nc-press-chotatsu/db-external-secret.yaml
@@ -1,0 +1,29 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: nc-press-chotatsu-db-credentials
+  namespace: nc-press-chotatsu
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: k8s-postgres
+    kind: SecretStore
+  target:
+    name: nc-press-chotatsu-db-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+      data:
+        DATABASE_URL: "postgresql+psycopg://{{ .username }}:{{ .password }}@postgres-shared.postgres-operator-deployment.svc.cluster.local:5432/nc_press_chotatsu_data"
+  data:
+    - secretKey: username
+      remoteRef:
+        key: nc-press-chotatsu-data.postgres-shared.credentials.postgresql.acid.zalan.do
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: nc-press-chotatsu-data.postgres-shared.credentials.postgresql.acid.zalan.do
+        property: password

--- a/nc-press-chotatsu/db-secret-store.yaml
+++ b/nc-press-chotatsu/db-secret-store.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso-db
+  namespace: nc-press-chotatsu
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: k8s-postgres
+  namespace: nc-press-chotatsu
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: postgres-operator-deployment
+      server:
+        url: "https://kubernetes.default.svc"
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: eso-db

--- a/nc-press-chotatsu/external-secret.yaml
+++ b/nc-press-chotatsu/external-secret.yaml
@@ -1,0 +1,45 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: nc-press-chotatsu-config
+  namespace: nc-press-chotatsu
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  target:
+    name: nc-press-chotatsu-config
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+  dataFrom:
+    - extract:
+        key: config
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: nc-press-chotatsu-gdrive-sa
+  namespace: nc-press-chotatsu
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  target:
+    name: nc-press-chotatsu-gdrive-sa
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+  data:
+    - secretKey: sa.json
+      remoteRef:
+        key: gdrive-sa
+        property: sa.json

--- a/nc-press-chotatsu/frontend-deployment.yaml
+++ b/nc-press-chotatsu/frontend-deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: nc-press-chotatsu-frontend
     spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
       containers:
         - name: frontend
           image: harbor.i.shion1305.com/shion1305/nc-press-chotatsu-crawl-agent-frontend:latest

--- a/nc-press-chotatsu/frontend-deployment.yaml
+++ b/nc-press-chotatsu/frontend-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nc-press-chotatsu-frontend
+  namespace: nc-press-chotatsu
+  labels:
+    app: nc-press-chotatsu-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nc-press-chotatsu-frontend
+  template:
+    metadata:
+      labels:
+        app: nc-press-chotatsu-frontend
+    spec:
+      containers:
+        - name: frontend
+          image: harbor.i.shion1305.com/shion1305/nc-press-chotatsu-crawl-agent-frontend:latest
+          ports:
+            - containerPort: 3000
+              name: http
+              protocol: TCP
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: nc-press-chotatsu-db-credentials
+                  key: DATABASE_URL
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          readinessProbe:
+            tcpSocket:
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 20

--- a/nc-press-chotatsu/frontend-service.yaml
+++ b/nc-press-chotatsu/frontend-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nc-press-chotatsu-frontend
+  namespace: nc-press-chotatsu
+  labels:
+    app: nc-press-chotatsu-frontend
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3000
+      targetPort: 3000
+      protocol: TCP
+      name: http
+  selector:
+    app: nc-press-chotatsu-frontend

--- a/nc-press-chotatsu/httproute-external.yaml
+++ b/nc-press-chotatsu/httproute-external.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: nc-press-chotatsu-external
+  namespace: nc-press-chotatsu
+spec:
+  parentRefs:
+    - name: external
+      namespace: envoy-gateway-system
+      sectionName: https
+  hostnames:
+    - nc-chotatsu.shion1305.com
+  rules:
+    - backendRefs:
+        - name: nc-press-chotatsu-frontend
+          port: 3000

--- a/nc-press-chotatsu/kustomization.yaml
+++ b/nc-press-chotatsu/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - db-secret-store.yaml
+  - db-external-secret.yaml
+  - vault-secret-store.yaml
+  - external-secret.yaml
+  - frontend-deployment.yaml
+  - frontend-service.yaml
+  - reference-grant.yaml
+  - httproute-external.yaml
+  - crawler-cronjob.yaml

--- a/nc-press-chotatsu/namespace.yaml
+++ b/nc-press-chotatsu/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nc-press-chotatsu
+  labels:
+    name: nc-press-chotatsu

--- a/nc-press-chotatsu/reference-grant.yaml
+++ b/nc-press-chotatsu/reference-grant.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-envoy-gateway
+  namespace: nc-press-chotatsu
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: envoy-gateway-system
+  to:
+    - group: ""
+      kind: Service

--- a/nc-press-chotatsu/vault-secret-store.yaml
+++ b/nc-press-chotatsu/vault-secret-store.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso
+  namespace: nc-press-chotatsu
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: vault
+  namespace: nc-press-chotatsu
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "nc-press-chotatsu"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "eso-nc-press-chotatsu"
+          serviceAccountRef:
+            name: "eso"

--- a/postgres-shared/postgres-cluster.yaml
+++ b/postgres-shared/postgres-cluster.yaml
@@ -14,14 +14,14 @@ spec:
     langfuse: []
     keycloak: []
     mlflow: []
-    nc_press_chotatsu_data: []
+    nc_press_chotatsu: []
     harbor: []
   databases:
     openwebui: openwebui
     langfuse: langfuse
     keycloak: keycloak
     mlflow: mlflow
-    nc_press_chotatsu_data: nc_press_chotatsu_data
+    nc_press_chotatsu: nc_press_chotatsu
     harbor: harbor
   postgresql:
     version: "17"

--- a/vault/scripts/setup-eso-policies.sh
+++ b/vault/scripts/setup-eso-policies.sh
@@ -117,6 +117,17 @@ path "harbor/metadata/*" {
 EOF
 echo "✓ Created policy: eso-harbor"
 
+# Policy for nc-press-chotatsu namespace (separate KV v2 engine mounted at nc-press-chotatsu/)
+vault policy write eso-nc-press-chotatsu - <<EOF
+path "nc-press-chotatsu/data/*" {
+  capabilities = ["read"]
+}
+path "nc-press-chotatsu/metadata/*" {
+  capabilities = ["read", "list"]
+}
+EOF
+echo "✓ Created policy: eso-nc-press-chotatsu"
+
 # NOTE: An `eso-harbor-broker` role for the Keycloak namespace to read
 # `harbor/broker-credentials` is intentionally NOT created here. There is no
 # precedent yet for ESO-managed broker client secrets in the keycloak ns
@@ -252,6 +263,14 @@ vault write auth/kubernetes/role/eso-harbor \
   ttl=1h
 echo "✓ Created role: eso-harbor"
 
+# nc-press-chotatsu
+vault write auth/kubernetes/role/eso-nc-press-chotatsu \
+  bound_service_account_names=eso \
+  bound_service_account_namespaces=nc-press-chotatsu \
+  policies=eso-nc-press-chotatsu \
+  ttl=1h
+echo "✓ Created role: eso-nc-press-chotatsu"
+
 # github-app (cluster-scoped store; binds to the ESO operator SA, not a per-namespace SA)
 vault write auth/kubernetes/role/eso-github-app \
   bound_service_account_names=external-secrets \
@@ -383,6 +402,7 @@ echo "  eso-freqtrade   → SA eso/freqtrade       → freqtrade/data/*"
 echo "  eso-cert-manager→ SA eso/cert-manager    → system/data/cert-manager"
 echo "  eso-zot         → SA eso/zot             → zot/data/*"
 echo "  eso-harbor      → SA eso/harbor          → harbor/data/*"
+echo "  eso-nc-press-chotatsu → SA eso/nc-press-chotatsu → nc-press-chotatsu/data/*"
 echo "  eso-github-app  → SA external-secrets/external-secrets → github-app-shared/data/*"
 echo "  eso-cloudflare-grafana → SA eso/monitoring     → cloudflare-grafana/data/*"
 echo "  eso-cluster-puller → SA external-secrets/external-secrets → zot/data/cluster-puller"


### PR DESCRIPTION
## Summary
- Frontend Deployment + Service for `nc-press-chotatsu-crawl-agent-frontend`, exposed externally at `nc-chotatsu.shion1305.com` via the external Envoy Gateway.
- Daily CronJob (`0 0 * * *` UTC = 09:00 JST) running the backend crawler with `run --max 500`. Uses `concurrencyPolicy: Forbid` and a 6h activeDeadlineSeconds cap; entrypoint runs `alembic upgrade head` first so migrations are automatic.
- DB credentials are pulled from `postgres-shared` (user `nc_press_chotatsu_data`) via the existing per-namespace `k8s-postgres` ESO pattern. The ExternalSecret templates a ready-to-consume `DATABASE_URL` value so both the Deployment and CronJob only depend on a single env var.
- App-specific config (`OPENAI_API_KEY`, `GDRIVE_PARENT_FOLDER_ID`, `CONTACT_*`) and the Google Drive service-account JSON come from a new dedicated Vault KV v2 mount at `nc-press-chotatsu/`, mirrored into Kubernetes Secrets by ESO.
- Adds `eso-nc-press-chotatsu` Vault policy + k8s auth role binding to the `nc-press-chotatsu` namespace's `eso` ServiceAccount.
- Harbor image-pull credentials are auto-injected by the existing Kyverno `harbor-pull-injection` policy (images reference `harbor.i.shion1305.com/*`).

## Out-of-band steps before merge
The cluster-side Vault role/policy + secret data must exist for the ExternalSecrets to sync. After this PR merges:
```
# 1) Apply Vault policies + roles
bash vault/scripts/setup-eso-policies.sh

# 2) Enable the per-service KV mount
vault secrets enable -path=nc-press-chotatsu kv-v2

# 3) Write config + SA JSON (real values from PMs / GCP console)
vault kv put nc-press-chotatsu/config \
  OPENAI_API_KEY=... \
  GDRIVE_PARENT_FOLDER_ID=... \
  CONTACT_COMPANY=... CONTACT_NAME=... CONTACT_PHONE=... CONTACT_EMAIL=...
vault kv put nc-press-chotatsu/gdrive-sa sa.json=@path/to/sa.json
```

## Test plan
- [x] `./scripts/render-validate.sh` — all apps including `nc-press-chotatsu` pass kubeconform.
- [ ] After merge + Argo sync: verify the Deployment goes Ready and the HTTPRoute serves the Next.js viewer at `https://nc-chotatsu.shion1305.com`.
- [ ] Verify `kubectl get externalsecret -n nc-press-chotatsu` show `SecretSynced=True` for all three (DB, config, GDrive SA).
- [ ] Trigger the CronJob manually with `kubectl create job --from=cronjob/nc-press-chotatsu-crawler nc-test -n nc-press-chotatsu`; confirm `alembic upgrade head` runs and `chotatsu run --max 500` reaches the crawl stage.
- [ ] Confirm cluster DNS resolves `nc-chotatsu.shion1305.com` to the external Gateway VIP (`141.147.189.36`) once the CNAME / A record is in place.