### PR TITLE
feat(metrics-server): add metrics-server App (kubectl top + HPA)

### DIFF
--- a/apps/metrics-server-app.yaml
+++ b/apps/metrics-server-app.yaml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: metrics-server
+  namespace: argocd
+spec:
+  project: default
+  sources:
+    - repoURL: https://kubernetes-sigs.github.io/metrics-server/
+      chart: metrics-server
+      targetRevision: 3.13.0
+      helm:
+        valueFiles:
+          - $values/metrics-server/values.yaml
+    - repoURL: https://github.com/Shion1305/k8s-GitOps.git
+      targetRevision: HEAD
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/metrics-server/values.yaml
+++ b/metrics-server/values.yaml
@@ -1,0 +1,18 @@
+# metrics-server (kubernetes-sigs): serves the resource metrics API
+# (metrics.k8s.io) that backs `kubectl top` and HPA.
+# Chart: metrics-server/metrics-server
+
+# Kubelet serving certificates on this cluster are self-signed (kubeadm does
+# not have them signed by the cluster CA by default), so metrics-server cannot
+# verify them over TLS. This is the standard self-managed/homelab fix.
+args:
+  - --kubelet-insecure-tls
+
+replicas: 1
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    memory: 256Mi


### PR DESCRIPTION
## Why

The cluster has **no metrics-server**, so `kubectl top nodes/pods` returns *"Metrics API not available"* and HPAs can't read CPU/memory. (I hit this while sizing langfuse — couldn't measure live pod memory.)

## What

Adds metrics-server as a new ArgoCD App following the repo's multi-source chart pattern.

- Chart: `metrics-server/metrics-server` **3.13.0** (app `0.8.0`)
- 2-source pattern (chart + `$values` ref) — no extra manifests needed, so no `path:` source.
- Namespace: `kube-system` (chart convention for this cluster addon)
- `--kubelet-insecure-tls`: kubelet serving certs on this kubeadm-style cluster are **self-signed** (not signed by the cluster CA), so metrics-server's TLS verification to kubelets would otherwise fail with `x509: certificate signed by unknown authority`. Standard self-managed/homelab fix.
- 1 replica, lean resources: requests 50m / 128Mi, memory limit 256Mi.

## Validation

- `helm template` renders cleanly (9 resources)
- `kubeconform -strict`: **Valid 9 / Invalid 0 / Errors 0**

## After sync

Once ArgoCD syncs and the Deployment is Ready, the aggregated API `v1beta1.metrics.k8s.io` registers and `kubectl top nodes` / `kubectl top pods -A` start working (~30-60s for first metrics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)