### PR TITLE
feat(postgres): alert on spilo PGDATA-permission failure + fix manage-postgres.sh namespace

### DIFF
--- a/manage-postgres.sh
+++ b/manage-postgres.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-NAMESPACE="postgres-clusters"
+NAMESPACE="postgres-operator-deployment"
 
 function usage() {
     echo "Usage: $0 [command] [options]"

--- a/postgres-shared/kustomization.yaml
+++ b/postgres-shared/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - postgres-cluster.yaml
   - tlsroute-internal.yaml
+  - prometheus-rule.yaml

--- a/postgres-shared/prometheus-rule.yaml
+++ b/postgres-shared/prometheus-rule.yaml
@@ -1,0 +1,33 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: spilo-postgres-health
+  namespace: postgres-operator-deployment
+  labels:
+    app.kubernetes.io/part-of: postgres-operator
+spec:
+  groups:
+    - name: spilo-postgres
+      rules:
+        # Detect the fsGroup-induced "data directory has invalid permissions"
+        # FATAL: Patroni cannot start postgres, so the pod is NotReady while its
+        # container keeps running (no crashloop). This signature is distinct from
+        # a normal crash and is what the 2026-05-30 outage looked like.
+        - alert: SpiloPostgresNotReadyWhileRunning
+          expr: |
+            (kube_pod_container_status_running{namespace="postgres-operator-deployment"} == 1)
+            and on (namespace, pod)
+            (kube_pod_status_ready{namespace="postgres-operator-deployment", condition="true"} == 0)
+            and on (namespace, pod)
+            (kube_pod_labels{label_application="spilo"} == 1)
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Spilo postgres pod {{ $labels.pod }} is running but NotReady (possible PGDATA permission failure)"
+            description: >-
+              {{ $labels.namespace }}/{{ $labels.pod }} has a running container but has been
+              NotReady for >10m with no restart. This matches the fsGroup-induced
+              'data directory has invalid permissions' FATAL, where Patroni cannot start
+              postgres while the container stays up. Recovery: recreate the pod
+              (kubectl delete pod) so the spilo entrypoint re-applies chmod 0700 to PGDATA.


### PR DESCRIPTION
## What

Detection + recovery-tooling improvements for the spilo PGDATA-permission failure class (defense-in-depth, **not** prevention — see the root-cause fix in a separate PR):

1. **`postgres-shared/prometheus-rule.yaml`** — a `PrometheusRule` alerting `SpiloPostgresNotReadyWhileRunning` when a spilo pod's container is running but the pod is NotReady for >10m with no restart. This is the exact signature of the `FATAL: data directory has invalid permissions` failure (Patroni can't start postgres, container stays up — distinct from a crashloop). Added to `postgres-shared/kustomization.yaml`.
2. **`manage-postgres.sh`** — fix `NAMESPACE` from the stale `postgres-clusters` to the actual `postgres-operator-deployment`, so the management script targets the real clusters.

## Why

During the 2026-05-30 outage the DB was down for ~2h before a human noticed; there was no alert. The pod stays `Running`/`NotReady` (not crashlooping), so a readiness-based rule catches it. Prometheus rule discovery is cluster-wide here (`ruleSelector: {}`), so the rule is picked up automatically.

## Notes

- Alert only — it does **not** auto-delete pods (auto-remediation would need tight guards against false positives during bootstrap/restore/detach). Recovery action is documented in the alert annotation (recreate the pod).
- `kustomize build postgres-shared` renders cleanly (postgresql + TLSRoute + PrometheusRule).
