### PR TITLE
feat(scalable-llm): KubeAI on Tenstorrent Blackhole PoC

### DIFF
--- a/apps/kube-ai-crd-app.yaml
+++ b/apps/kube-ai-crd-app.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kube-ai-crd
+  namespace: argocd
+  annotations:
+    # Install the KubeAI CRD (models.kubeai.org) before the controller and any
+    # Model CRs. scalable-llm renders the controller Helm chart with skipCrds,
+    # so the CRD must already exist when its Model manifests sync.
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  project: default
+  source:
+    # Vendored from the kubeai chart at the version pinned in scalable-llm-app.yaml:
+    #   helm template kubeai kubeai/kubeai --version 0.23.2 --include-crds \
+    #     | yq 'select(.kind=="CustomResourceDefinition")' > apps/kube-ai-crd/crds.yaml
+    # Keep in lockstep with the chart targetRevision in scalable-llm-app.yaml.
+    repoURL: https://github.com/Shion1305/k8s-GitOps.git
+    targetRevision: HEAD
+    path: apps/kube-ai-crd
+  destination:
+    # CRDs are cluster-scoped.
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: false # never auto-delete the CRD (would cascade-delete Models)
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true # KubeAI CRD exceeds the client-side apply size limit

--- a/apps/kube-ai-crd/crds.yaml
+++ b/apps/kube-ai-crd/crds.yaml
@@ -1,0 +1,351 @@
+# Source: kubeai/templates/crds/kubeai.org_models.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: models.kubeai.org
+spec:
+  group: kubeai.org
+  names:
+    kind: Model
+    listKind: ModelList
+    plural: models
+    singular: model
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: Model resources define the ML models that will be served by KubeAI.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ModelSpec defines the desired state of Model.
+              properties:
+                adapters:
+                  items:
+                    properties:
+                      name:
+                        description: Name must be a lowercase string with no spaces.
+                        maxLength: 63
+                        pattern: ^[a-z0-9-]+$
+                        type: string
+                      url:
+                        type: string
+                        x-kubernetes-validations:
+                          - message: adapter url must start with "hf://", "s3://", "gs://", or "oss://".
+                            rule: self.startsWith("hf://") || self.startsWith("s3://") || self.startsWith("gs://") || self.startsWith("oss://")
+                    required:
+                      - name
+                      - url
+                    type: object
+                  type: array
+                args:
+                  description: Args to be added to the server process.
+                  items:
+                    type: string
+                  type: array
+                autoscalingDisabled:
+                  description: |-
+                    AutoscalingDisabled will stop the controller from managing the replicas
+                    for the Model. When disabled, metrics will not be collected on server Pods.
+                  type: boolean
+                cacheProfile:
+                  description: |-
+                    CacheProfile to be used for caching model artifacts.
+                    Must be a valid CacheProfile defined in the system config.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: cacheProfile is immutable.
+                      rule: self == oldSelf
+                engine:
+                  description: Engine to be used for the server process.
+                  enum:
+                    - OLlama
+                    - VLLM
+                    - FasterWhisper
+                    - Infinity
+                  type: string
+                env:
+                  additionalProperties:
+                    type: string
+                  description: Env variables to be added to the server process.
+                  type: object
+                envFrom:
+                  description: Env variables to be added to the server process from Secret or ConfigMap.
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      prefix:
+                        description: |-
+                          Optional text to prepend to the name of each environment variable.
+                          May consist of any printable ASCII characters except '='.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  type: array
+                features:
+                  description: |-
+                    Features that the model supports.
+                    Dictates the APIs that are available for the model.
+                  items:
+                    enum:
+                      - TextGeneration
+                      - TextEmbedding
+                      - Reranking
+                      - SpeechToText
+                    type: string
+                  type: array
+                files:
+                  description: Files to be mounted in the model Pods.
+                  items:
+                    description: File represents a file to be mounted in the model pod.
+                    properties:
+                      content:
+                        description: |-
+                          Content of the file to be mounted.
+                          Will be injected into a ConfigMap and mounted in the model Pods.
+                        maxLength: 100000
+                        type: string
+                      path:
+                        description: |-
+                          Path where the file should be mounted in the pod.
+                          Must be an absolute path.
+                        maxLength: 1024
+                        type: string
+                        x-kubernetes-validations:
+                          - message: Path must be an absolute path, starting with /, and must not contain a ':' character.
+                            rule: self.startsWith('/') && !self.contains(':')
+                    required:
+                      - content
+                      - path
+                    type: object
+                  maxItems: 10
+                  type: array
+                image:
+                  description: |-
+                    Image to be used for the server process.
+                    Will be set from ResourceProfile + Engine if not specified.
+                  type: string
+                loadBalancing:
+                  default: {}
+                  description: |-
+                    LoadBalancing configuration for the model.
+                    If not specified, a default is used based on the engine and request.
+                  properties:
+                    prefixHash:
+                      default: {}
+                      properties:
+                        meanLoadFactor:
+                          default: 125
+                          description: |-
+                            MeanLoadPercentage is the percentage that any given endpoint's load must not exceed
+                            over the mean load of all endpoints in the hash ring. Defaults to 125% which is
+                            a widely accepted value for the Consistent Hashing with Bounded Loads algorithm.
+                          minimum: 100
+                          type: integer
+                        prefixCharLength:
+                          default: 100
+                          description: PrefixCharLength is the number of characters to count when building the prefix to hash.
+                          type: integer
+                        replication:
+                          default: 256
+                          description: |-
+                            Replication is the number of replicas of each endpoint on the hash ring.
+                            Higher values will result in a more even distribution of load but will
+                            decrease lookup performance.
+                          type: integer
+                          x-kubernetes-validations:
+                            - message: replication is immutable.
+                              rule: self == oldSelf
+                      type: object
+                    strategy:
+                      default: LeastLoad
+                      enum:
+                        - LeastLoad
+                        - PrefixHash
+                      type: string
+                  type: object
+                maxReplicas:
+                  description: |-
+                    MaxReplicas is the maximum number of Pod replicas that the model can scale up to.
+                    Empty value means no limit.
+                  format: int32
+                  minimum: 1
+                  type: integer
+                minReplicas:
+                  description: |-
+                    MinReplicas is the minimum number of Pod replicas that the model can scale down to.
+                    Note: 0 is a valid value.
+                  format: int32
+                  minimum: 0
+                  type: integer
+                owner:
+                  description: |-
+                    Owner of the model. Used solely to populate the owner field in the
+                    OpenAI /v1/models endpoint.
+                    DEPRECATED.
+                  type: string
+                priorityClassName:
+                  description: |-
+                    PriorityClassName sets the priority class for all pods created for this model.
+                    If specified, the PriorityClass must exist before the model is created.
+                    This is useful for implementing priority and preemption for models.
+                  type: string
+                replicas:
+                  description: |-
+                    Replicas is the number of Pod replicas that should be actively
+                    serving the model. KubeAI will manage this field unless AutoscalingDisabled
+                    is set to true.
+                  format: int32
+                  type: integer
+                resourceProfile:
+                  description: |-
+                    ResourceProfile required to serve the model.
+                    Use the format "<resource-profile-name>:<count>".
+                    Example: "nvidia-gpu-l4:2" - 2x NVIDIA L4 GPUs.
+                    Must be a valid ResourceProfile defined in the system config.
+                  type: string
+                scaleDownDelaySeconds:
+                  default: 30
+                  description: |-
+                    ScaleDownDelay is the minimum time before a deployment is scaled down after
+                    the autoscaling algorithm determines that it should be scaled down.
+                  format: int64
+                  type: integer
+                targetRequests:
+                  default: 100
+                  description: |-
+                    TargetRequests is average number of active requests that the autoscaler
+                    will try to maintain on model server Pods.
+                  format: int32
+                  minimum: 1
+                  type: integer
+                url:
+                  description: |-
+                    URL of the model to be served.
+                    Currently the following formats are supported:
+
+                    For VLLM, FasterWhisper, Infinity engines:
+
+                    "hf://<repo>/<model>"
+                    "pvc://<pvcName>"
+                    "pvc://<pvcName>/<pvcSubpath>"
+                    "gs://<bucket>/<path>" (only with cacheProfile)
+                    "oss://<bucket>/<path>" (only with cacheProfile)
+                    "s3://<bucket>/<path>" (only with cacheProfile)
+
+                    For OLlama engine:
+
+                    "ollama://<model>"
+                  pattern: ^([a-z0-9]+):\/\/([a-zA-Z0-9._:/-]+)(\?.*)?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: url must start with "hf://", "pvc://", "ollama://", "s3://", "gs://", or "oss://" and not be empty.
+                      rule: self.startsWith("hf://") || self.startsWith("pvc://") || self.startsWith("ollama://") || self.startsWith("s3://") || self.startsWith("gs://") || self.startsWith("oss://")
+              required:
+                - engine
+                - features
+                - scaleDownDelaySeconds
+                - targetRequests
+                - url
+              type: object
+              x-kubernetes-validations:
+                - message: cacheProfile is only supported with urls of format "hf://...", "s3://...", "gs://...", or "oss://..." at the moment.
+                  rule: '!has(self.cacheProfile) || self.url.startsWith("hf://") || self.url.startsWith("s3://") || self.url.startsWith("gs://") || self.url.startsWith("oss://")'
+                - message: urls of format "gs://..." only supported when using a cacheProfile
+                  rule: '!self.url.startsWith("gs://") || has(self.cacheProfile)'
+                - message: urls of format "oss://..." only supported when using a cacheProfile
+                  rule: '!self.url.startsWith("oss://") || has(self.cacheProfile)'
+                - message: minReplicas should be less than or equal to maxReplicas.
+                  rule: '!has(self.maxReplicas) || self.minReplicas <= self.maxReplicas'
+                - message: adapters only supported with VLLM engine.
+                  rule: '!has(self.adapters) || self.engine == "VLLM"'
+                - message: url is immutable when using cacheProfile.
+                  rule: '!has(oldSelf.cacheProfile) || self.url == oldSelf.url'
+                - message: All file paths must be unique.
+                  rule: '!has(self.files) || self.files.size() <= 1 || !self.files.exists(f, self.files.filter(other, other.path == f.path).size() > 1)'
+            status:
+              description: ModelStatus defines the observed state of Model.
+              properties:
+                cache:
+                  properties:
+                    loaded:
+                      type: boolean
+                  required:
+                    - loaded
+                  type: object
+                replicas:
+                  properties:
+                    all:
+                      format: int32
+                      type: integer
+                    ready:
+                      format: int32
+                      type: integer
+                  required:
+                    - all
+                    - ready
+                  type: object
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: name must not exceed 40 characters.
+              rule: size(self.metadata.name) <= 40
+      served: true
+      storage: true
+      subresources:
+        scale:
+          specReplicasPath: .spec.replicas
+          statusReplicasPath: .status.replicas.all
+        status: {}

