### PR TITLE
fix(postgres-shared): pin spilo to Longhorn node via nodeAffinity

### DIFF
--- a/postgres-shared/postgres-cluster.yaml
+++ b/postgres-shared/postgres-cluster.yaml
@@ -37,3 +37,11 @@ spec:
       - local all all trust
       - host all all 0.0.0.0/0 md5
       - hostssl all all 0.0.0.0/0 md5
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - shion-ubuntu-2505


### PR DESCRIPTION
## What

Pin the `postgres-shared` spilo cluster to a Longhorn-capable node via `spec.nodeAffinity` (`kubernetes.io/hostname In [shion-ubuntu-2505]`), mirroring what `atc/postgres-cluster.yaml` already does.

## Why

`shion-raspi-cm4` was added to the cluster but is **not a Longhorn storage node** and is **untainted**, so the default scheduler can place any spilo pod there. When that happens the RWO Longhorn volume can never attach:

```
Multi-Attach error ... / node.longhorn.io "shion-raspi-cm4" not found (404 from longhorn-backend)
```

`github-data-0` already fell into this trap during the 2026-05-30 reboot aftermath and was stuck `Pending` until rescheduled. `atc` was protected by its existing `nodeAffinity`; `postgres-shared` had none. This adds the same protection. (The `postgres-shared` Longhorn volume's only replica lives on `shion-ubuntu-2505`, so pinning there is also where the data is.)

## Scope / not covered here

- `github-data` is **not managed in this repo** (no manifest, no ArgoCD labels), so its missing `nodeAffinity` cannot be fixed by a repo change — it needs to be imported into GitOps, or the operator-wide `node_readiness_label: {longhorn.io/node: "true"}` approach (covers all clusters but changes operator-global behavior and needs validation of the `node_readiness_label_merge` semantics). Tracked separately.
- This is orthogonal to the fsGroup permission root cause (separate PR).
