### PR TITLE
fix(gateway): bump TLSRoute to v1 (fixes ArgoCD diff) and ReferenceGrant to v1

### DIFF
--- a/argocd/reference-grant.yaml
+++ b/argocd/reference-grant.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: allow-envoy-gateway

--- a/atc/reference-grant.yaml
+++ b/atc/reference-grant.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: allow-envoy-gateway

--- a/cloudflare-exporter/reference-grant.yaml
+++ b/cloudflare-exporter/reference-grant.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: allow-envoy-gateway

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -82,7 +82,7 @@ to reach a backend `Service` in your app's namespace, also add a
 `ReferenceGrant`:
 
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: allow-envoy-gateway

--- a/freqtrade/reference-grant.yaml
+++ b/freqtrade/reference-grant.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: allow-envoy-gateway

--- a/github-readme-stats/reference-grant.yaml
+++ b/github-readme-stats/reference-grant.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: allow-envoy-gateway

--- a/grafana/reference-grant.yaml
+++ b/grafana/reference-grant.yaml
@@ -1,5 +1,5 @@
 # Allows Gateways in envoy-gateway-system to attach HTTPRoutes living in the grafana namespace.
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: allow-envoy-gateway

--- a/guestbook/reference-grant.yaml
+++ b/guestbook/reference-grant.yaml
@@ -1,5 +1,5 @@
 # Allows Gateways in envoy-gateway-system to attach HTTPRoutes living in the guestbook namespace.
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: allow-envoy-gateway

--- a/harbor/reference-grant.yaml
+++ b/harbor/reference-grant.yaml
@@ -1,5 +1,5 @@
 # Allows Gateways in envoy-gateway-system to attach HTTPRoutes living in the harbor namespace.
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: allow-envoy-gateway

--- a/keycloak-operator/reference-grant.yaml
+++ b/keycloak-operator/reference-grant.yaml
@@ -1,5 +1,5 @@
 # Allows Gateways in envoy-gateway-system to attach HTTPRoutes living in the keycloak namespace.
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: allow-envoy-gateway

--- a/langfuse/reference-grant.yaml
+++ b/langfuse/reference-grant.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: allow-envoy-gateway

--- a/longhorn/reference-grant.yaml
+++ b/longhorn/reference-grant.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: allow-envoy-gateway

--- a/memgator/reference-grant.yaml
+++ b/memgator/reference-grant.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: allow-envoy-gateway

--- a/mlflow/reference-grant.yaml
+++ b/mlflow/reference-grant.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: allow-envoy-gateway

--- a/nc-press-chotatsu/reference-grant.yaml
+++ b/nc-press-chotatsu/reference-grant.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: allow-envoy-gateway

--- a/openwebui/reference-grant.yaml
+++ b/openwebui/reference-grant.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: allow-envoy-gateway

--- a/postgres-shared/tlsroute-internal.yaml
+++ b/postgres-shared/tlsroute-internal.yaml
@@ -2,7 +2,7 @@
 # internal Gateway's port 5432 listener to the postgres-shared master Service.
 # Envoy does not terminate TLS — Spilo presents its self-signed cert and the
 # client must connect with sslmode=require (or distribute the CA for verify-full).
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: postgres-shared

--- a/zot/reference-grant.yaml
+++ b/zot/reference-grant.yaml
@@ -1,5 +1,5 @@
 # Allows Gateways in envoy-gateway-system to attach HTTPRoutes living in the zot namespace.
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: allow-envoy-gateway


### PR DESCRIPTION
## Problem

ArgoCD failed to diff the postgres-shared internal Gateway route:

```
Failed to compare desired state to live state: failed to calculate diff:
error calculating structured merge diff: unable to resolve parseableType
for GroupVersionKind: gateway.networking.k8s.io/v1alpha2, Kind=TLSRoute
```

## Root cause

Gateway API **v1.5.1** (installed cluster-wide via `apps/gateway-api-crds-app.yaml`) promoted `TLSRoute` to the **standard channel at `v1`** and set `v1alpha2` to `served: false` (deprecated). The cluster CRD no longer exposes the `v1alpha2` GVK, so ArgoCD cannot resolve its type for the structured-merge diff.

## Fix

### TLSRoute (the actual bug)
- `postgres-shared/tlsroute-internal.yaml`: `gateway.networking.k8s.io/v1alpha2` → `/v1`. Spec shape is identical between versions.

### ReferenceGrant (cleanup, no-op for the live cluster)
- Bumped all 17 `ReferenceGrant` manifests + the `docs/networking.md` example from `/v1beta1` → `/v1`.
- **Safe:** in v1.5.1 the ReferenceGrant CRD serves **both** `v1` and `v1beta1` (`v1beta1` is still the storage version and is *not* deprecated), so this causes no behavioral change. Done for consistency with the TLSRoute bump and to future-proof against the eventual `v1beta1` removal.

After this PR there are no remaining `v1alpha2`/`v1beta1` Gateway API references in the repo.