### PR TITLE
fix(cloudflare-monitoring): set default account variable

### DIFF
--- a/cloudflare-exporter/grafana-dashboards.yaml
+++ b/cloudflare-exporter/grafana-dashboards.yaml
@@ -31,10 +31,11 @@ spec:
             "type": "query",
             "datasource": { "type": "prometheus", "uid": "prometheus" },
             "query": "label_values(cloudflare_worker_requests_count, account)",
-            "refresh": 2,
+            "refresh": 1,
             "multi": false,
             "includeAll": false,
-            "label": "アカウント"
+            "label": "アカウント",
+            "current": { "selected": false, "text": "ynufes-tech", "value": "ynufes-tech" }
           }
         ]
       },
@@ -458,10 +459,11 @@ spec:
             "type": "query",
             "datasource": { "type": "prometheus", "uid": "prometheus" },
             "query": "label_values(cloudflare_worker_requests_count, account)",
-            "refresh": 2,
+            "refresh": 1,
             "multi": false,
             "includeAll": false,
-            "label": "アカウント"
+            "label": "アカウント",
+            "current": { "selected": false, "text": "ynufes-tech", "value": "ynufes-tech" }
           },
           {
             "name": "script",
@@ -969,10 +971,11 @@ spec:
             "type": "query",
             "datasource": { "type": "prometheus", "uid": "prometheus" },
             "query": "label_values(cloudflare_r2_storage_total_bytes, account)",
-            "refresh": 2,
+            "refresh": 1,
             "multi": false,
             "includeAll": false,
-            "label": "アカウント"
+            "label": "アカウント",
+            "current": { "selected": false, "text": "ynufes-tech", "value": "ynufes-tech" }
           }
         ]
       },


### PR DESCRIPTION
## Summary
After PR #333 merged, the three Cloudflare dashboards rendered with **"No data"** everywhere on first visit. URLs with `?var-account=ynufes-tech` rendered correctly.

## Root cause
The template variable was defined with \`refresh: 2\` (= "On dashboard load") and no \`current\` value. Grafana paints panels before the \`label_values()\` query resolves on cold load, so PromQL targets that reference \`$account\` execute with an empty string, which doesn't match any series.

## Fix
- Hard-code \`current = {text: ynufes-tech, value: ynufes-tech}\` so the variable is initialised from the saved dashboard state before panel rendering.
- Switch \`refresh\` to \`1\` ("On time range change") so panel paint doesn't depend on the variable query completing first.

Applied to all three dashboards (\`cloudflare-overview\`, \`cloudflare-workers\`, \`cloudflare-r2\`).

## Test plan
- [x] Live cluster patched manually; dashboards now render real data on first visit without query parameters.
- [ ] After merge: visit \`https://ynufes-cf.shion1305.com/d/cloudflare-overview\` in a fresh tab — should show 136K gauge, 100k line, etc., not "No data".