### PR TITLE
feat(network-policies): cross-namespace ingress isolation (Cilium + Kyverno)

### DIFF
--- a/apps/network-policies-app.yaml
+++ b/apps/network-policies-app.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: network-policies
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Shion1305/k8s-GitOps.git
+    targetRevision: HEAD
+    path: network-policies
+  destination:
+    server: https://kubernetes.default.svc
+    # CiliumClusterwideNetworkPolicy is cluster-scoped (this namespace is only
+    # Argo bookkeeping); the per-namespace CiliumNetworkPolicy resources carry
+    # their own metadata.namespace and land there.
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/atc/kustomization.yaml
+++ b/atc/kustomization.yaml
@@ -21,3 +21,4 @@ resources:
   - seaweedfs-statefulset.yaml
   - seaweedfs-service.yaml
   - seaweedfs-httproute.yaml
+  - network-policy-openwebui-to-mcp.yaml

--- a/atc/network-policy-openwebui-to-mcp.yaml
+++ b/atc/network-policy-openwebui-to-mcp.yaml
@@ -1,0 +1,22 @@
+# Allow openwebui (mcpo) to reach postgres-mcp. Additive ingress allow;
+# cross-ns default-deny is applied by the cluster-wide network-policies generator.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-ingress-from-openwebui-to-postgres-mcp
+  namespace: atc
+spec:
+  endpointSelector:
+    matchLabels:
+      app: postgres-mcp
+  enableDefaultDeny:
+    ingress: false
+    egress: false
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: openwebui
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP

--- a/cloudflare-exporter/kustomization.yaml
+++ b/cloudflare-exporter/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - grafana-dashboards.yaml
   - vault-secret-store.yaml
   - external-secret.yaml
+  - networkpolicy.yaml

--- a/cloudflare-exporter/networkpolicy.yaml
+++ b/cloudflare-exporter/networkpolicy.yaml
@@ -1,0 +1,22 @@
+# cloudflare-grafana is reached externally via Cloudflare tunnel, so allow
+# ingress from outside the cluster on :3000. Additive ingress allow; cross-ns
+# default-deny is applied by the cluster-wide network-policies generator.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-ingress-from-world-to-cloudflare-grafana
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app: cloudflare-grafana
+  enableDefaultDeny:
+    ingress: false
+    egress: false
+  ingress:
+    - fromEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP

--- a/grafana/kustomization.yaml
+++ b/grafana/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - dashboards/kubernetes.yaml
   - dashboards/node-metrics.yaml
   - dashboards/monitoring.yaml
+  - networkpolicy.yaml

--- a/grafana/networkpolicy.yaml
+++ b/grafana/networkpolicy.yaml
@@ -1,0 +1,21 @@
+# Allow the monitoring namespace (cloudflare-grafana proxy datasource) to query
+# Prometheus on :9090. Additive ingress allow; cross-ns default-deny is applied
+# by the cluster-wide network-policies generator.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-ingress-from-monitoring
+  namespace: grafana
+spec:
+  endpointSelector: {}
+  enableDefaultDeny:
+    ingress: false
+    egress: false
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP

