### PR TITLE
fix(langfuse): make redis resilient to unclean shutdown (RDB) + fix ignored redis.master.* keys

### DIFF
--- a/langfuse/values.yaml
+++ b/langfuse/values.yaml
@@ -112,18 +112,28 @@ clickhouse:
                   values:
                     - shion-ubuntu-2505
 
-# Redis - embedded deployment
+# Redis: bitnami valkey subchart (aliased `redis`) -> uses `primary.*`,
+# not the redis chart's `master.*` (the latter is silently ignored here).
 redis:
-  enabled: true
+  deploy: true
   auth:
     enabled: true
     existingSecret: "langfuse-credentials"
     existingSecretPasswordKey: "REDIS_PASSWORD"
-  master:
+  # RDB snapshots (written to a temp file then atomically renamed) instead of
+  # AOF (in-place append): an unclean node shutdown can't leave a half-written
+  # file that blocks startup. redis is a disposable BullMQ queue/cache here;
+  # postgres + clickhouse hold the source of truth.
+  commonConfiguration: |-
+    appendonly no
+    save "900 1 300 10 60 10000"
+  primary:
+    extraFlags:
+      - "--maxmemory-policy noeviction"   # required by the langfuse chart
     persistence:
       enabled: true
-      size: 5Gi
-      storageClass: "longhorn-ssd"
+      # size/storageClass left at chart default (8Gi, default longhorn-ssd):
+      # the existing PVC is 8Gi and StatefulSet volumeClaimTemplates are immutable.
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
## Problem
A node reboot (`shion-ubuntu-2505`, unclean shutdown) left valkey's incremental AOF with a corrupt tail. On restart valkey loaded the base RDB (76 keys) then died on `Bad file format reading the append only file …appendonly.aof.16.incr.aof` → CrashLoopBackOff → `langfuse-web` and `langfuse-worker` crashlooped (`connect EPERM …:6379`, Redis ping timeout) → **langfuse fully down**. The live AOF was hand-repaired with `valkey-check-aof --fix` to restore service; this PR prevents recurrence.

## Two issues fixed

**1. `redis.master.*` was silently ignored.** The embedded redis is the bitnami **valkey** subchart (aliased `redis`), which uses `redis.primary.*`. The repo used `redis.master.*`, so resources/persistence/affinity never applied — redis ran on the default `nano` preset (**192Mi**, not the intended 512Mi) with no node affinity. Renamed `master.*` → `primary.*` (also `enabled` → `deploy`).

**2. AOF → RDB persistence.** AOF appends in-place, so an unclean shutdown can leave a half-written, format-corrupt file that blocks startup (no valkey setting tolerates mid-file corruption — `aof-load-truncated` only covers a truncated tail). RDB writes to a temp file then atomically renames, so a crash can't leave a startup-blocking file — valkey just loads the last complete snapshot. redis here is a disposable BullMQ queue/cache; **postgres + clickhouse hold the source of truth**, so the larger crash-loss window is acceptable.

```
redis.commonConfiguration:
  appendonly no
  save "900 1 300 10 60 10000"
```

## Safety / behavior on sync
- `--maxmemory-policy noeviction` retained (langfuse chart requirement).
- PVC `size`/`storageClass` left at chart default (**8Gi**, default `longhorn-ssd`) — verified the rendered volumeClaimTemplate matches the live one, so the immutable `volumeClaimTemplates` field is unchanged and sync won't fail.
- On sync the redis pod rolls (resources/affinity/config change). With `appendonly no` and no `dump.rdb` yet, **redis starts empty once** — a one-time loss of the current disposable cache/queue (no effect on postgres/clickhouse data). The orphan `appendonlydir` remains on the PVC, harmless and ignored.

## Test plan
- [x] `helm template` renders cleanly; configmap shows `appendonly no` + `save`; resources = 512Mi; `--maxmemory-policy noeviction` present; volumeClaimTemplate = 8Gi / no storageClass (matches live)
- [ ] render-validate CI passes
- [ ] After merge: redis pod 1/1, `dump.rdb` appears in /data, web/worker healthy