### PR TITLE
feat(cloudflare-monitoring): enable anonymous Viewer access

### DIFF
--- a/cloudflare-exporter/grafana.yaml
+++ b/cloudflare-exporter/grafana.yaml
@@ -10,8 +10,17 @@ spec:
     server:
       root_url: "https://ynufes-cf.shion1305.com/"
       serve_from_sub_path: "false"
+    # Anonymous (no login) access at Viewer role. This grants read-only access
+    # to dashboards in folders that allow Viewer permissions for anonymous
+    # users (or where folder permissions are not restricted). This Grafana
+    # instance hosts only the Cloudflare Monitoring folder, so this exposes
+    # the cloudflare-overview / cloudflare-workers / cloudflare-r2 dashboards
+    # to anyone with the link. Editing/admin actions still require Keycloak
+    # OIDC login.
     auth.anonymous:
-      enabled: "false"
+      enabled: "true"
+      org_name: "Main Org."
+      org_role: "Viewer"
     # auth.basic must remain enabled (the default) so grafana-operator can
     # authenticate to /api via the admin credentials it manages. The login
     # form is hidden via auth.disable_login_form below — interactive users


### PR DESCRIPTION
## Summary
Enable anonymous Viewer access on the cloudflare-grafana instance so the three Cloudflare dashboards can be shared with anyone via standard \`/d/...\` URLs.

## Why not "Public Dashboard"
PR #333 enabled Grafana's \`publicDashboards\` feature, but the share-externally flow disables template variables and gates several datasource types. With our \`\$account\` / \`\$script\` template variables in place, every panel rendered as **"No data"** under the public-link URL. Rather than hard-code \`account=ynufes-tech\` into every query (and lose flexibility for any future account), this PR takes the simpler path: turn on anonymous Viewer at the instance level.

## What this changes
\`\`\`yaml
auth.anonymous:
  enabled: "true"
  org_name: "Main Org."
  org_role: "Viewer"
\`\`\`

After ArgoCD sync:
- Visiting \`https://ynufes-cf.shion1305.com/d/cloudflare-overview\` (or \`-workers\` / \`-r2\`) without logging in renders the dashboard as a **Viewer**.
- All datasources, template variables, panel queries continue to work.
- Inter-dashboard links (\`/d/cloudflare-workers\`, etc.) resolve correctly for anonymous visitors.
- Editing, sharing, admin actions still require Keycloak OIDC login (anonymous = Viewer only).

## Scope justification
This Grafana instance hosts **only** the \`Cloudflare Monitoring\` folder. Enabling anonymous Viewer therefore exposes only the intended Cloudflare quota dashboards. The cluster's separate kube-prometheus-stack Grafana (under the \`grafana\` namespace) is untouched and remains login-required.

## Test plan
- [x] \`scripts/render-validate.sh\` ✓
- [ ] After merge + sync: opening \`https://ynufes-cf.shion1305.com/d/cloudflare-overview\` in a fresh Incognito window renders the dashboard with real data, no Keycloak redirect.
- [ ] Edit button is hidden / not functional for anonymous user (Viewer role).