--- a/network-policies/README.md
+++ b/network-policies/README.md
@@ -1,0 +1,71 @@
+# Network Policies — Cross-Namespace Isolation (Cilium + Kyverno)
+
+Cluster-wide cross-namespace isolation. Cilium (`enable-policy: default`)
+enforces standard and Cilium network policies together as a union of allows.
+
+## Model
+
+- **Ingress is default-denied per namespace; egress is left open.** A pod accepts
+  a cross-namespace connection only when an allow exists; egress to the internet,
+  DNS and the API server are unaffected.
+- `cross-ns-isolation-generator.yaml` (Kyverno `ClusterPolicy`) generates a
+  default-deny-ingress NetworkPolicy that allows same-namespace ingress into every
+  non-system namespace, **including ones created later** (new apps). A standard
+  `networking.k8s.io` NetworkPolicy is used so Kyverno needs no extra RBAC.
+- `allow-from-infra.yaml` adds the universal cross-namespace ingress allows:
+  `host`/`remote-node` (kubelet probes), `kube-apiserver` (webhooks), `health`,
+  the `envoy-gateway-system` namespace (ingress proxy), and the `grafana`
+  namespace (Prometheus scrape + operator).
+- **East-west (app-to-app) allows live in each receiving app's own directory**, as
+  a `CiliumNetworkPolicy` alongside that app's other manifests.
+
+### Excluded namespaces
+
+The generator excludes `kube-system`, `kube-node-lease`, `kube-public` (CoreDNS
+serves DNS to every namespace) and `kyverno` (decoupled from its own engine).
+To exclude more, add names to the generator's `exclude.any[].resources.names`.
+
+## East-west allows
+
+| Receiver | Allowed source(s) | Port | File |
+|---|---|---|---|
+| shared Postgres (`postgres-operator-deployment`) | adminer, atc, harbor, keycloak, langfuse, mlflow, nc-press-chotatsu, openwebui, postgres-operator | 5432 | `postgres-shared/networkpolicy.yaml` |
+| shared Postgres | postgres-operator (Patroni) | 8008 | `postgres-shared/networkpolicy.yaml` |
+| `vault` | external-secrets | 8200 | `vault/networkpolicy.yaml` |
+| `atc` (`app=postgres-mcp`) | openwebui | 8000 | `atc/network-policy-openwebui-to-mcp.yaml` |
+| `monitoring` (`app=cloudflare-grafana`) | world (external) | 3000 | `cloudflare-exporter/networkpolicy.yaml` |
+| `grafana` (Prometheus) | monitoring (cloudflare-grafana datasource) | 9090 | `grafana/networkpolicy.yaml` |
+
+To allow a new cross-namespace path, add a `CiliumNetworkPolicy` (additive,
+`enableDefaultDeny: false`) to the receiving app's directory.
+
+## Rollout
+
+`root-app` auto-syncs `apps/`, so merging `apps/network-policies-app.yaml` applies
+the generator with `generateExisting: true` and default-denies ingress across all
+non-excluded namespaces in one sync.
+
+To stage, enable the deny on a pilot namespace first so misses are observable —
+scope the generator with `match.any[].resources.names: [<pilot-ns>]`, watch
+`hubble observe -f --namespace <pilot-ns> --verdict DROPPED`, add any missing
+source to the receiver's app directory, then widen. (Disabling the generator and
+watching for drops does **not** work: with nothing denied, the DROPPED log is
+empty regardless of coverage.)
+
+```bash
+hubble observe -f --verdict DROPPED                                   # legitimate drops?
+kubectl get netpol -A -l network-policies/purpose=cross-ns-isolation  # one per namespace
+```
+
+## Rollback
+
+Delete the `cross-ns-isolation` ClusterPolicy; `synchronize: true` removes every
+generated NetworkPolicy and all namespaces return to default-allow. Verify (Kyverno
+must be healthy to garbage-collect):
+
+```bash
+kubectl get netpol -A -l network-policies/purpose=cross-ns-isolation  # expect: none
+kubectl delete netpol -A -l network-policies/purpose=cross-ns-isolation  # force if any remain
+```
+
+To exempt one namespace, add its name to the generator's `exclude` list.

--- a/network-policies/allow-from-infra.yaml
+++ b/network-policies/allow-from-infra.yaml
@@ -1,0 +1,52 @@
+# Universal ingress allows that every pod needs. All additive
+# (enableDefaultDeny: false) — they grant ingress without isolating anything;
+# the per-namespace generator applies the default-deny.
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-ingress-from-node-and-apiserver
+spec:
+  # host/remote-node: kubelet probes and node/cross-node datapath.
+  # kube-apiserver: admission & conversion webhook callbacks.
+  # health: Cilium endpoint health checks.
+  endpointSelector: {}
+  enableDefaultDeny:
+    ingress: false
+    egress: false
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+        - kube-apiserver
+        - health
+---
+# Envoy Gateway is the ingress proxy and reaches every published backend.
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-ingress-from-envoy-gateway
+spec:
+  endpointSelector: {}
+  enableDefaultDeny:
+    ingress: false
+    egress: false
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+---
+# Prometheus scrapes, and the Grafana operator manages, targets in every
+# namespace.
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-ingress-from-monitoring
+spec:
+  endpointSelector: {}
+  enableDefaultDeny:
+    ingress: false
+    egress: false
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: grafana

