### PR TITLE
fix(scalable-llm): raise LiteLLM memory limit to stop startup OOMKill

### DIFF
--- a/scalable-llm/litellm/deployment.yaml
+++ b/scalable-llm/litellm/deployment.yaml
@@ -58,9 +58,12 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 256Mi
+              # LiteLLM v1.86.x loads the full provider map + a Prisma engine and
+              # runs DB migrations at startup; it OOMKills (exit 137) under ~1Gi
+              # before it can even log. Reserve enough so the scheduler places it.
+              memory: 512Mi
             limits:
-              memory: 1Gi
+              memory: 2Gi
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
Follow-up to #407. Verifying the live deployment after #407 merged: the device-plugin domain fix, image-tag fix, and open-webui removal all worked — but the LiteLLM Pod now reveals a **memory limit too low** for v1.86.2.

## Issue

With the corrected `v1.86.2` image, `litellm` pulls fine but crashloops with **OOMKilled (exit 137)** before it can emit any logs:

```
Reason: OOMKilled   Exit Code: 137   (x2 restarts, BackOff)
limits.memory: 1Gi
```

LiteLLM v1.86.x loads the full provider map + a Prisma engine and runs DB migrations at startup, exceeding 1Gi.

## Fix

- `limits.memory`: 1Gi → **2Gi**
- `requests.memory`: 256Mi → **512Mi** (so the scheduler reserves real headroom)

## Verification

- `scripts/render-validate.sh` → **EXIT=0**.
- Confirmed on the cluster that **#407's device fix worked**: the node now advertises `squat.io/tenstorrent: 1`, and `model-tt-llama` schedules onto `shion-ubuntu-2605` — its only remaining blocker is the intentional `REPLACE_*` placeholder image (`InvalidImageName`), exactly as designed. `open-webui` is gone.

After this merges, `litellm` should reach Ready; the only not-Ready workload left will be `model-tt-llama`, pending the Phase-2 host work + placeholder fill-in per `scalable-llm/README.md`.