### PR TITLE
fix(envoy-gateway): decouple Gateway API CRDs from gateway-helm chart

### DIFF
--- a/apps/envoy-gateway-app.yaml
+++ b/apps/envoy-gateway-app.yaml
@@ -11,6 +11,12 @@ spec:
       targetRevision: 1.8.0
       helm:
         releaseName: envoy-gateway
+        # Gateway API CRDs and Envoy Gateway's own CRDs are managed by the
+        # dedicated gateway-api-crds / envoy-gateway-crds apps. Skipping them
+        # here stops the chart from re-installing Gateway API CRDs on the
+        # experimental channel, which the safe-upgrades ValidatingAdmissionPolicy
+        # rejects on top of the standard channel CRDs.
+        skipCrds: true
         valueFiles:
           - $values/envoy-gateway/values.yaml
     - repoURL: https://github.com/Shion1305/k8s-GitOps.git
@@ -24,7 +30,11 @@ spec:
     namespace: envoy-gateway-system
   syncPolicy:
     automated:
-      prune: true
+      # TEMPORARY (CRD ownership handoff): prune disabled so this app cannot
+      # delete the previously-bundled CRDs — and cascade-delete their CRs —
+      # when skipCrds removes them from its desired state. Restore to `true`
+      # in a follow-up once envoy-gateway-crds / gateway-api-crds own all CRDs.
+      prune: false
       selfHeal: true
     syncOptions:
       - CreateNamespace=true

--- a/apps/envoy-gateway-crds-app.yaml
+++ b/apps/envoy-gateway-crds-app.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: envoy-gateway-crds
+  namespace: argocd
+  annotations:
+    # Install CRDs before the controller and any CRs (same wave as gateway-api-crds).
+    argocd.argoproj.io/sync-wave: "-10"
+spec:
+  project: default
+  # Envoy Gateway's *own* CRDs (gateway.envoyproxy.io/*) only.
+  # The Gateway API CRDs (gateway.networking.k8s.io/*) are owned by the
+  # `gateway-api-crds` app (standard channel). The envoy-gateway controller
+  # app sets helm.skipCrds=true so the chart no longer ships either set,
+  # which is what previously collided with the standard CRDs via the
+  # safe-upgrades ValidatingAdmissionPolicy.
+  # Keep targetRevision in lockstep with the gateway-helm chart version in
+  # apps/envoy-gateway-app.yaml.
+  source:
+    repoURL: https://github.com/envoyproxy/gateway.git
+    targetRevision: v1.8.0
+    path: charts/gateway-helm/charts/crds/crds/generated
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
+      - Replace=true


### PR DESCRIPTION
## 背景 / 根本原因

5/28 に Renovate が2件を相次いで自動マージしたことで CRD のチャネル衝突が発生しました:

- `envoy-gateway` チャート `1.7.2 → 1.8.0` (#350)
- `gateway-api-crds` standard `v1.2.1 → v1.5.1` (#356)

gateway-helm **1.8.0** から Gateway API CRD が `crds` サブチャートに同梱され、**experimental channel** でインストールされるようになりました。一方クラスタの Gateway API CRD は `gateway-api-crds` アプリが **standard v1.5.1** で管理しています。

v1.5.1 が導入した **`safe-upgrades` ValidatingAdmissionPolicy** が「standard CRD の上に experimental CRD を載せる」更新を拒否するため、`envoy-gateway` アプリが恒久的に **SyncError / OutOfSync** に陥っていました。

> なおデータプレーンは正常稼働中（両 Gateway `Programmed=True`、HTTPRoute 拒否 0 件）。詰まっていたのは ArgoCD の sync のみ。

リポジトリで使う Kind は HTTPRoute / Gateway / ReferenceGrant / TLSRoute / GatewayClass のみで、experimental 専用 Kind（TCPRoute/UDPRoute/BackendLBPolicy）は未使用。**standard channel で十分**で、experimental を強制していたのは 1.8.0 チャートの同梱 CRD だけでした。

## 変更内容 — CRD グループごとに単独所有者を確立

| CRD グループ | 所有者 |
|---|---|
| Gateway API（standard 8種）+ safe-upgrades VAP | `gateway-api-crds`（既存・変更なし） |
| Envoy Gateway 独自 8種（`gateway.envoyproxy.io/*`） | **`envoy-gateway-crds`（新規）** — `envoyproxy/gateway` @ `v1.8.0` ピン |
| 上記以外（コントローラ等） | `envoy-gateway` — `helm.skipCrds: true` |

## 安全なロールアウト

`envoy-gateway` の `automated.prune` を **一時的に `false`** にしています。`skipCrds` で CRD が desired から外れても、所有権移譲中に CRD（および配下の CR）が連鎖削除されないようにするためです。

- merge 後、`envoy-gateway-crds`（sync-wave `-10`）が先に EG 独自 CRD の所有権を取得
- `envoy-gateway`（wave 0）は CRD を desired から外すが prune:false で削除ゼロ
- 全アプリが Synced になったのを確認後、**追従 PR で `prune: true` に戻す**

## 検証手順

```bash
kubectl get app envoy-gateway gateway-api-crds envoy-gateway-crds -n argocd   # 全て Synced/Healthy
kubectl get crd | grep -E 'gateway.(envoyproxy.io|networking.k8s.io)' | wc -l # 数が減っていないこと
kubectl get envoyproxy,gateway,httproute -A                                   # CR 無傷
kubectl get gateway -n envoy-gateway-system                                   # Programmed=True
```

## フォローアップ
- [ ] 移譲確認後、`envoy-gateway` の `automated.prune` を `true` に戻す
- [ ] （任意）未使用の orphan experimental CRD（tcproutes/udproutes/backendlbpolicies/xmeshes/xbackendtrafficpolicies、いずれも 0 件）のクリーンアップ
