### PR TITLE
fix(node-healthcheck): update raspi-cm4 node affinity hostname

### DIFF
--- a/node-healthcheck/cronjob-raspi-cm4.yaml
+++ b/node-healthcheck/cronjob-raspi-cm4.yaml
@@ -28,7 +28,7 @@ spec:
                       - key: kubernetes.io/hostname
                         operator: In
                         values:
-                          - raspi-cm4
+                          - shion-raspi-cm4
           containers:
             - name: ping
               image: nicolaka/netshoot:v0.15


### PR DESCRIPTION
## Summary

Updates the `raspi-cm4` node-healthcheck CronJob's `nodeAffinity` to match the node's actual `kubernetes.io/hostname` label, which is `shion-raspi-cm4` rather than `raspi-cm4`. With the previous value the affinity selector never matched, leaving the cronjob pods unschedulable.

## Changes

- `node-healthcheck/cronjob-raspi-cm4.yaml`: `raspi-cm4` → `shion-raspi-cm4` in the `kubernetes.io/hostname` affinity values.