### PR TITLE
feat(scalable-llm): wire Llama-3.1-8B on single p150 card + HF token

### DIFF
--- a/scalable-llm/README.md
+++ b/scalable-llm/README.md
@@ -1,7 +1,15 @@
 # scalable-llm — KubeAI on Tenstorrent Blackhole (PoC)
 
-OpenAI-compatible inference on **Tenstorrent Blackhole** (2 cards meshed) via the
-**Tenstorrent vLLM fork**, orchestrated by **KubeAI**, fronted by **LiteLLM**.
+OpenAI-compatible inference on **Tenstorrent Blackhole** via the official
+**tt-inference-server vLLM** image, orchestrated by **KubeAI**, fronted by
+**LiteLLM**.
+
+**Hardware (verified):** `shion-ubuntu-2605` has **2× Blackhole p150a** (32GB
+each), tt-kmd 2.8.0, FW 19.6.0.0. tt-inference-server has no 2-card (p150x2)
+mesh, and **Llama-3.1-8B** (the only LLM it supports on p150) fits one card — so
+the design is **one card per replica**: the device-plugin advertises
+`squat.io/tenstorrent: 2` and each model replica takes one card. The second card
+backs a second replica (`maxReplicas: 2`) later.
 
 All TT workloads are pinned to **`shion-ubuntu-2605`** (`ssh s2605`) — the only
 node with cards. Everything in this namespace is GitOps-managed; do not
@@ -28,9 +36,10 @@ helm template kubeai kubeai/kubeai --version <new> --include-crds \
 ```
 scalable-llm/
 ├── namespace.yaml          # ns: scalable-llm
-├── device-plugin.yaml      # generic-device-plugin: 2 cards -> squat.io/tenstorrent:1
-├── kubeai-values.yaml      # KubeAI Helm values: resourceProfile + tt-vllm image + hostPath cache patch
-├── models/tt-llama.yaml    # KubeAI Model (TEMPLATE — fill from Phase 2)
+├── device-plugin.yaml      # generic-device-plugin: 1 card = 1 unit -> squat.io/tenstorrent:2
+├── kubeai-values.yaml      # KubeAI Helm values: resourceProfile + tt image + cache/HF/hugepages patches
+├── llama-hf-token.yaml     # ESO: Vault scalable-llm/llama → HF_TOKEN Secret (gated Llama-3.1-8B)
+├── models/tt-llama.yaml    # KubeAI Model: Llama-3.1-8B on one p150 card
 └── litellm/                # LiteLLM front + DB (shared Postgres) + Vault key + HTTPRoute
 ```
 
@@ -76,46 +85,55 @@ kubectl label node shion-ubuntu-2605 tenstorrent.com/blackhole=true
 kubectl describe node shion-ubuntu-2605 | grep -i taint   # mirror any taint into kubeai-values
 ```
 
-### Phase 2 — build the image and single-container smoke test
+### Phase 2 — official image, no custom build
 
-Build with containerd tooling and load into the `k8s.io` namespace so kubelet
-sees it (or push to a registry the cluster can pull):
+We use Tenstorrent's published image directly (no Dockerfile to build):
+`ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.0-555f240-22be241`
+(public on ghcr; pinned in `kubeai-values.yaml` and `models/tt-llama.yaml`).
+
+Optional host smoke test (outside Kubernetes) once the HF token is in your
+shell — proves the card + weights + server before relying on KubeAI:
 
 ```bash