--- a/apps/scalable-llm-app.yaml
+++ b/apps/scalable-llm-app.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: scalable-llm
+  namespace: argocd
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: scalable-llm
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+  sources:
+    # 1) KubeAI controller (Helm, version-pinned). The CRD is owned by the
+    #    kube-ai-crd app (sync-wave -1), so skip it here to avoid a collision.
+    - repoURL: https://www.kubeai.org
+      chart: kubeai
+      targetRevision: 0.23.2
+      helm:
+        skipCrds: true
+        valueFiles:
+          - $values/scalable-llm/kubeai-values.yaml
+    # 2) Self-authored manifests: namespace, generic-device-plugin DaemonSet,
+    #    Model CRs, LiteLLM front, ESO/DB/Vault wiring, HTTPRoute. The KubeAI
+    #    Helm release does not own these.
+    - repoURL: https://github.com/Shion1305/k8s-GitOps.git
+      targetRevision: HEAD
+      path: scalable-llm
+      ref: values

--- a/external-secrets/rbac-db-reader.yaml
+++ b/external-secrets/rbac-db-reader.yaml
@@ -156,3 +156,29 @@ subjects:
   - kind: ServiceAccount
     name: eso-db
     namespace: nc-press-chotatsu
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: eso-db-scalable-llm
+  namespace: postgres-operator-deployment
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - litellm.postgres-shared.credentials.postgresql.acid.zalan.do
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: eso-db-scalable-llm
+  namespace: postgres-operator-deployment
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: eso-db-scalable-llm
+subjects:
+  - kind: ServiceAccount
+    name: eso-db
+    namespace: scalable-llm

