### PR TITLE
feat(claude-code): OTLP governance receiver + Loki store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,36 @@ spec:
           port: <port>
 ```
 
+## Network Policy & Namespace Isolation
+
+Cross-namespace traffic is **default-denied on ingress**. A Kyverno
+`ClusterPolicy` (`network-policies/cross-ns-isolation-generator.yaml`)
+generates a default-deny-ingress `NetworkPolicy` into every non-system
+namespace (current and future), allowing only **same-namespace** ingress.
+**Egress is left open** (the generated policy sets `policyTypes: [Ingress]`
+only). Cilium evaluates standard + Cilium policies as a **union of allows**.
+
+The only cluster-wide ingress allows are in
+`network-policies/allow-from-infra.yaml` (additive
+`CiliumClusterwideNetworkPolicy`, all ports):
+
+- node / kubelet / kube-apiserver / Cilium health
+- the **`envoy-gateway-system`** namespace (the ingress proxy → any backend)
+- the **`grafana`** namespace (Prometheus scrapes **and** Grafana datasource
+  queries both originate here)
+
+**When adding an app, ask who needs to reach it on ingress:**
+
+- Reached only by the **Gateway**, by **Prometheus/Grafana**, or by
+  **same-namespace** pods → **no NetworkPolicy needed** (covered above).
+- Reached from **any other namespace** (e.g. another app's pod, or a
+  controller that connects *from* its own namespace) → add an app-specific
+  allow policy in the app dir; it unions with the generated default-deny.
+
+Note that `ServiceMonitor` scrapes and cross-namespace `GrafanaDatasource`
+queries are both ingress *from the `grafana` namespace*, so both are already
+allowed. See `network-policies/README.md` for the full model.
+
 ## Application Directory Structure
 
 Each application directory typically contains:

--- a/apps/claude-code-app.yaml
+++ b/apps/claude-code-app.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: claude-code
+  namespace: argocd
+spec:
+  project: default
+  sources:
+    - repoURL: https://open-telemetry.github.io/opentelemetry-helm-charts
+      chart: opentelemetry-collector
+      targetRevision: 0.158.0
+      helm:
+        releaseName: claude-code
+        valueFiles:
+          - $values/claude-code/values.yaml
+    - repoURL: https://github.com/Shion1305/k8s-GitOps.git
+      targetRevision: HEAD
+      ref: values
+    - repoURL: https://github.com/Shion1305/k8s-GitOps.git
+      targetRevision: HEAD
+      path: claude-code
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: claude-code
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/apps/loki-app.yaml
+++ b/apps/loki-app.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: loki
+  namespace: argocd
+spec:
+  project: default
+  sources:
+    - repoURL: ghcr.io/grafana/helm-charts
+      chart: loki
+      targetRevision: 7.0.0
+      helm:
+        releaseName: loki
+        valueFiles:
+          - $values/loki/values.yaml
+    - repoURL: https://github.com/Shion1305/k8s-GitOps.git
+      targetRevision: HEAD
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: claude-code
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -11,7 +11,7 @@ registries:
 - type: standard
   ref: v4.519.0 # renovate: depName=aquaproj/aqua-registry
 packages:
-- name: hashicorp/vault@v2.0.1
+- name: hashicorp/vault@v2.0.0
 - name: google/go-containerregistry@v0.21.6
 # Used by scripts/render-validate.sh (.github/workflows/render-validate.yaml).
 - name: kubernetes-sigs/kustomize@kustomize/v5.8.1

--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -1,0 +1,92 @@
+# claude-code — Claude Code OTLP governance receiver
+
+OpenTelemetry Collector that receives Claude Code telemetry over OTLP and
+persists it for governance. Published on the **internal** Gateway at
+`cc.i.shion1305.com` (WireGuard-only), protected by a bearer token.
+
+## Architecture
+
+```
+Claude Code ──OTLP/HTTP, Bearer token──► cc.i.shion1305.com
+                                            │ Envoy internal Gateway (TLS terminate)
+                                            ▼
+                          OTel Collector (claude-code-opentelemetry-collector)
+                          bearertokenauth validates Authorization header
+                             │ logs                      │ metrics
+                             ▼                            ▼
+                  Loki (loki:3100, 90d retention)   Prometheus (ServiceMonitor → :8889)
+                             │
+                             ▼
+                  Grafana Explore (Loki datasource)
+```
+
+- **Receiver:** `apps/claude-code-app.yaml` (chart `opentelemetry-collector`,
+  contrib image — the core image lacks `bearertokenauth`). Config in
+  `values.yaml`.
+- **Store:** `apps/loki-app.yaml` (chart `loki`, SingleBinary, filesystem on
+  Longhorn, 90-day retention). Both run in the `claude-code` namespace.
+- Only **OTLP/HTTP (4318)** is exposed (`HTTPRoute` is HTTP-only; gRPC/4317
+  would need a `GRPCRoute`). Use the `http/protobuf` exporter.
+
+## What is captured
+
+Claude Code's OTel feature emits **events/logs** — `user_prompt`,
+`tool_result`, `tool_decision`, `api_request`, `api_error` — and **metrics**
+(token usage, cost, session count, active time, lines-of-code). It does **not**
+emit full assistant responses; "conversation data" here means the prompt +
+tool/API event stream. Prompt *content* is only included when the client sets
+`OTEL_LOG_USER_PROMPTS=1` (off by default).
+
+## Client configuration
+
+Set these in the Claude Code environment (or `settings.json` `env`):
+
+```sh
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_LOGS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://cc.i.shion1305.com
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer <token>"   # vault kv get claude-code/otlp
+export OTEL_LOG_USER_PROMPTS=1   # capture prompt content for governance
+```
+
+The endpoint is only reachable from the WireGuard network.
+
+## Querying
+
+Grafana → Explore → datasource **Loki**:
+
+```logql
+{service_name="claude-code"}
+```
+
+Filter by event, e.g. `{service_name="claude-code"} | event_name = "user_prompt"`.
+Metrics are in Prometheus as `claude_code_*` (e.g. `claude_code_token_usage`).
+
+## Secret / token management
+
+The bearer token lives in Vault and is synced to the `claude-code-otlp-token`
+Secret by External Secrets Operator (`external-secret.yaml`).
+
+One-time setup (run out-of-band by an operator — never commit the token):
+
+```sh
+# Vault policy + role are added by vault/scripts/setup-eso-policies.sh
+vault secrets enable -path=claude-code kv-v2
+vault kv put claude-code/otlp token="$(openssl rand -hex 32)"
+```
+
+Rotating the token: `vault kv put claude-code/otlp token=<new>`, then restart the
+collector Deployment (the `bearertokenauth` extension reads the token file at
+startup), and update each client's `OTEL_EXPORTER_OTLP_HEADERS`.
+
+## Notes
+
+- Loki is single-replica/filesystem — sized for an append-only audit store at
+  homelab volume, not HA. Promote to a dedicated namespace if logging later
+  becomes shared infrastructure.
+- No custom NetworkPolicy is needed: the cluster-wide `allow-from-infra`
+  policies already permit Envoy Gateway → collector and Prometheus scrapes, and
+  the Kyverno cross-namespace isolation generator allows same-namespace
+  collector ↔ Loki traffic.

--- a/claude-code/external-secret.yaml
+++ b/claude-code/external-secret.yaml
@@ -1,0 +1,26 @@
+# Materializes the OTLP bearer token from Vault (claude-code/otlp, key `token`)
+# into a Secret the collector mounts. Token value is written to Vault
+# out-of-band; never committed (public repo).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: claude-code-otlp-token
+  namespace: claude-code
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  target:
+    name: claude-code-otlp-token
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+  data:
+    - secretKey: token
+      remoteRef:
+        key: otlp
+        property: token

--- a/claude-code/httproute-internal.yaml
+++ b/claude-code/httproute-internal.yaml
@@ -1,0 +1,19 @@
+# Publishes the OTLP/HTTP receiver on the internal Gateway (WireGuard-only).
+# Claude Code points OTEL_EXPORTER_OTLP_ENDPOINT at https://cc.i.shion1305.com
+# (http/protobuf); TLS terminates at the Gateway, plain HTTP to the collector.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: claude-code-otlp
+  namespace: claude-code
+spec:
+  parentRefs:
+    - name: internal
+      namespace: envoy-gateway-system
+      sectionName: https
+  hostnames:
+    - cc.i.shion1305.com
+  rules:
+    - backendRefs:
+        - name: claude-code-opentelemetry-collector
+          port: 4318

--- a/claude-code/kustomization.yaml
+++ b/claude-code/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: claude-code
+resources:
+  - reference-grant.yaml
+  - httproute-internal.yaml
+  - vault-secret-store.yaml
+  - external-secret.yaml
+  - servicemonitor.yaml

--- a/claude-code/reference-grant.yaml
+++ b/claude-code/reference-grant.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ReferenceGrant
+metadata:
+  name: allow-envoy-gateway
+  namespace: claude-code
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: envoy-gateway-system
+  to:
+    - group: ""
+      kind: Service

--- a/claude-code/servicemonitor.yaml
+++ b/claude-code/servicemonitor.yaml
@@ -1,0 +1,22 @@
+# Scrapes the collector's prometheus exporter (Claude Code token/cost/session
+# metrics). The `release` label is how kube-prometheus-stack discovers it.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: claude-code-collector
+  namespace: claude-code
+  labels:
+    app: claude-code-collector
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-collector
+      app.kubernetes.io/instance: claude-code
+  namespaceSelector:
+    matchNames:
+      - claude-code
+  endpoints:
+    - port: prometheus
+      path: /metrics
+      interval: 30s

--- a/claude-code/values.yaml
+++ b/claude-code/values.yaml
@@ -1,0 +1,103 @@
+# OpenTelemetry Collector — the OTLP receiver for Claude Code governance data.
+# Published at cc.i.shion1305.com (internal Gateway, WireGuard-only). Validates a
+# bearer token, ships events to Loki and metrics to Prometheus.
+mode: deployment
+replicaCount: 1
+
+# Contrib distribution: the core image lacks the bearertokenauth extension.
+image:
+  repository: otel/opentelemetry-collector-contrib
+command:
+  name: otelcol-contrib
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    memory: 512Mi
+
+# Only OTLP/HTTP is published (HTTPRoute is HTTP-only; gRPC would need a
+# GRPCRoute). The prometheus port exposes the Claude Code metrics scrape target.
+ports:
+  otlp:
+    enabled: false
+  otlp-http:
+    enabled: true
+    containerPort: 4318
+    servicePort: 4318
+    hostPort: null
+    protocol: TCP
+  jaeger-compact:
+    enabled: false
+  jaeger-thrift:
+    enabled: false
+  jaeger-grpc:
+    enabled: false
+  zipkin:
+    enabled: false
+  prometheus:
+    enabled: true
+    containerPort: 8889
+    servicePort: 8889
+    protocol: TCP
+
+# Mount the ESO-synced bearer token; bearertokenauth reads it from this file.
+extraVolumes:
+  - name: otlp-token
+    secret:
+      secretName: claude-code-otlp-token
+extraVolumeMounts:
+  - name: otlp-token
+    mountPath: /etc/otelcol/token
+    readOnly: true
+
+config:
+  extensions:
+    health_check:
+      endpoint: ${env:MY_POD_IP}:13133
+    bearertokenauth:
+      scheme: "Bearer"
+      filename: /etc/otelcol/token/token
+  receivers:
+    # Drop the chart's default receivers we don't accept.
+    jaeger: null
+    zipkin: null
+    prometheus: null
+    otlp:
+      protocols:
+        grpc: null
+        http:
+          endpoint: ${env:MY_POD_IP}:4318
+          auth:
+            authenticator: bearertokenauth
+  processors:
+    batch: {}
+    memory_limiter:
+      check_interval: 5s
+      limit_percentage: 80
+      spike_limit_percentage: 25
+  exporters:
+    # Loki 3.x ingests OTLP natively at /otlp/v1/logs.
+    otlphttp/loki:
+      endpoint: http://loki.claude-code.svc.cluster.local:3100/otlp
+    prometheus:
+      endpoint: ${env:MY_POD_IP}:8889
+      resource_to_telemetry_conversion:
+        enabled: true
+  service:
+    extensions:
+      - health_check
+      - bearertokenauth
+    pipelines:
+      # Drop the chart's default traces pipeline (it references the jaeger /
+      # zipkin receivers removed above); Claude Code emits no spans.
+      traces: null
+      logs:
+        receivers: [otlp]
+        processors: [memory_limiter, batch]
+        exporters: [otlphttp/loki]
+      metrics:
+        receivers: [otlp]
+        processors: [memory_limiter, batch]
+        exporters: [prometheus]

--- a/claude-code/vault-secret-store.yaml
+++ b/claude-code/vault-secret-store.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso
+  namespace: claude-code
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: vault
+  namespace: claude-code
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      # Dedicated KV v2 mount: vault secrets enable -path=claude-code kv-v2
+      path: "claude-code"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "eso-claude-code"
+          serviceAccountRef:
+            name: "eso"

--- a/grafana/datasource-loki.yaml
+++ b/grafana/datasource-loki.yaml
@@ -1,0 +1,20 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: loki
+  namespace: grafana
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: main-grafana
+  # Cross-namespace: Loki runs in the claude-code namespace.
+  allowCrossNamespaceImport: true
+  datasource:
+    # Stable UID so saved Explore queries / dashboards can pin this datasource.
+    uid: loki
+    name: Loki
+    type: loki
+    access: proxy
+    url: http://loki.claude-code.svc.cluster.local:3100
+    isDefault: false
+    editable: true

--- a/grafana/kustomization.yaml
+++ b/grafana/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - httproute-external.yaml
   - grafana.yaml
   - datasource.yaml
+  - datasource-loki.yaml
   - folders.yaml
   - dashboards/kubernetes.yaml
   - dashboards/node-metrics.yaml

--- a/loki/values.yaml
+++ b/loki/values.yaml
@@ -1,0 +1,80 @@
+# Loki — governance log store for Claude Code OTLP events.
+# Single-binary, filesystem-backed, single replica: this is an append-only
+# audit store at homelab volume, so HA replication isn't worth the footprint
+# (instance-k8s-proxy is already memory-constrained). Loki 3.x ingests OTLP
+# natively at /otlp/v1/logs; the OTel collector ships logs straight here.
+deploymentMode: SingleBinary
+
+loki:
+  auth_enabled: false
+  commonConfig:
+    replication_factor: 1
+  schemaConfig:
+    configs:
+      - from: "2024-04-01"
+        store: tsdb
+        object_store: filesystem
+        schema: v13
+        index:
+          prefix: index_
+          period: 24h
+  storage:
+    type: filesystem
+  limits_config:
+    # 90-day governance retention; enforced by the compactor below.
+    retention_period: 2160h
+    # Required for OTLP ingestion (resource/scope attributes land as
+    # structured metadata).
+    allow_structured_metadata: true
+    volume_enabled: true
+  compactor:
+    working_directory: /var/loki/compactor
+    retention_enabled: true
+    delete_request_store: filesystem
+  # Trim the collector's chatter; keep server defaults otherwise.
+  server:
+    http_listen_port: 3100
+    grpc_listen_port: 9095
+
+singleBinary:
+  replicas: 1
+  persistence:
+    enabled: true
+    storageClass: longhorn-hdd
+    size: 100Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 192Mi
+    limits:
+      memory: 512Mi
+
+# Single-binary mode only — keep the scalable targets at zero replicas.
+read:
+  replicas: 0
+write:
+  replicas: 0
+backend:
+  replicas: 0
+
+# No nginx gateway: the collector and Grafana reach the `loki` Service
+# (port 3100) directly inside the cluster.
+gateway:
+  enabled: false
+
+# Drop the optional sidecars/caches that don't pull their weight at this scale.
+lokiCanary:
+  enabled: false
+test:
+  enabled: false
+chunksCache:
+  enabled: false
+resultsCache:
+  enabled: false
+monitoring:
+  selfMonitoring:
+    enabled: false
+    grafanaAgent:
+      installOperator: false
+  serviceMonitor:
+    enabled: false

--- a/vault/scripts/setup-eso-policies.sh
+++ b/vault/scripts/setup-eso-policies.sh
@@ -84,6 +84,17 @@ path "freqtrade/metadata/*" {
 EOF
 echo "✓ Created policy: eso-freqtrade"
 
+# Policy for claude-code namespace (separate KV v2 engine mounted at claude-code/)
+vault policy write eso-claude-code - <<EOF
+path "claude-code/data/*" {
+  capabilities = ["read"]
+}
+path "claude-code/metadata/*" {
+  capabilities = ["read", "list"]
+}
+EOF
+echo "✓ Created policy: eso-claude-code"
+
 # Policy for cert-manager namespace (system/ KV v2 mount, cert-manager only)
 vault policy write eso-cert-manager - <<EOF
 path "system/data/cert-manager" {
@@ -253,6 +264,14 @@ vault write auth/kubernetes/role/eso-freqtrade \
   ttl=1h
 echo "✓ Created role: eso-freqtrade"
 
+# claude-code
+vault write auth/kubernetes/role/eso-claude-code \
+  bound_service_account_names=eso \
+  bound_service_account_namespaces=claude-code \
+  policies=eso-claude-code \
+  ttl=1h
+echo "✓ Created role: eso-claude-code"
+
 # cert-manager
 vault write auth/kubernetes/role/eso-cert-manager \
   bound_service_account_names=eso \
@@ -421,6 +440,7 @@ echo "  eso-keycloak    → SA eso/keycloak        → secret/data/shared/keyclo
 echo "  eso-atc         → SA eso/atc             → atc/data/*"
 echo "  eso-lumos-bot   → SA eso/lumos-bot       → lumos-bot/data/*"
 echo "  eso-freqtrade   → SA eso/freqtrade       → freqtrade/data/*"
+echo "  eso-claude-code → SA eso/claude-code     → claude-code/data/*"
 echo "  eso-cert-manager→ SA eso/cert-manager    → system/data/cert-manager"
 echo "  eso-zot         → SA eso/zot             → zot/data/*"
 echo "  eso-harbor      → SA eso/harbor          → harbor/data/*"


### PR DESCRIPTION
## What

Adds a Claude Code **OTLP receiver** for governance: an OpenTelemetry Collector
published on the internal Gateway at `cc.i.shion1305.com`, persisting Claude Code
telemetry to a new single-binary **Loki** store.

```
Claude Code ──OTLP/HTTP + Bearer──► cc.i.shion1305.com (internal Gateway, WireGuard-only)
                                       └► OTel Collector (bearertokenauth)
                                            ├─ logs    → Loki (90d, longhorn-hdd 100Gi)
                                            └─ metrics → Prometheus (ServiceMonitor)
                                                          Grafana ← Loki datasource
