### PR TITLE
fix(cloudflare-monitoring): pin Prometheus datasource UID

### DIFF
--- a/cloudflare-exporter/grafana-datasource.yaml
+++ b/cloudflare-exporter/grafana-datasource.yaml
@@ -8,6 +8,10 @@ spec:
     matchLabels:
       dashboards: cloudflare-grafana
   datasource:
+    # Pin a stable UID so dashboard JSONs can reference this datasource by
+    # name. Without this, grafana-operator assigns a random UUID on first
+    # apply and dashboards lose their datasource link.
+    uid: prometheus
     name: Prometheus
     type: prometheus
     access: proxy


### PR DESCRIPTION
## Summary
Pin the cloudflare-grafana Prometheus datasource UID to the literal string \`prometheus\` so dashboard JSONs can reference it.

## Why
The new \`cloudflare-quota\` dashboard (PR #331) uses \`{ type: prometheus, uid: prometheus }\` on every panel target. grafana-operator was generating a random UUID on first apply (\`139d19bf-...\` in cluster today), so Grafana resolved every panel's datasource to "not registered" and showed an error.

Setting \`spec.datasource.uid: prometheus\` makes the operator install the datasource with the deterministic UID the dashboard expects.

## Test plan
- [x] \`scripts/render-validate.sh\` ✓
- [ ] After sync: \`GrafanaDatasource/prometheus\` status reapplies; \`cloudflare-quota\` dashboard panels render Prometheus data instead of the datasource-missing error.