### PR TITLE
fix(grafana): pin main-grafana Prometheus datasource UID to "prometheus"

### DIFF
--- a/grafana/datasource.yaml
+++ b/grafana/datasource.yaml
@@ -8,6 +8,11 @@ spec:
     matchLabels:
       dashboards: main-grafana
   datasource:
+    # Stable UID so dashboards can reference this datasource by a fixed
+    # string. Without this, grafana-operator assigns a random UUID on first
+    # apply and any GrafanaDashboard JSON that hard-codes `uid: prometheus`
+    # silently shows "No data".
+    uid: prometheus
     name: Prometheus
     type: prometheus
     access: proxy


### PR DESCRIPTION
## Summary

Pins the main-grafana Prometheus `GrafanaDatasource` to `uid: prometheus`. Without this, grafana-operator generated a random UUID and any `GrafanaDashboard` JSON that hard-coded `datasource.uid: prometheus` (the obvious value given the resource is literally named "prometheus") silently rendered every panel as "No data". Matches the pattern already used in `cloudflare-exporter/grafana-datasource.yaml`.

## Impact

- Existing main-grafana dashboards: **no change** — they all reference the datasource via the `$datasource` template variable picker (kube-prometheus-stack standard pattern), not by hard-coded UID.
- Hits the failure I encountered with `clearnet-website-monitoring`'s dashboard, where every panel showed "No data" because the dashboard JSON references `uid: prometheus` but the live datasource was `17aac52a-794e-42f1-a1c1-caefeb5ff24c`.

## Test plan

- [x] `scripts/render-validate.sh` passes locally.
- [ ] After merge: `kubectl get grafanadatasource prometheus -n grafana -o jsonpath='{.spec.datasource.uid}'` returns `prometheus`.
- [ ] Clearnet Website Monitoring dashboard panels render values instead of "No data".