-# on s2605
-nerdctl build -t REPLACE_ME/tt-vllm:REPLACE_TAG -f Dockerfile .
-sudo nerdctl -n k8s.io load -i tt-vllm.tar          # if not using a registry
-sudo crictl images | grep tt-vllm
-
-# verify the container talks to BOTH cards as a mesh, OUTSIDE Kubernetes:
-sudo nerdctl run --rm \
-  --device /dev/tenstorrent/0 --device /dev/tenstorrent/1 \
-  --mount type=bind,src=/dev/hugepages,dst=/dev/hugepages \
-  --shm-size=<value> -p 8000:8000 \
-  REPLACE_ME/tt-vllm:REPLACE_TAG <TT launch: mesh-shape=1x2 ... --model ...>
+# on s2605; docker is installed there. Needs HF_TOKEN (gated Llama-3.1-8B).
+docker run --rm \
+  --env HF_TOKEN=$HF_TOKEN \
+  --env CACHE_ROOT=/home/container_app_user/cache_root \
+  --ipc host \
+  --device /dev/tenstorrent \
+  --mount type=bind,src=/dev/hugepages-1G,dst=/dev/hugepages-1G \
+  -v tt_llama_cache:/home/container_app_user/cache_root \
+  -p 8000:8000 \
+  ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.0-555f240-22be241 \
+  --model Llama-3.1-8B --tt-device p150
 curl localhost:8000/v1/models
 ```
 
-**The launch command that works here is the source of truth** for `models/tt-llama.yaml`
-(`spec.args`) and the TT cache env var (`spec.env`).
+The image entrypoint downloads the weights (first run, slow), compiles TT-Metal
+kernels (cached under `CACHE_ROOT`), and serves the OpenAI API on :8000.
 
 ---
 
-## Placeholders to fill before this serves traffic
+## The one remaining out-of-band step: the HF token
 
-| Where | Placeholder | Replace with |
-|-------|-------------|--------------|
-| `kubeai-values.yaml`, `models/tt-llama.yaml` | `REPLACE_ME/tt-vllm:REPLACE_TAG` | the image built in Phase 2 |
-| `models/tt-llama.yaml` | `url`, `metadata.name` | real model + TT load method |
-| `models/tt-llama.yaml` | `spec.args`, `spec.env` | Phase-2 launch flags + TT cache var |
-| `kubeai-values.yaml` | `/cache/tt` mountPath | TT runtime's actual cache dir |
+Everything else is wired in git. Llama-3.1-8B is **gated** on Hugging Face, so the
+weight download needs your HF token (accept the model's license on huggingface.co
+first, then create a read token). Write it to Vault; ESO syncs it and the model
+Pod picks it up:
+
+```bash
+vault kv put scalable-llm/llama hf_token=hf_xxx
+# force-sync (else waits up to 5m):
+kubectl annotate externalsecret -n scalable-llm llama-hf-token force-sync="$(date +%s)" --overwrite
+```
 
 ## Secrets (out-of-band, public repo — never commit values)
 
 ```bash
-# Vault KV v2 mount + LiteLLM master key
+# Vault KV v2 mount + LiteLLM master key + HF token
 vault secrets enable -path=scalable-llm kv-v2
 vault kv put scalable-llm/litellm master_key=sk-<random>
