### PR TITLE
chore(gh-analysis): upgrade gh-spam-analysis image to v0.1.10

### DIFF
--- a/gh-analysis/values.yaml
+++ b/gh-analysis/values.yaml
@@ -1,7 +1,7 @@
 image:
   # Use the same image repo you publish in CI
   repository: ghcr.io/shion1305/gh-spam-analysis-proj
-  tag: "v0.1.7"
+  tag: "v0.1.10"
   pullPolicy: IfNotPresent
 api:
   replicaCount: 1


### PR DESCRIPTION
## Summary
Bumps the pinned `gh-spam-analysis` image tag from `v0.1.7` → `v0.1.10` in [`gh-analysis/values.yaml`](gh-analysis/values.yaml).

`v0.1.10` is the latest upstream release of `Shion1305/gh-spam-analysis-proj` (published 2026-05-31), succeeding the intermediate `v0.1.8` and `v0.1.9` tags.

## Details
- Image: `ghcr.io/shion1305/gh-spam-analysis-proj`
- The ArgoCD `gh-analysis` app tracks the chart at upstream `HEAD`; only the image tag is pinned here.

## Test plan
- [ ] render-validate CI passes
- [ ] ArgoCD syncs `gh-analysis` and api/collector pods roll to `v0.1.10`