### PR TITLE
fix(argocd): clear permanent OutOfSync from CRD server-side defaults

### DIFF
--- a/apps/cloudflare-exporter-app.yaml
+++ b/apps/cloudflare-exporter-app.yaml
@@ -25,6 +25,15 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: monitoring
+  # The grafana-operator writes the running version back into spec.version, and
+  # the embedded ServicePort defaults protocol=TCP — neither is in the repo CR,
+  # so ArgoCD diffs them forever. Per-app because spec.version is operator-owned.
+  ignoreDifferences:
+    - group: grafana.integreatly.org
+      kind: Grafana
+      jqPathExpressions:
+        - '.spec.version'
+        - '.spec.service.spec.ports[].protocol'
   syncPolicy:
     automated:
       prune: true

--- a/apps/grafana-app.yaml
+++ b/apps/grafana-app.yaml
@@ -21,6 +21,22 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: grafana
+  # grafana-operator writes spec.version back into the CR and the embedded
+  # ServicePort defaults protocol=TCP; the node-exporter ServiceMonitor's
+  # job-pin relabeling gets action=replace defaulted by the operator. None are
+  # in the repo manifests, so ArgoCD diffs them forever. Per-app because these
+  # fields carry real intent on other Grafana / ServiceMonitor objects.
+  ignoreDifferences:
+    - group: grafana.integreatly.org
+      kind: Grafana
+      jqPathExpressions:
+        - '.spec.version'
+        - '.spec.service.spec.ports[].protocol'
+    - group: monitoring.coreos.com
+      kind: ServiceMonitor
+      name: kube-prometheus-stack-prometheus-node-exporter
+      jqPathExpressions:
+        - '.spec.endpoints[].relabelings[].action'
   syncPolicy:
     automated:
       prune: true

--- a/apps/kyverno-policies-app.yaml
+++ b/apps/kyverno-policies-app.yaml
@@ -19,6 +19,19 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: kyverno
+  # Kyverno defaults these ClusterPolicy fields server-side; the repo manifests
+  # omit them, so ServerSideApply leaves them live-only and ArgoCD diffs them
+  # forever. Kept per-app rather than cluster-wide because these fields can
+  # carry real intent on other ClusterPolicies.
+  ignoreDifferences:
+    - group: kyverno.io
+      kind: ClusterPolicy
+      jqPathExpressions:
+        - '.spec.admission'
+        - '.spec.background'
+        - '.spec.emitWarning'
+        - '.spec.validationFailureAction'
+        - '.spec.rules[].skipBackgroundRequests'
   syncPolicy:
     automated:
       prune: true

--- a/apps/network-policies-app.yaml
+++ b/apps/network-policies-app.yaml
@@ -15,6 +15,18 @@ spec:
     # Argo bookkeeping); the per-namespace CiliumNetworkPolicy resources carry
     # their own metadata.namespace and land there.
     namespace: kube-system
+  # Kyverno defaults these ClusterPolicy fields server-side (the cross-ns
+  # isolation generator policy omits them), producing a permanent OutOfSync
+  # under ServerSideApply. Kept per-app for the same reason as kyverno-policies.
+  ignoreDifferences:
+    - group: kyverno.io
+      kind: ClusterPolicy
+      jqPathExpressions:
+        - '.spec.admission'
+        - '.spec.background'
+        - '.spec.emitWarning'
+        - '.spec.validationFailureAction'
+        - '.spec.rules[].skipBackgroundRequests'
   syncPolicy:
     automated:
       prune: true

--- a/argocd/values.yaml
+++ b/argocd/values.yaml
@@ -112,6 +112,57 @@ configs:
         - /metadata
         - /endpoints
         - /ports