--- a/network-policies/cross-ns-isolation-generator.yaml
+++ b/network-policies/cross-ns-isolation-generator.yaml
@@ -1,0 +1,65 @@
+# Default-deny cross-namespace ingress in every non-system namespace, current and
+# future. Kyverno watches Namespace objects and generates a NetworkPolicy that
+# denies ingress except from the same namespace; allow-from-infra.yaml and each
+# app's own policy add back the permitted cross-namespace ingress (Cilium
+# evaluates standard and Cilium policies together as a union of allows).
+#
+# A standard networking.k8s.io NetworkPolicy is generated (Kyverno already has the
+# RBAC for it). synchronize: true realigns/recreates the policy and removes it on
+# ClusterPolicy deletion. failurePolicy: Ignore keeps Namespace admission working
+# if Kyverno is down, at the cost of isolation being applied only once it recovers.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: cross-ns-isolation
+  annotations:
+    policies.kyverno.io/title: Cross-namespace ingress isolation
+    policies.kyverno.io/category: Network Isolation
+    policies.kyverno.io/subject: Namespace, NetworkPolicy
+    policies.kyverno.io/description: >-
+      Generates a default-deny-ingress NetworkPolicy (allowing same-namespace
+      ingress) into every non-system namespace so cross-namespace traffic is
+      denied by default. Cross-namespace allows are added by
+      network-policies/allow-from-infra.yaml and each app's own policy.
+spec:
+  generateExisting: true
+  webhookConfiguration:
+    failurePolicy: Ignore
+  rules:
+    - name: add-cross-ns-isolation-netpol
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+      exclude:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                # CoreDNS in kube-system serves DNS to every namespace; the
+                # kyverno engine is kept unisolated to avoid coupling it to its
+                # own reachability.
+                - kube-system
+                - kube-node-lease
+                - kube-public
+                - kyverno
+      generate:
+        apiVersion: networking.k8s.io/v1
+        kind: NetworkPolicy
+        name: cross-ns-isolation
+        namespace: "{{ request.object.metadata.name }}"
+        synchronize: true
+        data:
+          metadata:
+            labels:
+              app.kubernetes.io/managed-by: kyverno
+              network-policies/purpose: cross-ns-isolation
+          spec:
+            podSelector: {}
+            policyTypes:
+              - Ingress
+            ingress:
+              - from:
+                  - podSelector: {}

--- a/network-policies/kustomization.yaml
+++ b/network-policies/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Cluster-wide cross-namespace isolation framework:
+# - cross-ns-isolation-generator.yaml : Kyverno ClusterPolicy that default-denies
+#   ingress (allowing same-namespace) in every non-system namespace, current and
+#   future.
+# - allow-from-infra.yaml : the universal ingress allows (node/apiserver, Envoy
+#   Gateway, monitoring).
+# Per-namespace east-west allows live in each app's own directory. See README.md.
+resources:
+  - allow-from-infra.yaml
+  - cross-ns-isolation-generator.yaml

--- a/postgres-shared/kustomization.yaml
+++ b/postgres-shared/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - postgres-cluster.yaml
   - tlsroute-internal.yaml
+  - networkpolicy.yaml

--- a/postgres-shared/networkpolicy.yaml
+++ b/postgres-shared/networkpolicy.yaml
@@ -1,0 +1,39 @@
+# Allow the shared-Postgres DB clients (:5432) and the operator's Patroni REST
+# API (:8008). Additive ingress allow; cross-ns default-deny is applied by the
+# cluster-wide network-policies generator.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-ingress-from-db-clients
+  namespace: postgres-operator-deployment
+spec:
+  endpointSelector: {}
+  enableDefaultDeny:
+    ingress: false
+    egress: false
+  ingress:
+    - fromEndpoints:
+        - matchExpressions:
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: In
+              values:
+                - adminer
+                - atc
+                - harbor
+                - keycloak
+                - langfuse
+                - mlflow
+                - nc-press-chotatsu
+                - openwebui
+                - postgres-operator
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: postgres-operator
+      toPorts:
+        - ports:
+            - port: "8008"
+              protocol: TCP

