### PR TITLE
feat(envoy-gateway): add *.shion.dev listener and cert

### DIFF
--- a/envoy-gateway/certificates.yaml
+++ b/envoy-gateway/certificates.yaml
@@ -47,3 +47,18 @@ spec:
   dnsNames:
     - "*.k.shion1305.com"
     - "k.shion1305.com"
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-shion-dev
+  namespace: envoy-gateway-system
+spec:
+  secretName: wildcard-shion-dev-tls
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  commonName: "*.shion.dev"
+  dnsNames:
+    - "*.shion.dev"
+    - "shion.dev"

--- a/envoy-gateway/gateway-external.yaml
+++ b/envoy-gateway/gateway-external.yaml
@@ -39,3 +39,14 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+    - name: https-shion-dev
+      port: 443
+      protocol: HTTPS
+      hostname: "*.shion.dev"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: wildcard-shion-dev-tls
+      allowedRoutes:
+        namespaces:
+          from: All


### PR DESCRIPTION
## What
Add a cert-manager wildcard `Certificate` for `*.shion.dev` (Let's Encrypt DNS-01 via the existing Cloudflare issuer) and an `https-shion-dev` listener on the external Gateway that terminates it.

## Why
`github-readme-stats.shion.dev` (the github-readme-stats-deployment repo) and its observability Grafana are the last consumers still on nginx-ingress. Moving them to Envoy Gateway needs the Gateway to terminate `shion.dev` TLS. This also retires the brittle host-level certbot + `cert-sync` CronJob that previously populated the nginx TLS Secret.

## Notes
- The Cloudflare API token used by `letsencrypt-prod` now has `shion.dev` zone access (verified), so the cert will issue.
- **Non-breaking**: adds an isolated listener + cert; no existing traffic is affected. SNI routes `*.shion.dev` to the new cert while the catch-all `https` listener keeps serving `*.shion1305.com`.
- Validated via `kustomize build` + server-side dry-run against live CRDs.

## Part of the github-readme-stats nginx-ingress migration
1. **This PR** (Gateway listener + cert) — merge first.
2. github-readme-stats-deployment: o11y Grafana → operator CRs on `github-readme-stats-o11y.shion.dev`.
3. github-readme-stats-deployment: app → Gateway on `github-readme-stats.shion.dev` (after Cloudflare origin cutover).