+    # Sync-diff ignore rules: the API server stamps schema defaults onto these
+    # CRD-backed resources at admission. Because every app syncs with
+    # ServerSideApply=true and the repo manifests are field-sparse, the
+    # defaulted fields live only on the cluster object and never appear in the
+    # desired state, so ArgoCD reports a permanent (cosmetic) OutOfSync. These
+    # entries drop the defaulted fields from the diff. Kinds are grouped here
+    # because the same defaults recur for every Gateway-API / External-Secrets
+    # resource cluster-wide; narrower per-app fields stay in apps/*.yaml.
+    resource.customizations.ignoreDifferences.gateway.networking.k8s.io_HTTPRoute: |
+      jqPathExpressions:
+        - '.spec.parentRefs[].group'
+        - '.spec.parentRefs[].kind'
+        - '.spec.rules[].backendRefs[].group'
+        - '.spec.rules[].backendRefs[].kind'
+        - '.spec.rules[].backendRefs[].weight'
+        - '.spec.rules[].matches'
+    resource.customizations.ignoreDifferences.gateway.networking.k8s.io_TLSRoute: |
+      jqPathExpressions:
+        - '.spec.parentRefs[].group'
+        - '.spec.parentRefs[].kind'
+        - '.spec.rules[].backendRefs[].group'
+        - '.spec.rules[].backendRefs[].kind'
+        - '.spec.rules[].backendRefs[].weight'
+    resource.customizations.ignoreDifferences.gateway.networking.k8s.io_Gateway: |
+      jqPathExpressions:
+        - '.spec.listeners[].tls.certificateRefs[].group'
+        - '.spec.listeners[].tls.certificateRefs[].kind'
+        - '.spec.listeners[].allowedRoutes.kinds[].group'
+    resource.customizations.ignoreDifferences.external-secrets.io_ExternalSecret: |
+      jqPathExpressions:
+        - '.spec.data[].remoteRef.conversionStrategy'
+        - '.spec.data[].remoteRef.decodingStrategy'
+        - '.spec.data[].remoteRef.metadataPolicy'
+        - '.spec.data[].remoteRef.nullBytePolicy'
+        - '.spec.dataFrom[].extract.conversionStrategy'
+        - '.spec.dataFrom[].extract.decodingStrategy'
+        - '.spec.dataFrom[].extract.metadataPolicy'
+        - '.spec.dataFrom[].extract.nullBytePolicy'
+        - '.spec.target.deletionPolicy'
+        - '.spec.target.template.engineVersion'
+        - '.spec.target.template.mergePolicy'
+    resource.customizations.ignoreDifferences.external-secrets.io_ClusterExternalSecret: |
+      jqPathExpressions:
+        - '.spec.externalSecretSpec.data[].remoteRef.conversionStrategy'
+        - '.spec.externalSecretSpec.data[].remoteRef.decodingStrategy'
+        - '.spec.externalSecretSpec.data[].remoteRef.metadataPolicy'
+        - '.spec.externalSecretSpec.data[].remoteRef.nullBytePolicy'
+        - '.spec.externalSecretSpec.target.template.mergePolicy'
+    resource.customizations.ignoreDifferences.apiextensions.k8s.io_CustomResourceDefinition: |
+      jqPathExpressions:
+        - '.spec.conversion'
   # RBAC configuration
   rbac:
     policy.default: role:admin


### PR DESCRIPTION
## 背景 / 調査結果

24個のアプリが永続的に **OutOfSync** でした。全アプリを調査した結果、**根本原因はほぼ単一**です:

> リポジトリのマニフェストはフィールドが疎（sparse）だが、API サーバが admission 時に CRD の OpenAPI スキーマ default を live オブジェクトに刻む。全アプリが `syncOptions: ServerSideApply=true` でありながら `ignoreDifferences` がクラスタのどこにも未設定なので、ArgoCD の `argocd-controller` フィールドマネージャは default 化されたフィールドを所有せず、desired は live に永遠に一致せず、self-heal も収束できない。

`kubectl diff --server-side` / managedFields / 各 live オブジェクトの実値で検証済み。**全アプリ Healthy であり、これは表示上の cosmetic drift** です（zot を除く、後述）。

