### PR TITLE
fix(langfuse): scale ClickHouse & ZooKeeper to 1 replica for PoC

### DIFF
--- a/langfuse/values.yaml
+++ b/langfuse/values.yaml
@@ -78,6 +78,9 @@ postgresql:
 # ClickHouse - embedded deployment
 clickhouse:
   enabled: true
+  # Single replica for PoC: shards=1, so every replica is a full copy of the
+  # same data. HA replication isn't worth 3x the memory/disk at this scale.
+  replicaCount: 1
   auth:
     existingSecret: "langfuse-credentials"
     existingSecretKey: "CLICKHOUSE_PASSWORD"
@@ -90,8 +93,8 @@ clickhouse:
       cpu: 500m
       memory: 1Gi
     limits:
-      cpu: 2000m
-      memory: 4Gi
+      cpu: 1000m
+      memory: 2Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -102,6 +105,9 @@ clickhouse:
                 values:
                   - shion-ubuntu-2505
   zookeeper:
+    # Single node: just enough coordination for ClickHouse's ReplicatedMergeTree
+    # tables, which langfuse's migrations require even on one ClickHouse replica.
+    replicaCount: 1
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Why

langfuse is running at **PoC scale** (only ~1 GiB of ClickHouse data, low ingest), but the embedded stack was deployed at HA defaults:

| Component | Replicas | requests/pod | PVC/pod | actual data |
|---|---|---|---|---|
| ClickHouse | **3** | 1Gi / 500m | 20Gi | ~1.0 GiB (each replica is a full copy) |
| ZooKeeper | **3** | 256Mi / 250m | 8Gi | ~210 MiB |

`shards=1` means all 3 ClickHouse replicas hold the **same data** — the 3× was pure HA redundancy we don't need for a PoC. This is what made "ClickHouse alone eat ~3GB" (1Gi × 3 requests).

## What

- `clickhouse.replicaCount` 3 → **1**
- `clickhouse.zookeeper.replicaCount` 3 → **1**
- ClickHouse memory limit 4Gi → **2Gi** (cpu limit 2 → 1)

**Impact:** langfuse memory requests **~3.75Gi → ~1.25Gi**, pod count **8 → 4**.

Data is preserved on `shard0-0` / `zookeeper-0` (each held a full copy). No data loss.

> ZooKeeper can't be removed entirely — langfuse's ClickHouse migrations create `ReplicatedMergeTree` tables, which require keeper coordination even on a single ClickHouse node. 1 replica is the floor.

## Post-merge manual cleanup (not in this PR — destructive)

After ArgoCD scales the StatefulSets down, these are left orphaned and reclaimed by hand:

- Orphaned PVCs + Longhorn volumes: `data-langfuse-clickhouse-shard0-{1,2}` (2×20Gi) + `data-langfuse-zookeeper-{1,2}` (2×8Gi) → **~56Gi freed**
- `SYSTEM DROP REPLICA` on shard0-0 to deregister the removed ClickHouse replicas from ZooKeeper (hygiene; prevents replication-queue buildup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)