--- a/postgres-shared/networkpolicy.yaml
+++ b/postgres-shared/networkpolicy.yaml
@@ -27,6 +27,7 @@ spec:
                 - nc-press-chotatsu
                 - openwebui
                 - postgres-operator
+                - scalable-llm
       toPorts:
         - ports:
             - port: "5432"

--- a/postgres-shared/postgres-cluster.yaml
+++ b/postgres-shared/postgres-cluster.yaml
@@ -16,6 +16,7 @@ spec:
     mlflow: []
     nc_press_chotatsu: []
     harbor: []
+    litellm: [] # LiteLLM front for scalable-llm (KubeAI on Tenstorrent)
   databases:
     openwebui: openwebui
     langfuse: langfuse
@@ -23,6 +24,7 @@ spec:
     mlflow: mlflow
     nc_press_chotatsu: nc_press_chotatsu
     harbor: harbor
+    litellm: litellm
   postgresql:
     version: "17"
   resources:

--- a/scalable-llm/README.md
+++ b/scalable-llm/README.md
@@ -1,0 +1,158 @@
+# scalable-llm — KubeAI on Tenstorrent Blackhole (PoC)
+
+OpenAI-compatible inference on **Tenstorrent Blackhole** (2 cards meshed) via the
+**Tenstorrent vLLM fork**, orchestrated by **KubeAI**, fronted by **LiteLLM**.
+
+All TT workloads are pinned to **`shion-ubuntu-2605`** (`ssh s2605`) — the only
+node with cards. Everything in this namespace is GitOps-managed; do not
+`kubectl apply` / `helm install` by hand (kubectl is for inspection only).
+
+## ArgoCD apps
+
+| App | Path | Role |
+|-----|------|------|
+| `kube-ai-crd` | `apps/kube-ai-crd/` | `models.kubeai.org` CRD only, sync-wave `-1` (before everything else) |
+| `scalable-llm` | `apps/scalable-llm-app.yaml` | KubeAI controller (Helm, `skipCrds`) + this dir's manifests |
+
+KubeAI chart is pinned to **0.23.2**. When bumping it, re-vendor the CRD and keep
+the two in lockstep:
+
+```bash
+helm repo add kubeai https://www.kubeai.org && helm repo update
+helm template kubeai kubeai/kubeai --version <new> --include-crds \
+  | yq 'select(.kind=="CustomResourceDefinition")' > apps/kube-ai-crd/crds.yaml
+```
+
+## What lives here
+
+```
+scalable-llm/
+├── namespace.yaml          # ns: scalable-llm
+├── device-plugin.yaml      # generic-device-plugin: 2 cards -> squat.io/tenstorrent:1
+├── kubeai-values.yaml      # KubeAI Helm values: resourceProfile + tt-vllm image + hostPath cache patch
+├── models/tt-llama.yaml    # KubeAI Model (TEMPLATE — fill from Phase 2)
+└── litellm/                # LiteLLM front + DB (shared Postgres) + Vault key + HTTPRoute
+```
+
+Endpoint (internal Gateway, WireGuard-only): **`https://ai.i.shion1305.com`**
+→ LiteLLM → KubeAI (`kubeai.scalable-llm.svc`) → TT vLLM Pod.
+
+---
+
+## Host-side prerequisites (NOT GitOps — run on `s2605`)
+
+These are the hardware steps the cluster cannot do for you. Do them before the
+apps can become healthy. The plan's Phases 0–2 in full; summarized here.
+
+### Phase 1-1/1-2 — on `ssh s2605`
+
+```bash
+# tt-kmd + firmware + HugePages + tt-smi via the official installer.
+# containerd is the runtime here, so do NOT install Podman/Docker.
+curl -fsSL https://github.com/tenstorrent/tt-installer/releases/latest/download/install.sh -O
+chmod +x install.sh && ./install.sh --help        # confirm flags for your version
+./install.sh \
+  --mode-non-interactive \
+  --install-container-runtime=no \
+  --no-install-metalium-container \
+  --no-install-inference-server \
+  --no-install-studio
+sudo reboot                                        # KMD load / HugePages
+
+# After reboot: both cards visible, mesh healthy
+source ~/.tenstorrent-venv/bin/activate            # if tt-smi not on PATH
+tt-smi                                              # expect 2x Blackhole
+tt-topology                                         # configure + verify the 2-card mesh
+ls -l /dev/tenstorrent/ /dev/tenstorrent/by-id/     # devices 0 and 1
+
+# Pre-create the node-local TT compile/weights cache (mounted by every model Pod)
+sudo mkdir -p /var/local-storage/tt-cache && sudo chmod 1777 /var/local-storage/tt-cache
+```
+
+### Phase 1-3 — cluster side (from your kubectl host)
+
+```bash
+kubectl label node shion-ubuntu-2605 tenstorrent.com/blackhole=true
+kubectl describe node shion-ubuntu-2605 | grep -i taint   # mirror any taint into kubeai-values
+```
+
+### Phase 2 — build the image and single-container smoke test
+
+Build with containerd tooling and load into the `k8s.io` namespace so kubelet
+sees it (or push to a registry the cluster can pull):
+
+```bash
+# on s2605
+nerdctl build -t REPLACE_ME/tt-vllm:REPLACE_TAG -f Dockerfile .
+sudo nerdctl -n k8s.io load -i tt-vllm.tar          # if not using a registry
+sudo crictl images | grep tt-vllm
+
+# verify the container talks to BOTH cards as a mesh, OUTSIDE Kubernetes:
+sudo nerdctl run --rm \
+  --device /dev/tenstorrent/0 --device /dev/tenstorrent/1 \
+  --mount type=bind,src=/dev/hugepages,dst=/dev/hugepages \
+  --shm-size=<value> -p 8000:8000 \
+  REPLACE_ME/tt-vllm:REPLACE_TAG <TT launch: mesh-shape=1x2 ... --model ...>
+curl localhost:8000/v1/models
+```
+
+**The launch command that works here is the source of truth** for `models/tt-llama.yaml`
+(`spec.args`) and the TT cache env var (`spec.env`).
+
+---
+
+## Placeholders to fill before this serves traffic
+
+| Where | Placeholder | Replace with |
+|-------|-------------|--------------|
+| `kubeai-values.yaml`, `models/tt-llama.yaml` | `REPLACE_ME/tt-vllm:REPLACE_TAG` | the image built in Phase 2 |
+| `models/tt-llama.yaml` | `url`, `metadata.name` | real model + TT load method |
+| `models/tt-llama.yaml` | `spec.args`, `spec.env` | Phase-2 launch flags + TT cache var |
+| `kubeai-values.yaml` | `/cache/tt` mountPath | TT runtime's actual cache dir |
+
+## Secrets (out-of-band, public repo — never commit values)
+
+```bash
+# Vault KV v2 mount + LiteLLM master key
+vault secrets enable -path=scalable-llm kv-v2
+vault kv put scalable-llm/litellm master_key=sk-<random>
+# Vault policy + k8s auth role: run vault/scripts/setup-eso-policies.sh (eso-scalable-llm added)
+```
+
+The `litellm` DB user/database are declared in `postgres-shared/postgres-cluster.yaml`;
+the operator generates the credential Secret, ESO copies it in
+(`litellm-db-credentials`). RBAC: `external-secrets/rbac-db-reader.yaml`
+(`eso-db-scalable-llm`). Postgres-side ingress allow:
+`postgres-shared/networkpolicy.yaml` (added `scalable-llm`).
+
+## Verify (Phase 7)
+
+```bash
+kubectl -n argocd get applications kube-ai-crd scalable-llm
+kubectl get crd | grep kubeai.org
+kubectl -n scalable-llm get pods
+kubectl get node shion-ubuntu-2605 -o json | jq '.status.capacity' | grep tenstorrent
+kubectl -n scalable-llm get model tt-llama -o yaml
+
+# through KubeAI directly
+kubectl -n scalable-llm port-forward svc/kubeai 8000:80
+curl http://localhost:8000/openai/v1/models
+
+# through LiteLLM (the published front)
+curl https://ai.i.shion1305.com/v1/chat/completions \
+  -H "Authorization: Bearer sk-<your-litellm-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"tt-llama","messages":[{"role":"user","content":"hello"}]}'
+```
+
+Cold-start (`minReplicas: 0`) measurement, latency/throughput baseline, and the
+prefix-aware LB question are deferred to Phase 7; the PoC ships warm
+(`minReplicas: 1`) so weight load + TT-Metal compile stays off the request path.
+
+## Network model
+
+`scalable-llm` is default-deny-ingress (Kyverno-generated). Ingress reaches it
+only from: the Gateway (cluster-wide allow), Grafana/Prometheus (cluster-wide
+allow), and same-namespace pods (LiteLLM → KubeAI → model Pod). So no
+app-specific ingress NetworkPolicy is needed. Egress is open, so reaching the
+shared Postgres works; the Postgres *side* allow was added separately.

