### PR TITLE
fix(ynufes-tech): hoist groups mapper into a clientScope

### DIFF
--- a/keycloak-operator/ynufes-tech-realm.yaml
+++ b/keycloak-operator/ynufes-tech-realm.yaml
@@ -22,7 +22,8 @@
 #
 # Role-to-Grafana-role mapping is performed inside Grafana via
 # `auth.generic_oauth.role_attribute_path`, keying off the `groups` claim
-# emitted by the group-membership protocol mapper attached to each client.
+# emitted by the `groups` client scope (see clientScopes below). Clients
+# that need the claim opt in via defaultClientScopes.
 #
 # -----------------------------------------------------------------------------
 # Manual post-import steps (one-time, after first successful sync):
@@ -120,6 +121,34 @@ spec:
           - grafana-viewer
 
     # -------------------------------------------------------------------------
+    # Client scopes
+    # -------------------------------------------------------------------------
+    # `groups` scope: owns the oidc-group-membership-mapper so any client in
+    # this realm that needs the `groups` claim can opt in by listing this
+    # scope in defaultClientScopes (or by requesting `scope=groups` at /auth).
+    # Keeping the mapper here (rather than directly on the client) lets
+    # Keycloak accept `scope=groups` as a known scope — without a matching
+    # clientScope, Keycloak returns `invalid_scope` even though the mapper
+    # would otherwise inject the claim.
+    clientScopes:
+      - name: groups
+        protocol: openid-connect
+        attributes:
+          include.in.token.scope: "true"
+          display.on.consent.screen: "false"
+        protocolMappers:
+          - name: groups
+            protocolMapper: oidc-group-membership-mapper
+            protocol: openid-connect
+            consentRequired: false
+            config:
+              claim.name: "groups"
+              full.path: "false"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+
+    # -------------------------------------------------------------------------
     # Clients
     # -------------------------------------------------------------------------
     clients:
@@ -141,19 +170,11 @@ spec:
           - https://ynufes-cf.shion1305.com/*
         webOrigins:
           - https://ynufes-cf.shion1305.com
-        protocolMappers:
-          # Emit `groups` claim in id_token, access_token and userinfo so
-          # Grafana's role_attribute_path can map group -> org role.
-          - name: groups
-            protocolMapper: oidc-group-membership-mapper
-            protocol: openid-connect
-            consentRequired: false
-            config:
-              claim.name: "groups"
-              full.path: "false"
-              id.token.claim: "true"
-              access.token.claim: "true"
-              userinfo.token.claim: "true"
+        # `openid`, `email`, `profile` are Keycloak's built-in default scopes
+        # and are added automatically. Only `groups` (defined above) needs to
+        # be opted in here so the `groups` claim is emitted into tokens.
+        defaultClientScopes:
+          - groups
 
     # -------------------------------------------------------------------------
     # Identity Providers


### PR DESCRIPTION
## Summary
- Define a top-level `groups` clientScope in the `ynufes-tech` realm so Keycloak accepts `scope=groups` from clients.
- Attach the new scope to `cloudflare-grafana` as a default scope.
- Remove the now-redundant direct `groups` mapper from the client (already removed via admin UI to avoid claim duplication; this PR catches the YAML up).

## Why
Grafana's cloudflare-grafana auth config requests `scope=openid email profile groups`. The realm had a group-membership protocol mapper attached directly to the client, which would normally inject the `groups` claim — but because no `groups` clientScope existed, Keycloak rejected the request with `invalid_scope`: `"Invalid scopes: openid email profile groups"`. Result: every Grafana login was bouncing back with "Login provider denied login request".

Hoisting the mapper into a real clientScope is the idiomatic Keycloak shape: clients opt in via `defaultClientScopes`, the scope is advertised in `/.well-known/openid-configuration`, and `scope=groups` becomes a known, accepted scope. Verified post-change that the discovery endpoint now lists `groups` and that Grafana login completes end-to-end.

## Test plan
- [x] `KeycloakRealmImport` re-applied; admin UI shows new `groups` clientScope under realm `ynufes-tech`.
- [x] `cloudflare-grafana` client has `groups` assigned with type **Default**; dedicated scope no longer contains the direct mapper.
- [x] `curl https://keycloak.shion1305.com/realms/ynufes-tech/.well-known/openid-configuration | jq .scopes_supported` includes `groups`.
- [x] Browser login at https://ynufes-cf.shion1305.com succeeds; no more `invalid_scope` / "Login provider denied login request" in grafana pod logs.