--- a/vault/kustomization.yaml
+++ b/vault/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - httproute-internal.yaml
   - httproute-external.yaml
   - httproute-legacy-redirect.yaml
+  - networkpolicy.yaml

--- a/vault/networkpolicy.yaml
+++ b/vault/networkpolicy.yaml
@@ -1,0 +1,21 @@
+# Allow External Secrets Operator to reach Vault. Additive: contributes an
+# ingress allow without isolating Vault by itself (cross-ns default-deny is
+# applied by the cluster-wide network-policies generator).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-ingress-from-external-secrets
+  namespace: vault
+spec:
+  endpointSelector: {}
+  enableDefaultDeny:
+    ingress: false
+    egress: false
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: external-secrets
+      toPorts:
+        - ports:
+            - port: "8200"
+              protocol: TCP


### PR DESCRIPTION
## What

Cluster-wide **cross-namespace ingress isolation** using Cilium + Kyverno. Ingress
is default-denied per namespace (same-namespace allowed); egress is left open, so
internet / DNS / API-server access is unaffected.

## How

- **`network-policies/cross-ns-isolation-generator.yaml`** — a Kyverno `ClusterPolicy`
  generates a default-deny-ingress `NetworkPolicy` into every non-system namespace,
  **including ones created later** (new apps). `generateExisting` backfills existing
  namespaces; `synchronize` keeps them aligned and removes them on rollback. A
  standard `networking.k8s.io` NetworkPolicy is generated (no extra Kyverno RBAC);
  Cilium merges it additively with the Cilium allows.
- **`network-policies/allow-from-infra.yaml`** — universal ingress allows:
  `host`/`remote-node` (kubelet probes), `kube-apiserver` (webhooks), `health`,
  `envoy-gateway-system` (ingress proxy), `grafana` (Prometheus scrape + operator).
- **East-west (app-to-app) allows live in each receiving app's directory** as a
  `CiliumNetworkPolicy`:

| Receiver | Source | Port | File |
|---|---|---|---|
| shared Postgres | adminer, atc, harbor, keycloak, langfuse, mlflow, nc-press-chotatsu, openwebui, postgres-operator | 5432 | `postgres-shared/networkpolicy.yaml` |
| shared Postgres | postgres-operator (Patroni) | 8008 | `postgres-shared/networkpolicy.yaml` |
| vault | external-secrets | 8200 | `vault/networkpolicy.yaml` |
| atc (`app=postgres-mcp`) | openwebui | 8000 | `atc/network-policy-openwebui-to-mcp.yaml` |
| grafana (Prometheus) | monitoring (cloudflare-grafana datasource) | 9090 | `grafana/networkpolicy.yaml` |
| monitoring (`app=cloudflare-grafana`) | world (external) | 3000 | `cloudflare-exporter/networkpolicy.yaml` |

Excludes `kube-system` / `kube-node-lease` / `kube-public` / `kyverno`.

## Derivation & validation

Allow set derived from a Hubble flow capture across all nodes, cross-checked against
repo manifests, live Services and existing per-app NetworkPolicies (the
grafana←monitoring:9090 datasource edge was found by static analysis — it only fires
on dashboard render). Validated: kustomize build, `kubeconform --strict` (9/9),
server-side dry-run (Cilium + Kyverno admission), and a live test confirming a new
namespace receives the generated policy in ~1-2s.

## ⚠️ Rollout

`root-app` auto-syncs `apps/`, so merging default-denies ingress across all
non-excluded namespaces at once (`generateExisting`). To stage, scope the generator
to a pilot namespace, watch `hubble observe --verdict DROPPED`, then widen.
**Rollback:** delete the `cross-ns-isolation` ClusterPolicy — `synchronize` removes
every generated policy and namespaces revert to default-allow. See
`network-policies/README.md`.

Supersedes #139.