### PR TITLE
fix(mlflow): use Recreate strategy to avoid RWO PVC rollout deadlock

### DIFF
--- a/mlflow/values.yaml
+++ b/mlflow/values.yaml
@@ -1,3 +1,8 @@
+# Single replica with an RWO Longhorn artifact PVC: roll the old pod out before
+# the new one so the volume can detach instead of dead-locking the rollout.
+strategy:
+  type: Recreate
+
 backendStore:
   databaseMigration: true
   databaseConnectionCheck: true


### PR DESCRIPTION
## Problem

mlflow is `Degraded` in ArgoCD. The v1.8.2 chart bump (#383, image `3.7.0 → 3.12.0`) triggered a rollout that has been stuck for hours.

**Root cause — RWO PVC + RollingUpdate cross-node deadlock:**
- The chart default strategy is `RollingUpdate` with `maxSurge:100%, maxUnavailable:0`, so the old pod must stay Ready until the new pod is Ready.
- The artifact PVC `mlflow-artifacts` is **RWO** (`longhorn-hdd`), attached to `shion-ubuntu-2505` (old pod).
- The surge pod was scheduled onto a **different** node (`instance-k8s-proxy`), could not attach the RWO volume, and stalled at `Init:0/2` (`PodReadyToStartContainers=False`).
- Old pod won't release the volume (maxUnavailable:0) ⇄ new pod can't become Ready → permanent stall.

## Fix

Single-replica app with an RWO volume → `strategy: Recreate`. The old pod terminates first (volume detaches), then the new pod attaches on any node.

Verified `helm template` renders `strategy.type: Recreate`.