### PR TITLE
fix(postgres-operator): drop spilo fsGroup/runAsUser/runAsGroup to stop group-writable PGDATA

### DIFF
--- a/postgres-operator/values.yaml
+++ b/postgres-operator/values.yaml
@@ -16,9 +16,6 @@ configGeneral:
   enable_spilo_wal_path_compat: false
   etcd_host: ""
   kubernetes_use_configmaps: false
-  spilo_runasuser: 101
-  spilo_runasgroup: 103
-  spilo_fsgroup: 103
 configConnectionPooler:
   connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-32"
   connection_pooler_max_db_connections: 60


### PR DESCRIPTION
## What

Remove `spilo_runasuser` / `spilo_runasgroup` / `spilo_fsgroup` from the operator `configGeneral`, so the generated spilo `PodSecurityContext` no longer sets `fsGroup`.

## Why (root cause of the 2026-05-30 outage)

The spilo pods set `fsGroup: 103`. The kubelet applies `fsGroup` **recursively on every volume mount**, leaving PGDATA (`/home/postgres/pgdata/pgroot/data`) as `drwxrws---` (mode **2770**, group-writable). PostgreSQL refuses to start unless PGDATA is `0700`/`0750` (group-write forbidden).

Normally spilo's entrypoint `chmod 0700`s PGDATA **at container start**, so it's fine. But when a Longhorn volume is **remounted mid-life** (e.g. a node/control-plane reboot forcing detach→reattach), the kubelet re-applies `fsGroup` → PGDATA back to 2770 **without a container restart**, so spilo's chmod never re-runs. The data dir is then latently broken; the next in-container Patroni-driven postgres restart FATALs:

```
FATAL: data directory "/home/postgres/pgdata/pgroot/data" has invalid permissions
DETAIL: Permissions should be u=rwx (0700) or u=rwx,g=rx (0750).
```

On 2026-05-30 this hit all three spilo clusters (`postgres-shared`, `atc`, `github-data`) at once.

## How this fixes it

Per the Kubernetes spec, **if `fsGroup` is unset the kubelet does not modify the ownership/permissions of the volume at all** — so the recursive 2770 re-apply (the trigger) is removed structurally, not merely mitigated. Dropping `runAsUser`/`runAsGroup` together lets the spilo entrypoint run as root and `chown -R postgres: && chmod 0700` a freshly-created `root:root` volume (a non-root PID1 cannot chown a root-owned tree). The DB process itself is still dropped to the `postgres` user by spilo.

This was the only option that scored **"eliminates"** in the adversarial remediation review (e.g. `fsGroupChangePolicy: OnRootMismatch` is only a fragile partial mitigation and the operator v1.15.1 exposes no knob for it; HA does not help and can worsen this failure).

## Tradeoff / risk

- spilo **PID1 runs as root** (reverses the non-root hardening for the supervisor; the DB process stays non-root). Verified: the `postgres-operator-deployment` namespace has **no PodSecurity `restricted` enforcement** and **no Kyverno policy** blocking root, so this is not admission-blocked.
- Operator-wide: affects `postgres-shared`, `atc`, and `github-data` (the latter is not in this repo but shares the operator config).

## Rollout (do in a maintenance window)

After ArgoCD syncs, the operator updates the StatefulSet pod template; **existing pods keep the old securityContext until recreated**, and the operator may roll all spilo StatefulSets — briefly restarting all three single-instance DBs. Recreate pods one at a time and verify:

```
kubectl exec -n postgres-operator-deployment <cluster>-0 -c postgres -- stat -c %a /home/postgres/pgdata/pgroot/data   # expect 700
```

Related: mis-scheduling and detection fixes are in separate PRs.
