### PR TITLE
refactor(network-policies): scope shared-Postgres ingress allow per cluster

### DIFF
--- a/atc/kustomization.yaml
+++ b/atc/kustomization.yaml
@@ -22,3 +22,4 @@ resources:
   - seaweedfs-service.yaml
   - seaweedfs-httproute.yaml
   - network-policy-openwebui-to-mcp.yaml
+  - network-policy-to-postgres.yaml

--- a/atc/network-policy-to-postgres.yaml
+++ b/atc/network-policy-to-postgres.yaml
@@ -1,0 +1,33 @@
+# Allow the atc namespace (and the operator's Patroni REST API) to reach the atc
+# Postgres cluster. The cluster is defined in atc/postgres-cluster.yaml and runs
+# in the postgres-operator-deployment namespace, so this policy targets it there.
+# Additive ingress allow.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-ingress-to-atc-postgres
+  namespace: postgres-operator-deployment
+spec:
+  endpointSelector:
+    matchLabels:
+      cluster-name: atc
+  enableDefaultDeny:
+    ingress: false
+    egress: false
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: atc
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: postgres-operator
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+            - port: "8008"
+              protocol: TCP

--- a/postgres-shared/networkpolicy.yaml
+++ b/postgres-shared/networkpolicy.yaml
@@ -1,13 +1,15 @@
-# Allow the shared-Postgres DB clients (:5432) and the operator's Patroni REST
-# API (:8008). Additive ingress allow; cross-ns default-deny is applied by the
-# cluster-wide network-policies generator.
+# Allow shared-Postgres clients (:5432) and the operator's Patroni REST API
+# (:8008). Scoped to the postgres-shared cluster; the atc cluster has its own
+# policy in atc/. Additive ingress allow.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: allow-ingress-from-db-clients
+  name: allow-ingress-to-postgres-shared
   namespace: postgres-operator-deployment
 spec:
-  endpointSelector: {}
+  endpointSelector:
+    matchLabels:
+      cluster-name: postgres-shared
   enableDefaultDeny:
     ingress: false
     egress: false
@@ -18,7 +20,6 @@ spec:
               operator: In
               values:
                 - adminer
-                - atc
                 - harbor
                 - keycloak
                 - langfuse


### PR DESCRIPTION
## What

Split the `postgres-operator-deployment` ingress allow (added in #402) by Spilo
cluster, instead of one whole-namespace policy.

The namespace runs two clusters — `postgres-shared` (shared DB) and `atc` (atc's
own DB). The previous single policy used `endpointSelector: {}`, so every listed
client could reach **both** clusters.

## How

| Cluster (pod) | Allowed source(s) | Port | File |
|---|---|---|---|
| `cluster-name=postgres-shared` | adminer, harbor, keycloak, langfuse, mlflow, nc-press-chotatsu, openwebui, postgres-operator | 5432 | `postgres-shared/networkpolicy.yaml` |
| `cluster-name=postgres-shared` | postgres-operator (Patroni) | 8008 | `postgres-shared/networkpolicy.yaml` |
| `cluster-name=atc` | atc, postgres-operator | 5432 | `atc/network-policy-to-postgres.yaml` |
| `cluster-name=atc` | postgres-operator (Patroni) | 8008 | `atc/network-policy-to-postgres.yaml` |

The atc-cluster policy lives in `atc/` (the cluster is defined in
`atc/postgres-cluster.yaml`, targeting the `postgres-operator-deployment`
namespace) — consistent with the per-app ownership of #402.

## Effect

Least privilege: each cluster accepts only its own clients (the atc cluster no
longer accepts the shared-DB clients, and vice versa). Real traffic is unchanged
— atc uses only its own cluster and the shared clients use only `postgres-shared`.

## Validation

`kubeconform --strict` (valid), server-side dry-run (Cilium admission), and the
`cluster-name` selectors confirmed to match the live `atc-0` / `postgres-shared-0`
pods.