### PR TITLE
chore(postgres-shared): grow volume 1Ti -> 1.5Ti

### DIFF
--- a/postgres-shared/postgres-cluster.yaml
+++ b/postgres-shared/postgres-cluster.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   teamId: "default"
   volume:
-    size: 1Ti
+    size: 1536Gi
     storageClass: longhorn-ssd
   numberOfInstances: 1
   users:


### PR DESCRIPTION
## Summary
- Bump `spec.volume.size` on the shared Zalando `postgresql` cluster `postgres-shared` from `1Ti` to `1536Gi` (= 1.5 TiB) to give headroom for the growing tenant list (openwebui, langfuse, keycloak, mlflow, nc_press_chotatsu, harbor).
- Storage class: `longhorn-ssd` (online expansion supported). Single-instance cluster, so no replica-resync churn.

## Pre-merge evidence
- `kubectl get sc longhorn-ssd -o jsonpath='{.allowVolumeExpansion}'` → `true`
- Underlying Longhorn volume `pvc-d14ae3b9-a67b-46bc-b7b2-519734617130` (PVC `pgdata-postgres-shared-0`): state=`attached`, robustness=`healthy`, current size=1024 GiB, replicas=1, actual data ≈ 18 GiB.
- Node disk `shion-ubuntu-2505/ssd-4t`: 2389.5 GiB available / 3724.2 GiB max. The +512 GiB grow leaves ~1877 GiB headroom on the disk.
- Pre-resize `pg_dumpall` taken as insurance (held locally on the operator host, off-cluster):
  - file: `/tmp/postgres-shared-backup/pre-resize-20260511-222552.sql.gz`
  - size: 2.2 MB (2,266,131 bytes), 9 databases
  - sha256: `e25e7ae10865745059b11dba88d1b0be2f9d65024cd03ec6c5b156bc069aa092`
- Follow-up (not blocking this PR): no WAL-E continuous archiving is configured on the cluster (`/run/etc/wal-e.d/env` missing). Worth enabling proper continuous backups separately.

## Test plan
- [ ] PR CI: `render-validate` job passes (kubeconform on rendered manifests).
- [ ] After merge + ArgoCD sync: confirm `kubectl -n postgres-operator-deployment get pvc pgdata-postgres-shared-0 -o jsonpath='{.status.capacity.storage}'` reports `1536Gi`.
- [ ] Longhorn UI: volume `pvc-d14ae3b9-...` shows new size, state `attached`, robustness `healthy`.
- [ ] Postgres pod stays `Running` (online expansion; no restart expected).