+vault kv put scalable-llm/llama   hf_token=hf_<your-token>
 # Vault policy + k8s auth role: run vault/scripts/setup-eso-policies.sh (eso-scalable-llm added)
 ```
 

--- a/scalable-llm/device-plugin.yaml
+++ b/scalable-llm/device-plugin.yaml
@@ -1,11 +1,13 @@
 # Phase 3 (方式A): expose Tenstorrent Blackhole to the scheduler.
 #
 # No official Tenstorrent device plugin exists, so squat/generic-device-plugin
-# advertises the two linked cards as a single allocatable unit. A Pod that
-# requests `squat.io/tenstorrent: 1` gets BOTH /dev/tenstorrent/0 and
-# /dev/tenstorrent/1 injected — matching the "2 cards meshed into one vLLM
-# instance" model. The DaemonSet only runs on shion-ubuntu-2605 (the labelled
-# TT node); other nodes have no cards.
+# advertises each Blackhole card as its own allocatable unit. The node has two
+# p150a cards, so it advertises squat.io/tenstorrent: 2; a Pod that requests
+# `squat.io/tenstorrent: 1` gets ONE card injected. tt-inference-server has no
+# 2-card (p150x2) mesh for this model — Llama-3.1-8B runs single-card (p150) and
+# fits one card's 32GB — so each model replica uses one card, and the two cards
+# back up to two independent replicas. The DaemonSet only runs on
+# shion-ubuntu-2605 (the labelled TT node); other nodes have no cards.
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -42,11 +44,12 @@ spec:
             - |
               name: tenstorrent
               groups:
-                # One group = one allocation unit = both linked cards. A single
-                # vLLM instance gets card 0 and card 1 together (TP / mesh).
-                - count: 1
-                  paths:
+                # Each group is one allocatable unit = one card. Two groups → the
+                # node advertises squat.io/tenstorrent: 2. A Pod requesting 1 gets
+                # exactly one card's device file injected.
+                - paths:
                     - path: /dev/tenstorrent/0
+                - paths:
                     - path: /dev/tenstorrent/1
           ports:
             - containerPort: 8080

--- a/scalable-llm/kubeai-values.yaml
+++ b/scalable-llm/kubeai-values.yaml
@@ -16,7 +16,8 @@ open-webui:
 resourceProfiles:
   # The one profile this PoC uses. A Model references it as
   # `resourceProfile: tenstorrent-blackhole:1`, where `1` = one allocation
-  # unit = the two linked Blackhole cards (see device-plugin.yaml).
+  # unit = one Blackhole p150a card (see device-plugin.yaml; the node advertises
+  # squat.io/tenstorrent: 2, one per card).
   tenstorrent-blackhole:
     imageName: "tt-vllm" # -> modelServers.VLLM.images.tt-vllm below
     nodeSelector:
@@ -26,12 +27,12 @@ resourceProfiles:
       tenstorrent.com/blackhole: "true"
     limits:
       # Must match the resource name advertised by device-plugin.yaml exactly.
-      # One unit = both linked cards handed to a single vLLM instance.
+      # One unit = one p150a card handed to a single vLLM instance.
       squat.io/tenstorrent: "1"
     requests:
       squat.io/tenstorrent: "1"
       cpu: "4"
-      memory: "32Gi" # headroom for the 2-card mesh weight load
+      memory: "48Gi" # headroom for the 8B host-side weight load + TT runtime
     # shion-ubuntu-2605 carries no TT-specific taint today. If one is added,
     # mirror it here (confirm with `kubectl describe node shion-ubuntu-2605`):
     # tolerations:
@@ -42,16 +43,12 @@ resourceProfiles:
 modelServers:
   VLLM:
     images:
-      # Phase 2 image: the Tenstorrent vLLM fork (TT-Metal / TT-NN) serving an
-      # OpenAI-compatible API. Replace the placeholder with the tag built and
-      # loaded onto shion-ubuntu-2605 (Phase 1-3 / Phase 2). If the image is
-      # imported directly into containerd's k8s.io namespace (not pulled from a
-      # registry), the Model must also set imagePullPolicy via its `image`
-      # field's pull behaviour — KubeAI defaults to IfNotPresent, which works
-      # for a locally-imported image:tag that matches exactly.
-      tt-vllm: "REPLACE_ME/tt-vllm:REPLACE_TAG"
+      # Official tt-inference-server vLLM image (TT-Metal source release). Public
+      # on ghcr; serves an OpenAI-compatible API on :8000 for Llama-3.1-8B on a
+      # single p150 via the image entrypoint. Pinned; bump deliberately.
+      tt-vllm: "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.0-555f240-22be241"
       # `default` is required by the chart even though we never schedule on it.
-      default: "REPLACE_ME/tt-vllm:REPLACE_TAG"
+      default: "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.0-555f240-22be241"
 
 # Applied to every model server Pod. Because the only resourceProfile in this
 # PoC pins Pods to shion-ubuntu-2605, these patches only ever land on the TT
@@ -85,24 +82,33 @@ modelServerPods:
       path: /spec/containers/0/volumeMounts/-
       value:
         name: tt-cache
-        # ⚠️ Point this at the TT runtime's actual cache dir, and set the
-        # matching env var on the Model (TT_METAL_CACHE / program-cache path).
-        # Confirm the path/var in the TT docs (Phase 0/2).
+        # TT_CACHE_PATH / CACHE_ROOT on the Model point here (models/tt-llama.yaml).
         mountPath: /cache/tt
-    # HugePages: TT-Metal maps hugetlbfs. The host enables it via tt-installer
-    # (tenstorrent-tools). Expose /dev/hugepages into the model Pod.
+    # HugePages: TT-Metal maps 1G hugetlbfs. The host enables it via tt-installer;
+    # the official image binds /dev/hugepages-1G specifically.
     - op: add
       path: /spec/volumes/-
       value:
-        name: hugepages
+        name: hugepages-1g
         hostPath:
-          path: /dev/hugepages
+          path: /dev/hugepages-1G
           type: Directory
     - op: add
       path: /spec/containers/0/volumeMounts/-
       value:
-        name: hugepages
-        mountPath: /dev/hugepages
+        name: hugepages-1g
+        mountPath: /dev/hugepages-1G
+    # HF_TOKEN for the gated Llama-3.1-8B weight download, from the ESO-synced
+    # Secret (Vault scalable-llm/llama → llama-hf-token). The model Pod downloads
+    # weights on first start and persists them in the tt-cache hostPath.
+    - op: add
+      path: /spec/containers/0/env/-
+      value:
+        name: HF_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: llama-hf-token
+            key: HF_TOKEN
     # FALLBACK (commented): if the device-plugin device files are not enough
     # and the TT runtime needs /dev/tenstorrent/by-id or sysfs/PCIe resources,
     # promote the container to privileged with the whole device dir. Not for

--- a/scalable-llm/kustomization.yaml
+++ b/scalable-llm/kustomization.yaml
@@ -4,5 +4,6 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - device-plugin.yaml
+  - llama-hf-token.yaml
   - models/tt-llama.yaml
   - litellm

--- a/scalable-llm/llama-hf-token.yaml
+++ b/scalable-llm/llama-hf-token.yaml
@@ -1,0 +1,28 @@
+# HF token for the gated Llama-3.1-8B weight download. Written to Vault
+# out-of-band (public repo — never commit the value):
+#   vault kv put scalable-llm/llama hf_token=hf_xxx
+# Reuses the namespace `vault` SecretStore created in litellm/vault-secret-store.yaml
+# (mount scalable-llm/, role eso-scalable-llm).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: llama-hf-token
+  namespace: scalable-llm
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  target:
+    name: llama-hf-token
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+  data:
+    - secretKey: HF_TOKEN
+      remoteRef:
+        key: llama
+        property: hf_token

--- a/scalable-llm/models/tt-llama.yaml
+++ b/scalable-llm/models/tt-llama.yaml
@@ -1,57 +1,52 @@
-# Phase 6: the KubeAI Model served on Blackhole.
+# Phase 6: the KubeAI Model served on a single Blackhole p150a card.
 #
-# ⚠️ This is a template. Before it serves traffic you MUST fill in, from the
-# Phase 2 single-container run that succeeded:
-#   - metadata.name / url            -> the actual model + how the TT fork loads it
-#   - spec.image                     -> the tt-vllm tag built & loaded on s2605
-#   - spec.args                      -> the TT-fork launch flags (mesh-shape, etc.)
-#   - spec.env TT cache var          -> point at the mounted /cache/tt (see values)
+# Confirmed for this node (2x Blackhole p150a, tt-kmd 2.8.0, FW 19.6.0.0):
+#   - Llama-3.1-8B is the only LLM tt-inference-server supports on p150
+#     (experimental); 8B fits one card's 32GB → single-card (--tt-device p150).
+#   - There is no p150x2 mesh, so one replica = one card. With two cards the
+#     device-plugin advertises squat.io/tenstorrent: 2, so maxReplicas can be 2.
 #
-# The KubeAI default args for `engine: VLLM` assume upstream vLLM (GPU flags like
-# --gpu-memory-utilization) which the TT fork does NOT accept. Override them all
-# via spec.args, or absorb the TT launch in the image ENTRYPOINT and keep args
-# minimal. Whatever launched the container in Phase 2 is the source of truth.
+# Llama-3.1-8B is GATED on Hugging Face. The weights download needs an HF token,
+# supplied via an ESO chain: Vault (scalable-llm/llama, key hf_token) →
+# ExternalSecret → Secret `llama-hf-token` → HF_TOKEN env, injected into the
+# model Pod by kubeai-values.yaml modelServerPods.jsonPatches.
 apiVersion: kubeai.org/v1
 kind: Model
 metadata:
-  name: tt-llama # rename to the real model id (used as the OpenAI `model` name)
+  name: tt-llama # OpenAI `model` name; keep in sync with litellm/config.yaml
   namespace: scalable-llm
 spec:
   features: [TextGeneration]
 
-  # ⚠️ The TT fork may not run from a raw HF download — it can require a
-  # TT-Metal conversion/compile step. Decide in Phase 0/2 whether `hf://...`
-  # works directly or whether pre-converted weights are read from the mounted
-  # cache (then point url at that local path). Keep the compile output on the
-  # hostPath cache so it is reused on restart / scale-from-zero (R4).
-  url: hf://REPLACE_ORG/REPLACE_MODEL
+  # The tt-inference-server image resolves this short name to its model spec
+  # (HF repo meta-llama/Llama-3.1-8B) and downloads the weights on first start
+  # using HF_TOKEN, persisting them under the mounted cache (CACHE_ROOT). vLLM's
+  # url is informational here; the TT image owns the actual load.
+  url: hf://meta-llama/Llama-3.1-8B
 
   engine: VLLM
 
