### PR TITLE
fix(envoy-gateway): restore automated prune after CRD ownership handoff

### DIFF
--- a/apps/envoy-gateway-app.yaml
+++ b/apps/envoy-gateway-app.yaml
@@ -30,11 +30,7 @@ spec:
     namespace: envoy-gateway-system
   syncPolicy:
     automated:
-      # TEMPORARY (CRD ownership handoff): prune disabled so this app cannot
-      # delete the previously-bundled CRDs — and cascade-delete their CRs —
-      # when skipCrds removes them from its desired state. Restore to `true`
-      # in a follow-up once envoy-gateway-crds / gateway-api-crds own all CRDs.
-      prune: false
+      prune: true
       selfHeal: true
     syncOptions:
       - CreateNamespace=true


### PR DESCRIPTION
フォローアップ of #375。

## 概要
#375 で導入した一時的な `automated.prune: false` を `true` に戻し、`envoy-gateway` アプリの prune 動作を元に戻します。`helm.skipCrds: true` はそのまま維持。

## なぜ今なら安全か
CRD の所有権移譲が完了済み:

- `envoy-gateway` が tracking する **CRD は 0 件**(`gateway-api-crds` / `envoy-gateway-crds` が全所有)
- `envoy-gateway-crds` は EG 独自8 CRD を Synced で所有、`gateway-api-crds` は Gateway API CRD + safe-upgrades VAP を Synced で保持
- EnvoyProxy / Gateway / HTTPRoute の CR は無傷、両 Gateway `Programmed=True`

→ prune を戻しても CRD を連鎖削除する経路はありません。

## prune 待ちリソースについて(削除されません)
本アプリの prune 待ち6件はすべて **helm hook**(`helm.sh/hook: pre-install,pre-upgrade`)です:
certgen の SA/ClusterRole/ClusterRoleBinding/Role/RoleBinding、および topology-injector の `MutatingWebhookConfiguration`。
**ArgoCD の `prune` 設定は hook リソースを削除しません**(hook は delete-policy で別管理)。topology-injector Webhook は caBundle 注入済みで稼働中です。

## 検証
```bash
kubectl get app envoy-gateway -n argocd                         # prune 復帰後も CRD/hook の削除なし
kubectl get crd | grep -E 'gateway.(envoyproxy.io|networking.k8s.io)' | wc -l
kubectl get mutatingwebhookconfiguration envoy-gateway-topology-injector.envoy-gateway-system
```

> 補足: `Gateway/external`・`internal` の OutOfSync は prune 対象外の git ドリフト(別件・既存)で、本 PR の対象外です。
