### PR TITLE
fix(vault): grant IPC_LOCK capability for vault 2.0.1

### DIFF
--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -7,6 +7,16 @@ server:
   image:
     repository: hashicorp/vault
     tag: 2.0.1
+  # vault 2.0.1 ships the binary with the cap_ipc_lock file capability, so it
+  # refuses to start unless the container is granted IPC_LOCK (mlock keeps
+  # secrets out of swap). disable_mlock does not help: the entrypoint fails at
+  # `vault -version`, before any HCL config is read.
+  statefulSet:
+    securityContext:
+      container:
+        capabilities:
+          add:
+            - IPC_LOCK
   resources:
     requests:
       memory: 256Mi
@@ -113,9 +123,6 @@ server:
       setNodeId: true
       config: |
         ui = true
-        # vault 2.0.1's entrypoint hard-requires the IPC_LOCK capability to
-        # mlock memory; the pod is not granted it, so disable mlock instead.
-        disable_mlock = true
         # Internal hostname is the source of truth for any URL Vault echoes to
         # clients (e.g. UI redirects). External hostname is path-restricted and
         # auth-only — not suitable as api_addr.


### PR DESCRIPTION
## Why #367 was not enough

`disable_mlock = true` (PR #367) did **not** fix the Vault crashloop. The pods kept failing with the same error after ArgoCD resynced:

```
Vault requires the IPC_LOCK capability. Please use --cap-add IPC_LOCK ...
/usr/local/bin/docker-entrypoint.sh: exec: line 116: vault: Operation not permitted
```

Root cause confirmed by inspecting `docker-entrypoint.sh` in the `hashicorp/vault:2.0.1` image: the binary ships with the `cap_ipc_lock` **file capability** baked in, so even `vault -version` fails with `Operation not permitted` when the container lacks `IPC_LOCK` — this happens **before any HCL config is read**, so `disable_mlock` never takes effect. The non-root pod also can't `setcap` to strip the capability in the entrypoint's fallback path, so it crashloops unconditionally.

## Fix

Grant `IPC_LOCK` via `server.statefulSet.securityContext.container` (the chart's container-level securityContext key) and drop the ineffective `disable_mlock` line.

**Verified on-cluster**: a `hashicorp/vault:2.0.1` pod with `runAsNonRoot: true`, `runAsUser: 100`, `allowPrivilegeEscalation: false` **and** `capabilities.add: [IPC_LOCK]` runs `vault -version` successfully.

## Verification after merge/sync

- [ ] `kubectl get pods -n vault` -> all `2/2 Running`
- [ ] `kubectl get externalsecrets -A` -> Vault-backed stores flip to `SecretSynced`

> Supersedes the workaround in #367. Follow-up: consider excluding Vault from Renovate automerge so a stricter-entrypoint image can't ship unsmoke-tested.