-  # name:count — count 1 = the single allocation unit = both linked cards
-  # (device-plugin.yaml + kubeai-values.yaml resourceProfiles).
+  # count 1 = one p150a card (device-plugin advertises 2 units total).
   resourceProfile: tenstorrent-blackhole:1
 
-  # Pin the TT fork image on the Model so it overrides the profile's imageName
-  # if needed. Keep in sync with modelServers.VLLM.images.tt-vllm in values.
-  image: "REPLACE_ME/tt-vllm:REPLACE_TAG"
+  image: "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.0-555f240-22be241"
 
-  # PoC runs warm to take cold start (weight load + TT-Metal compile) off the
-  # request path. Measure the real cold start in Phase 7 before considering
-  # minReplicas: 0.
+  # PoC runs warm so the TT-Metal compile + weight load stays off the request
+  # path. With two cards available, maxReplicas: 2 is possible later.
   minReplicas: 1
   maxReplicas: 1
 
   env:
-    # ⚠️ Set the TT runtime's cache env var to the mounted hostPath so program/
-    # kernel compilation is cached on s2605 across restarts. Confirm the exact
-    # variable name in the TT docs (e.g. TT_METAL_CACHE) — this is a guess.
-    TT_METAL_CACHE: "/cache/tt"
+    # The tt-inference-server launcher (run_vllm_api_server.py) asserts these.
+    # TT_CACHE_PATH is the real compile-cache var (NOT TT_METAL_CACHE); it points
+    # at the hostPath cache mounted by kubeai-values.yaml so kernel compilation
+    # is reused across restarts / scale-from-zero.
+    TT_CACHE_PATH: "/cache/tt"
+    CACHE_ROOT: "/cache/tt"
+    MESH_DEVICE: "p150" # single card; no p150x2 exists for this model
 
