### PR TITLE
fix(scalable-llm): device-plugin domain, litellm image, disable bundled open-webui

### DIFF
--- a/scalable-llm/device-plugin.yaml
+++ b/scalable-llm/device-plugin.yaml
@@ -33,6 +33,11 @@ spec:
           # is the digest-pinnable tag. Renovate keeps it current.
           image: ghcr.io/squat/generic-device-plugin:latest
           args:
+            # generic-device-plugin defaults its resource domain to "devic.es";
+            # pin it to squat.io so the advertised name is squat.io/tenstorrent,
+            # matching the resourceProfile limits/requests in kubeai-values.yaml.
+            - --domain
+            - squat.io
             - --device
             - |
               name: tenstorrent

--- a/scalable-llm/kubeai-values.yaml
+++ b/scalable-llm/kubeai-values.yaml
@@ -7,6 +7,12 @@ replicaCount: 1
 
 # Istio / Knative / Prometheus-adapter are not used. Default messaging off.
 
+# The KubeAI chart bundles an Open WebUI subchart, enabled by default. This
+# cluster already runs Open WebUI as its own `openwebui` app, so disable the
+# bundled one to avoid a duplicate StatefulSet/PVC/Service in this namespace.
+open-webui:
+  enabled: false
+
 resourceProfiles:
   # The one profile this PoC uses. A Model references it as
   # `resourceProfile: tenstorrent-blackhole:1`, where `1` = one allocation

--- a/scalable-llm/litellm/deployment.yaml
+++ b/scalable-llm/litellm/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: litellm
-          image: ghcr.io/berriai/litellm:main-v1.86.2-stable
+          image: ghcr.io/berriai/litellm:v1.86.2
           args:
             - "--config"
             - "/etc/litellm/config.yaml"

--- a/scalable-llm/litellm/external-secret.yaml
+++ b/scalable-llm/litellm/external-secret.yaml
@@ -20,7 +20,7 @@ spec:
         labels:
           managed-by: external-secrets
       data:
-        DATABASE_URL: "postgresql://{{ .username }}:{{ .password }}@postgres-shared.postgres-operator-deployment.svc.cluster.local:5432/litellm"
+        DATABASE_URL: "postgresql://{{ .username | urlquery }}:{{ .password | urlquery }}@postgres-shared.postgres-operator-deployment.svc.cluster.local:5432/litellm"
   data:
     - secretKey: username
       remoteRef:


### PR DESCRIPTION
Follow-up to #406. After it merged, I verified the live deployment and found three issues that prevented the model and LiteLLM Pods from running. All found by inspecting actual ArgoCD/pod state on the cluster.

## Issues fixed

### 1. 🔴 Device-plugin resource domain mismatch (model Pod unschedulable)
`generic-device-plugin` defaults its resource domain to **`devic.es`**, so the node advertised `devic.es/tenstorrent` while the resourceProfile requested `squat.io/tenstorrent`:

```
FailedScheduling: 0/5 nodes are available: 1 Insufficient squat.io/tenstorrent ...
```

Fix: pin `--domain squat.io` on the DaemonSet so the advertised name matches the manifests (keeps the intended `squat.io/tenstorrent` name rather than rewriting 5 references).

### 2. 🔴 LiteLLM image tag does not exist (ImagePullBackOff)
`ghcr.io/berriai/litellm:main-v1.86.2-stable` 404s:

```
ErrImagePull: ... ghcr.io/berriai/litellm:main-v1.86.2-stable: not found
```

Fix: pin the published **`v1.86.2`** tag (verified to exist on ghcr).

### 3. 🟡 Bundled Open WebUI subchart (duplicate workload)
The KubeAI chart enables an Open WebUI subchart by default, which created a redundant `StatefulSet/PVC/Service` in `scalable-llm` (this cluster already runs Open WebUI as its own `openwebui` app — also the source of the app's `OrphanedResourceWarning`).

Fix: `open-webui.enabled: false`.

### 4. nit (from the 5-agent review): url-encode DB credentials
`DATABASE_URL` template now uses `{{ .username | urlquery }}:{{ .password | urlquery }}`, matching `nc-press-chotatsu`'s pattern, to guard against URL-reserved characters in the operator-generated password.

## Verification

- `scripts/render-validate.sh` → **EXIT=0** (both apps validate).
- Before this PR, live state: `model-tt-llama` Pending (insufficient `squat.io/tenstorrent`), `litellm` ImagePullBackOff, redundant `open-webui-0` Running. `kubeai`, `tenstorrent-device-plugin` healthy; ESO secrets synced (`SecretSynced/True`).

## Still expected after this merge (PoC scaffolding, not bugs)
`model-tt-llama` will remain Pending/not-Ready until the Phase-2 host work is done and the `REPLACE_*` placeholders (image, url, args) are filled per `scalable-llm/README.md`. The device-plugin will only advertise a non-zero count once the TT cards + driver are present on `shion-ubuntu-2605`.