--- a/scalable-llm/device-plugin.yaml
+++ b/scalable-llm/device-plugin.yaml
@@ -1,0 +1,69 @@
+# Phase 3 (方式A): expose Tenstorrent Blackhole to the scheduler.
+#
+# No official Tenstorrent device plugin exists, so squat/generic-device-plugin
+# advertises the two linked cards as a single allocatable unit. A Pod that
+# requests `squat.io/tenstorrent: 1` gets BOTH /dev/tenstorrent/0 and
+# /dev/tenstorrent/1 injected — matching the "2 cards meshed into one vLLM
+# instance" model. The DaemonSet only runs on shion-ubuntu-2605 (the labelled
+# TT node); other nodes have no cards.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: tenstorrent-device-plugin
+  namespace: scalable-llm
+  labels:
+    app: tenstorrent-device-plugin
+spec:
+  selector:
+    matchLabels:
+      app: tenstorrent-device-plugin
+  template:
+    metadata:
+      labels:
+        app: tenstorrent-device-plugin
+    spec:
+      priorityClassName: system-node-critical
+      nodeSelector:
+        tenstorrent.com/blackhole: "true" # = shion-ubuntu-2605 only
+      tolerations:
+        - operator: "Exists" # tolerate any taint the TT node may carry
+      containers:
+        - name: generic-device-plugin
+          # ghcr.io/squat/generic-device-plugin publishes commit-hash tags; this
+          # is the digest-pinnable tag. Renovate keeps it current.
+          image: ghcr.io/squat/generic-device-plugin:latest
+          args:
+            - --device
+            - |
+              name: tenstorrent
+              groups:
+                # One group = one allocation unit = both linked cards. A single
+                # vLLM instance gets card 0 and card 1 together (TP / mesh).
+                - count: 1
+                  paths:
+                    - path: /dev/tenstorrent/0
+                    - path: /dev/tenstorrent/1
+          ports:
+            - containerPort: 8080
+              name: http
+          resources:
+            requests:
+              cpu: 50m
+              memory: 10Mi
+            limits:
+              cpu: 50m
+              memory: 20Mi
+          securityContext:
+            privileged: true # device-plugin needs to mknod the device files
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: dev
+              mountPath: /dev
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: dev
+          hostPath:
+            path: /dev