-  args:
-    # ⚠️ Replace with the exact flags from the Phase 2 working launch command.
-    # Standard vLLM GPU flags do NOT map to the TT fork. Examples of what likely
-    # belongs here (names per the TT vLLM fork / tt-inference-server docs):
-    # - "--mesh-shape=1x2"        # use both linked cards as one mesh
-    # - "--max-model-len=4096"
-    []
+  # The TT image's entrypoint runs run_vllm_api_server.py for --tt-device p150;
+  # it does not take upstream vLLM GPU flags. Keep KubeAI from appending its
+  # default vLLM args by leaving this empty and letting the image entrypoint +
+  # env (above) drive the launch.
+  args: []


### PR DESCRIPTION
Fills in the Phase-2 `REPLACE_*` placeholders with the real, **image-verified** config to serve a model on the 2× Blackhole p150a node (`shion-ubuntu-2605`). Done autonomously after verifying the hardware (`tt-smi`: 2× p150a, FW 19.6.0.0, tt-kmd 2.8.0) and inspecting the official tt-inference-server image.

## Key findings that shaped the design

- **No 2-card mesh.** tt-inference-server's device map goes `p150`(1) → `p150x4`(4) → `p150x8` — there is **no `p150x2`**. And Llama-3.1-8B fits one card's 32GB. So the design is **one card per replica**, not "2 cards meshed into one instance" as the original plan assumed.
- **Llama-3.1-8B** is the only LLM supported on p150 (experimental, per `models_by_hardware.md`).
- The real TT compile-cache env var is **`TT_CACHE_PATH`** (the manifest's guessed `TT_METAL_CACHE` was wrong); the image binds **`/dev/hugepages-1G`**; weights are **gated**.

## Changes

- **device-plugin**: advertise each card as its own unit (2 groups → `squat.io/tenstorrent: 2`); a replica takes one card, the second card backs a future 2nd replica.
- **kubeai-values**: pin the official ghcr image; mount the hostPath cache as `TT_CACHE_PATH`; bind `/dev/hugepages-1G`; inject `HF_TOKEN` from the ESO-synced `llama-hf-token` Secret; raise the profile request to 48Gi for the 8B host-side load.
- **models/tt-llama.yaml**: real image, `url hf://meta-llama/Llama-3.1-8B`, `TT_CACHE_PATH`/`CACHE_ROOT`/`MESH_DEVICE=p150` env, single-card resourceProfile.
- **llama-hf-token.yaml**: ESO ExternalSecret (Vault `scalable-llm/llama` key `hf_token` → `HF_TOKEN`), reusing the existing namespace `vault` SecretStore.
- **README**: official-image flow, single-card design, host smoke-test command, and the one remaining out-of-band step.

## The one thing left before traffic flows

Llama-3.1-8B is gated on Hugging Face, so the weight download needs your HF token (accept the license on huggingface.co, create a read token):

```bash
vault kv put scalable-llm/llama hf_token=hf_xxx
kubectl annotate externalsecret -n scalable-llm llama-hf-token force-sync="$(date +%s)" --overwrite
```

After that, `model-tt-llama` downloads weights (slow first run), compiles TT-Metal kernels (cached on the hostPath), and serves on :8000 via KubeAI → LiteLLM (`ai.i.shion1305.com`).

## Verification

- `scripts/render-validate.sh` → **EXIT=0**.
- Official image pulled & inspected on s2605 (16.6GB); entrypoint + `run_vllm_api_server.py` env requirements (`TT_CACHE_PATH`, `MODEL_WEIGHTS_DIR`/`CACHE_ROOT`, `HF_TOKEN`) confirmed against the wiring.
- Host single-container launch reaches the HF-token wall (the only gate) — everything before it is in place.