### PR TITLE
chore(openwebui): bump chart 13.3.1 -> 14.6.0

### DIFF
--- a/apps/openwebui-app.yaml
+++ b/apps/openwebui-app.yaml
@@ -8,7 +8,7 @@ spec:
   sources:
     - repoURL: https://helm.openwebui.com
       chart: open-webui
-      targetRevision: 13.3.1
+      targetRevision: 14.6.0
       helm:
         valueFiles:
           - $values/openwebui/values.yaml


### PR DESCRIPTION
## Summary
- Upgrade open-webui Helm chart from 13.3.1 to 14.6.0 (latest available at https://helm.openwebui.com).

## Test plan
- [x] `./scripts/render-validate.sh` passes for `openwebui` locally
- [ ] Render-validate CI green
- [ ] ArgoCD reconciles cleanly post-merge