--- a/scalable-llm/kubeai-values.yaml
+++ b/scalable-llm/kubeai-values.yaml
@@ -1,0 +1,124 @@
+# KubeAI controller config for the Tenstorrent Blackhole PoC.
+# Rendered by the scalable-llm ArgoCD app (Helm source, skipCrds=true).
+# The models.kubeai.org CRD is owned by the kube-ai-crd app.
+
+# Single-replica controller; this is a PoC on one TT node.
+replicaCount: 1
+
+# Istio / Knative / Prometheus-adapter are not used. Default messaging off.
+
+resourceProfiles:
+  # The one profile this PoC uses. A Model references it as
+  # `resourceProfile: tenstorrent-blackhole:1`, where `1` = one allocation
+  # unit = the two linked Blackhole cards (see device-plugin.yaml).
+  tenstorrent-blackhole:
+    imageName: "tt-vllm" # -> modelServers.VLLM.images.tt-vllm below
+    nodeSelector:
+      # Pins every TT model Pod to shion-ubuntu-2605, the only node with cards.
+      # Label applied in Phase 1-3: kubectl label node shion-ubuntu-2605 \
+      #   tenstorrent.com/blackhole=true
+      tenstorrent.com/blackhole: "true"
+    limits:
+      # Must match the resource name advertised by device-plugin.yaml exactly.
+      # One unit = both linked cards handed to a single vLLM instance.
+      squat.io/tenstorrent: "1"
+    requests:
+      squat.io/tenstorrent: "1"
+      cpu: "4"
+      memory: "32Gi" # headroom for the 2-card mesh weight load
+    # shion-ubuntu-2605 carries no TT-specific taint today. If one is added,
+    # mirror it here (confirm with `kubectl describe node shion-ubuntu-2605`):
+    # tolerations:
+    #   - key: "<taint-key>"
+    #     operator: "Exists"
+    #     effect: "NoSchedule"
+
+modelServers:
+  VLLM:
+    images:
+      # Phase 2 image: the Tenstorrent vLLM fork (TT-Metal / TT-NN) serving an
+      # OpenAI-compatible API. Replace the placeholder with the tag built and
+      # loaded onto shion-ubuntu-2605 (Phase 1-3 / Phase 2). If the image is
+      # imported directly into containerd's k8s.io namespace (not pulled from a
+      # registry), the Model must also set imagePullPolicy via its `image`
+      # field's pull behaviour — KubeAI defaults to IfNotPresent, which works
+      # for a locally-imported image:tag that matches exactly.
+      tt-vllm: "REPLACE_ME/tt-vllm:REPLACE_TAG"
+      # `default` is required by the chart even though we never schedule on it.
+      default: "REPLACE_ME/tt-vllm:REPLACE_TAG"
+
+# Applied to every model server Pod. Because the only resourceProfile in this
+# PoC pins Pods to shion-ubuntu-2605, these patches only ever land on the TT
+# node. They attach the TT compile/program cache and the device directory.
+modelServerPods:
+  securityContext:
+    readOnlyRootFilesystem: false
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+  # NOTE: `add /spec/volumes/-` (append) requires spec.volumes to already exist.
+  # KubeAI's vLLM engine always adds a `dshm` volume + the server container's
+  # volumeMount, so both arrays exist on every model Pod and these appends are
+  # valid. KubeAI *ignores invalid patches silently* — if a future chart drops
+  # dshm, the cache mount would vanish without error. Re-check on chart bumps.
+  jsonPatches:
+    # Node-local hostPath cache for TT-Metal program/kernel compilation +
+    # downloaded/converted weights. Persisting this across Pod restarts and
+    # scale-from-zero is what keeps cold starts from re-compiling (Phase 2 / R4).
+    # The cache lives on shion-ubuntu-2605 only; pre-create the dir on the host:
+    #   sudo mkdir -p /var/local-storage/tt-cache && sudo chmod 1777 /var/local-storage/tt-cache
+    - op: add
+      path: /spec/volumes/-
+      value:
+        name: tt-cache
+        hostPath:
+          path: /var/local-storage/tt-cache
+          type: DirectoryOrCreate
+    - op: add
+      path: /spec/containers/0/volumeMounts/-
+      value:
+        name: tt-cache
+        # ⚠️ Point this at the TT runtime's actual cache dir, and set the
+        # matching env var on the Model (TT_METAL_CACHE / program-cache path).
+        # Confirm the path/var in the TT docs (Phase 0/2).
+        mountPath: /cache/tt
+    # HugePages: TT-Metal maps hugetlbfs. The host enables it via tt-installer
+    # (tenstorrent-tools). Expose /dev/hugepages into the model Pod.
+    - op: add
+      path: /spec/volumes/-
+      value:
+        name: hugepages
+        hostPath:
+          path: /dev/hugepages
+          type: Directory
+    - op: add
+      path: /spec/containers/0/volumeMounts/-
+      value:
+        name: hugepages
+        mountPath: /dev/hugepages
+    # FALLBACK (commented): if the device-plugin device files are not enough
+    # and the TT runtime needs /dev/tenstorrent/by-id or sysfs/PCIe resources,
+    # promote the container to privileged with the whole device dir. Not for
+    # production — try the device-plugin path (squat.io/tenstorrent) first.
+    # - op: add
+    #   path: /spec/containers/0/securityContext/privileged
+    #   value: true
+    # - op: add
+    #   path: /spec/volumes/-
+    #   value:
+    #     name: tt-dev
+    #     hostPath: { path: /dev/tenstorrent, type: Directory }
+    # - op: add
+    #   path: /spec/containers/0/volumeMounts/-
+    #   value:
+    #     name: tt-dev
+    #     mountPath: /dev/tenstorrent
+
+# The controller itself does not need the TT node; let it schedule anywhere.
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    memory: 512Mi

