### PR TITLE
ci(zot-demo): build & push shion1305/demo as multi-arch (amd64+arm64)

### DIFF
--- a/.github/workflows/demo-push-to-zot.yaml
+++ b/.github/workflows/demo-push-to-zot.yaml
@@ -22,6 +22,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # QEMU registers arm64 emulation on the amd64 GitHub-hosted runner so
+      # buildx can produce arm64 layers from the same Dockerfile.
+      - uses: docker/setup-qemu-action@v4
+        with:
+          platforms: arm64
+
       - uses: docker/setup-buildx-action@v4
 
       # We don't use docker/login-action / docker push: zot v2.1.16's bearer-
@@ -70,11 +76,14 @@ jobs:
       # accepts. (The docker-archive format pushes
       # application/vnd.docker.distribution.manifest.v2+json which zot rejects
       # with 415 / MANIFEST_INVALID.)
+      #
+      # Multi-arch: buildx writes an OCI image index referencing one manifest
+      # per platform; `crane push --index` propagates the whole index to zot.
       - name: Build OCI image
         run: |
           set -euo pipefail
           docker buildx build \
-            --platform linux/amd64 \
+            --platform linux/amd64,linux/arm64 \
             --output type=oci,dest=/tmp/image.tar \
             ./zot/demo
 
@@ -84,7 +93,10 @@ jobs:
           # Extract OCI tarball so crane can read it as an OCI layout dir.
           mkdir -p /tmp/oci
           tar -xf /tmp/image.tar -C /tmp/oci
-          crane push /tmp/oci \
+          # --index pushes the OCI image index (multi-arch manifest list)
+          # produced by the multi-platform buildx build. Without --index,
+          # crane would push only one of the per-arch manifests.
+          crane push --index /tmp/oci \
             registry.shion1305.com/shion1305/demo:${{ github.sha }}
           crane tag \
             registry.shion1305.com/shion1305/demo:${{ github.sha }} \


### PR DESCRIPTION
## What

Make the `registry.shion1305.com/shion1305/demo` (zot) image multi-arch.

The zot demo workflow built only `linux/amd64` and pushed a single-arch
manifest, so arm64 nodes (raspi-cm4) could not pull the image. This mirrors
the existing `harbor-build-push` composite action's approach.

## Changes

`.github/workflows/demo-push-to-zot.yaml` only:

1. **QEMU** — add `docker/setup-qemu-action@v4` so the amd64 runner can emulate arm64.
2. **Platforms** — `--platform linux/amd64` → `--platform linux/amd64,linux/arm64`; buildx emits an OCI image index (one manifest per arch).
3. **Push index** — `crane push` → `crane push --index` so the full manifest list reaches zot (otherwise only one per-arch manifest is pushed).

## Notes

- No Dockerfile change: `zot/demo/Dockerfile` is `FROM alpine:3.23`, already multi-arch upstream.
- No pull-side change: [`zot-pull-smoketest/job.yaml`](../blob/main/zot-pull-smoketest/job.yaml) pulls `:latest` without arch pinning, so kubelet selects the matching per-arch manifest.
- `crane tag … latest` is unchanged — it just remaps the tag onto the index.

## Verification

Merging hits the `zot/demo/**` + workflow path filter and runs the build for real. Can also be triggered manually via `workflow_dispatch` beforehand.