### カテゴリ別の内訳

| カテゴリ | 対象 kind | 影響アプリ数 |
|---|---|---|
| Gateway-API HTTPRoute default (`parentRefs[].group/kind`, `backendRefs[].group/kind/weight`, 暗黙の `rules[].matches`) | HTTPRoute | 13 |
| External-Secrets default (`remoteRef.*Strategy/Policy`, `target.deletionPolicy`, `template.engineVersion/mergePolicy`) | ExternalSecret | 13 |
| 同上 (cluster-scoped) | ClusterExternalSecret | 3 (external-secrets, harbor-pull, zot-pull) |
| Gateway listener default (`certificateRefs[].group/kind`, `allowedRoutes.kinds[].group`) | Gateway | 1 (envoy-gateway) |
| TLSRoute default | TLSRoute | 1 (shared-postgres) |
| CRD `spec.conversion` default | CustomResourceDefinition | 1 (kyverno, 11 CRD) |
| Kyverno ClusterPolicy default (`admission`/`background`/`validationFailureAction`/...) | ClusterPolicy | 2 (kyverno-policies, network-policies) |
| grafana-operator が書き戻す `spec.version` + ServicePort `protocol` default | Grafana | 2 |
| node-exporter ServiceMonitor `relabelings[].action` default | ServiceMonitor | 1 (kube-prometheus-stack) |
| **Helm hook（`status=null`）— 良性、sync diff から除外され OutOfSync の原因ではない** | SA/Role/Job/Webhook 等 | argocd, envoy-gateway, kube-prometheus-stack, kyverno, harbor, mlflow |

## この PR の変更

方針: **クラスタ全体 + 個別の併用**（合意済み）。

- **クラスタ全体** (`argocd/values.yaml` の `configs.cm`): Gateway-API / External-Secrets 系の default は全アプリ共通で再発するため、グローバルに `resource.customizations.ignoreDifferences.<group>_<Kind>` を追加。将来追加されるアプリも自動カバー。対象: `HTTPRoute` / `TLSRoute` / `Gateway` / `ExternalSecret` / `ClusterExternalSecret` / `CustomResourceDefinition`。
- **個別** (`apps/*.yaml` の `spec.ignoreDifferences`): 同 kind の他オブジェクトで意味を持ちうる狭いフィールドのみ。`kyverno-policies` / `network-policies`（ClusterPolicy）、`grafana`(=kube-prometheus-stack) / `cloudflare-exporter`(=cloudflare-monitoring)（Grafana CR + ServiceMonitor）。

各 `jqPathExpression` は対応する live オブジェクト上で「まさに default 化された値」に解決することを確認済み。`scripts/render-validate.sh` は全49アプリ pass。

### ⚠️ この PR では解決しない（別途クラスタ操作が必要）

**`zot` StatefulSet** は唯一の「本物の drift」です。zot chart **0.1.113** が immutable な `spec.serviceName: zot` を追加したが、live の StatefulSet は 0.1.112（`serviceName: ""`）で作成済みのため API サーバが更新を拒否し、毎回 SyncError になります。`ignoreDifferences` は誤った対処（収束し得ない sync を隠すだけ）なので **意図的に含めていません**。

承認後に実行する一回限りのクラスタ操作（Pod / PVC は保持）:

```bash
kubectl delete statefulset zot -n zot --cascade=orphan
kubectl patch application zot -n argocd --type merge \
  -p '{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}'
# 検証（zot / zot-0.1.113 になればOK）:
kubectl get sts zot -n zot -o jsonpath='{.spec.serviceName}{"  "}{.metadata.labels.helm\.sh/chart}{"\n"}'
```

## マージ後の期待

`argocd-cm` が再 sync されると、上記カテゴリの cosmetic drift は全て解消し、24→1（zot のみ、上記操作で解消）に削減される見込みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)