--- a/scalable-llm/kustomization.yaml
+++ b/scalable-llm/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - device-plugin.yaml
+  - models/tt-llama.yaml
+  - litellm

--- a/scalable-llm/litellm/config.yaml
+++ b/scalable-llm/litellm/config.yaml
@@ -1,0 +1,28 @@
+# LiteLLM proxy config. Registers the KubeAI-served model as an OpenAI backend.
+# The capture point for per-user keys / budgets / audit is LiteLLM regardless of
+# the TT backend.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: litellm-config
+  namespace: scalable-llm
+data:
+  config.yaml: |
+    model_list:
+      # Keep model_name in sync with the Model CR metadata.name (the OpenAI
+      # `model` clients pass). api_base is the in-cluster KubeAI OpenAI endpoint.
+      - model_name: tt-llama
+        litellm_params:
+          model: openai/tt-llama
+          api_base: http://kubeai.scalable-llm.svc.cluster.local/openai/v1
+          api_key: "ignored" # KubeAI does not auth; LiteLLM is the gate
+          timeout: 600 # large: cold start = weight load + TT-Metal compile (R4)
+
+    general_settings:
+      # Body audit off by default; opt-in with consent (CLAUDE.md: public repo).
+      store_prompts_in_spend_logs: false
+
+    litellm_settings:
+      # Don't let LiteLLM's own retry storm during a long cold start.
+      num_retries: 0
+      request_timeout: 600

--- a/scalable-llm/litellm/db-secret-store.yaml
+++ b/scalable-llm/litellm/db-secret-store.yaml
@@ -1,0 +1,28 @@
+# Copies the postgres-operator-generated `litellm` DB credentials from the
+# operator namespace into scalable-llm, via the ESO Kubernetes provider. The
+# eso-db SA is granted read on exactly that one Secret by
+# external-secrets/rbac-db-reader.yaml (Role eso-db-scalable-llm).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso-db
+  namespace: scalable-llm
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: k8s-postgres
+  namespace: scalable-llm
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: postgres-operator-deployment
+      server:
+        url: "https://kubernetes.default.svc"
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: eso-db

--- a/scalable-llm/litellm/deployment.yaml
+++ b/scalable-llm/litellm/deployment.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: litellm
+  namespace: scalable-llm
+  labels:
+    app: litellm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: litellm
+  template:
+    metadata:
+      labels:
+        app: litellm
+    spec:
+      containers:
+        - name: litellm
+          image: ghcr.io/berriai/litellm:main-v1.86.2-stable
+          args:
+            - "--config"
+            - "/etc/litellm/config.yaml"
+            - "--port"
+            - "4000"
+          ports:
+            - containerPort: 4000
+              name: http
+          env:
+            # DB-backed state (virtual keys, budgets, spend logs).
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: litellm-db-credentials
+                  key: DATABASE_URL
+            # Master key signs admin/virtual keys; from Vault via ESO.
+            - name: LITELLM_MASTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm-master-key
+                  key: LITELLM_MASTER_KEY
+          volumeMounts:
+            - name: config
+              mountPath: /etc/litellm
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /health/readiness
+              port: 4000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health/liveliness
+              port: 4000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+      volumes:
+        - name: config
+          configMap:
+            name: litellm-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: litellm
+  namespace: scalable-llm
+  labels:
+    app: litellm
+spec:
+  selector:
+    app: litellm
+  ports:
+    - name: http
+      port: 4000
+      targetPort: 4000

--- a/scalable-llm/litellm/external-secret.yaml
+++ b/scalable-llm/litellm/external-secret.yaml
@@ -1,0 +1,32 @@
+# Materializes the LiteLLM DB credentials (from the operator Secret copied by
+# the k8s-postgres SecretStore) into a Secret LiteLLM consumes. The template
+# assembles the full DATABASE_URL LiteLLM reads at startup.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: litellm-db-credentials
+  namespace: scalable-llm
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: k8s-postgres
+    kind: SecretStore
+  target:
+    name: litellm-db-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+      data:
+        DATABASE_URL: "postgresql://{{ .username }}:{{ .password }}@postgres-shared.postgres-operator-deployment.svc.cluster.local:5432/litellm"
+  data:
+    - secretKey: username
+      remoteRef:
+        key: litellm.postgres-shared.credentials.postgresql.acid.zalan.do
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: litellm.postgres-shared.credentials.postgresql.acid.zalan.do
+        property: password