```

## Changes

- **`apps/claude-code-app.yaml` + `claude-code/`** — opentelemetry-collector chart
  (contrib image; core lacks `bearertokenauth`). OTLP/HTTP only (HTTPRoute is
  HTTP-only; gRPC would need a GRPCRoute). `logs → Loki`, `metrics → Prometheus`.
  HTTPRoute + ReferenceGrant on the internal Gateway, ESO SecretStore/ExternalSecret
  for the bearer token, ServiceMonitor, README.
- **`apps/loki-app.yaml` + `loki/values.yaml`** — Loki 7.0.0, SingleBinary,
  filesystem, 90-day retention on `longhorn-hdd` (100Gi).
- **`grafana/datasource-loki.yaml`** — cross-namespace Loki datasource (stable `uid: loki`).
- **`vault/scripts/setup-eso-policies.sh`** — `eso-claude-code` policy + role
  (dedicated `claude-code/` KV mount).
- **`aqua.yaml`** — pin `hashicorp/vault` CLI to v2.0.0 (separate, unrelated change).

## Networking

No custom NetworkPolicy required — the cluster-wide `allow-from-infra` policies
already permit Envoy Gateway → collector and Prometheus scrapes, and the Kyverno
cross-namespace isolation generator allows same-namespace collector ↔ Loki.

## What it captures

Claude Code's OTel event stream (`user_prompt`, `tool_result`, `tool_decision`,
`api_request`, `api_error`) + metrics (token/cost/session/active-time). Not full
assistant responses. Prompt content only when the client sets `OTEL_LOG_USER_PROMPTS=1`.

## Manual steps before it goes Healthy

1. Vault (policy/role land via the script; mount + token are out-of-band):
   ```sh
   vault secrets enable -path=claude-code kv-v2
   vault kv put claude-code/otlp token="$(openssl rand -hex 32)"
   ```
   The collector Pod stays pending until the `claude-code-otlp-token` Secret syncs.
2. Confirm `cc.i.shion1305.com` resolves to the internal Gateway (`10.130.5.21`;
   the `*.i.shion1305.com` wildcard + cert should cover it).

## Validation

`scripts/render-validate.sh` passes for all apps including the new `claude-code`
and `loki`.