--- a/scalable-llm/litellm/httproute-internal.yaml
+++ b/scalable-llm/litellm/httproute-internal.yaml
@@ -1,0 +1,19 @@
+# Publishes LiteLLM on the internal Gateway (WireGuard-only). LiteLLM is the
+# auth/budget/audit front; KubeAI and the TT backend sit behind it and are not
+# published. TLS terminates at the Gateway; plain HTTP to the Service.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: litellm-internal
+  namespace: scalable-llm
+spec:
+  parentRefs:
+    - name: internal
+      namespace: envoy-gateway-system
+      sectionName: https
+  hostnames:
+    - ai.i.shion1305.com
+  rules:
+    - backendRefs:
+        - name: litellm
+          port: 4000

--- a/scalable-llm/litellm/kustomization.yaml
+++ b/scalable-llm/litellm/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - db-secret-store.yaml
+  - external-secret.yaml
+  - vault-secret-store.yaml
+  - config.yaml
+  - deployment.yaml
+  - httproute-internal.yaml
+  - reference-grant.yaml

--- a/scalable-llm/litellm/reference-grant.yaml
+++ b/scalable-llm/litellm/reference-grant.yaml
@@ -1,0 +1,15 @@
+# Lets the Gateway in envoy-gateway-system dial Services in scalable-llm
+# (cross-namespace backendRef from the internal Gateway's HTTPRoute).
+apiVersion: gateway.networking.k8s.io/v1
+kind: ReferenceGrant
+metadata:
+  name: allow-envoy-gateway
+  namespace: scalable-llm
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: envoy-gateway-system
+  to:
+    - group: ""
+      kind: Service

--- a/scalable-llm/litellm/vault-secret-store.yaml
+++ b/scalable-llm/litellm/vault-secret-store.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso
+  namespace: scalable-llm
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: vault
+  namespace: scalable-llm
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      # Dedicated KV v2 mount: vault secrets enable -path=scalable-llm kv-v2
+      path: "scalable-llm"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "eso-scalable-llm"
+          serviceAccountRef:
+            name: "eso"
+---
+# LiteLLM master key (admin/virtual-key signing). Written to Vault out-of-band
+# (public repo — never commit the value):
+#   vault kv put scalable-llm/litellm master_key=sk-<random>
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: litellm-master-key
+  namespace: scalable-llm
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  target:
+    name: litellm-master-key
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+  data:
+    - secretKey: LITELLM_MASTER_KEY
+      remoteRef:
+        key: litellm
+        property: master_key

--- a/scalable-llm/models/tt-llama.yaml
+++ b/scalable-llm/models/tt-llama.yaml
@@ -1,0 +1,57 @@
+# Phase 6: the KubeAI Model served on Blackhole.
+#
+# ⚠️ This is a template. Before it serves traffic you MUST fill in, from the
+# Phase 2 single-container run that succeeded:
+#   - metadata.name / url            -> the actual model + how the TT fork loads it
+#   - spec.image                     -> the tt-vllm tag built & loaded on s2605
+#   - spec.args                      -> the TT-fork launch flags (mesh-shape, etc.)
+#   - spec.env TT cache var          -> point at the mounted /cache/tt (see values)
+#
+# The KubeAI default args for `engine: VLLM` assume upstream vLLM (GPU flags like
+# --gpu-memory-utilization) which the TT fork does NOT accept. Override them all
+# via spec.args, or absorb the TT launch in the image ENTRYPOINT and keep args
+# minimal. Whatever launched the container in Phase 2 is the source of truth.
+apiVersion: kubeai.org/v1
+kind: Model
+metadata:
+  name: tt-llama # rename to the real model id (used as the OpenAI `model` name)
+  namespace: scalable-llm
+spec:
+  features: [TextGeneration]
+
+  # ⚠️ The TT fork may not run from a raw HF download — it can require a
+  # TT-Metal conversion/compile step. Decide in Phase 0/2 whether `hf://...`
+  # works directly or whether pre-converted weights are read from the mounted
+  # cache (then point url at that local path). Keep the compile output on the
+  # hostPath cache so it is reused on restart / scale-from-zero (R4).
+  url: hf://REPLACE_ORG/REPLACE_MODEL
+
+  engine: VLLM
+
+  # name:count — count 1 = the single allocation unit = both linked cards
+  # (device-plugin.yaml + kubeai-values.yaml resourceProfiles).
+  resourceProfile: tenstorrent-blackhole:1
+
+  # Pin the TT fork image on the Model so it overrides the profile's imageName
+  # if needed. Keep in sync with modelServers.VLLM.images.tt-vllm in values.
+  image: "REPLACE_ME/tt-vllm:REPLACE_TAG"
+
+  # PoC runs warm to take cold start (weight load + TT-Metal compile) off the
+  # request path. Measure the real cold start in Phase 7 before considering
+  # minReplicas: 0.
+  minReplicas: 1
+  maxReplicas: 1
+
+  env:
+    # ⚠️ Set the TT runtime's cache env var to the mounted hostPath so program/
+    # kernel compilation is cached on s2605 across restarts. Confirm the exact
+    # variable name in the TT docs (e.g. TT_METAL_CACHE) — this is a guess.
+    TT_METAL_CACHE: "/cache/tt"
+
+  args:
+    # ⚠️ Replace with the exact flags from the Phase 2 working launch command.
+    # Standard vLLM GPU flags do NOT map to the TT fork. Examples of what likely
+    # belongs here (names per the TT vLLM fork / tt-inference-server docs):
+    # - "--mesh-shape=1x2"        # use both linked cards as one mesh
+    # - "--max-model-len=4096"
+    []

--- a/scalable-llm/namespace.yaml
+++ b/scalable-llm/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: scalable-llm
+  labels:
+    name: scalable-llm

--- a/vault/scripts/setup-eso-policies.sh
+++ b/vault/scripts/setup-eso-policies.sh
@@ -95,6 +95,17 @@ path "claude-code/metadata/*" {
 EOF
 echo "✓ Created policy: eso-claude-code"
 
+# Policy for scalable-llm namespace (separate KV v2 engine mounted at scalable-llm/)
+vault policy write eso-scalable-llm - <<EOF
+path "scalable-llm/data/*" {
+  capabilities = ["read"]
+}
+path "scalable-llm/metadata/*" {
+  capabilities = ["read", "list"]
+}
+EOF
+echo "✓ Created policy: eso-scalable-llm"
+
 # Policy for cert-manager namespace (system/ KV v2 mount, cert-manager only)
 vault policy write eso-cert-manager - <<EOF
 path "system/data/cert-manager" {
@@ -272,6 +283,14 @@ vault write auth/kubernetes/role/eso-claude-code \
   ttl=1h
 echo "✓ Created role: eso-claude-code"
 
+# scalable-llm
+vault write auth/kubernetes/role/eso-scalable-llm \
+  bound_service_account_names=eso \
+  bound_service_account_namespaces=scalable-llm \
+  policies=eso-scalable-llm \
+  ttl=1h
+echo "✓ Created role: eso-scalable-llm"
+
 # cert-manager
 vault write auth/kubernetes/role/eso-cert-manager \
   bound_service_account_names=eso \
@@ -441,6 +460,7 @@ echo "  eso-atc         → SA eso/atc             → atc/data/*"
 echo "  eso-lumos-bot   → SA eso/lumos-bot       → lumos-bot/data/*"
 echo "  eso-freqtrade   → SA eso/freqtrade       → freqtrade/data/*"
 echo "  eso-claude-code → SA eso/claude-code     → claude-code/data/*"
+echo "  eso-scalable-llm→ SA eso/scalable-llm    → scalable-llm/data/*"
 echo "  eso-cert-manager→ SA eso/cert-manager    → system/data/cert-manager"
 echo "  eso-zot         → SA eso/zot             → zot/data/*"
 echo "  eso-harbor      → SA eso/harbor          → harbor/data/*"


### PR DESCRIPTION
## What

GitOps manifests for a PoC serving an OpenAI-compatible API on **Tenstorrent Blackhole** (2 cards meshed) via the **Tenstorrent vLLM fork**, orchestrated by **KubeAI** and fronted by **LiteLLM**. All TT workloads pin to `shion-ubuntu-2605` (the only node with cards). Published on the **internal Gateway** at `ai.i.shion1305.com` (WireGuard-only).

This implements Phases 3–8 of the PoC plan as declarative manifests. The hardware-dependent steps (Phases 0–2: `tt-installer`, firmware, 2-card mesh, image build/smoke-test) can't be done from the repo and are documented in `scalable-llm/README.md`.

## Apps (CRD-split, mirroring `envoy-gateway`)

| App | Role |
|-----|------|
| `kube-ai-crd` | vendors `models.kubeai.org` CRD (KubeAI **0.23.2**), sync-wave `-1`, `prune:false`, SSA |
| `scalable-llm` | KubeAI controller Helm (`skipCrds`) + self-authored manifests |

## `scalable-llm/` manifests

- **`device-plugin.yaml`** — `squat/generic-device-plugin` advertises the two linked cards as **one allocation unit** (`squat.io/tenstorrent:1`); a single vLLM instance gets `/dev/tenstorrent/0` and `/1` together.
- **`kubeai-values.yaml`** — `tenstorrent-blackhole` resourceProfile + `tt-vllm` image; `modelServerPods.jsonPatches` mount a **node-local hostPath TT compile/weights cache** (`/var/local-storage/tt-cache`) + HugePages into every model Pod, so cold start (weight load + TT-Metal compile) is cached across restarts / scale-from-zero.
- **`models/tt-llama.yaml`** — warm Model (`minReplicas:1`) **template**; TT-fork `url`/`args`/`env`/image are `REPLACE_*` placeholders to fill from the Phase 2 smoke test.
- **`litellm/`** — LiteLLM front (auth / budgets / audit) registering KubeAI as the OpenAI backend, internal HTTPRoute + ReferenceGrant.

## Supporting wiring (shared infra)

- `postgres-shared`: declare the `litellm` user/database on the shared cluster.
- `external-secrets`: `eso-db-scalable-llm` RBAC reads the operator-generated DB secret; ESO copies it in.
- `postgres-shared/networkpolicy.yaml`: add `scalable-llm` to the `:5432` ingress allow.
- `vault/scripts/setup-eso-policies.sh`: `eso-scalable-llm` policy + k8s auth role (dedicated `scalable-llm/` KV mount) for the LiteLLM master key.

No app-specific ingress NetworkPolicy: `scalable-llm` is reached only by the Gateway, Prometheus/Grafana, and same-namespace pods — all already allowed.

## Before this serves traffic (see `scalable-llm/README.md`)

1. `ssh s2605`: `tt-installer` → reboot → verify 2× Blackhole + mesh; create `/var/local-storage/tt-cache`.
2. `kubectl label node shion-ubuntu-2605 tenstorrent.com/blackhole=true`.
3. Phase 2: build the TT vLLM image, single-container smoke test, then fill the `REPLACE_*` placeholders.
4. Vault: `vault secrets enable -path=scalable-llm kv-v2`, write `master_key`, run `setup-eso-policies.sh`.

## Validation

`./scripts/render-validate.sh` → **all apps render + validate clean** (incl. the two new apps and the touched `shared-postgres`). Verified KubeAI's vLLM engine always adds a `dshm` volume, so the `/spec/volumes/-` append patches are valid (not silently dropped).