### PR TITLE
fix(scalable-llm): lower Llama model memory request 48Gi→32Gi

### DIFF
--- a/scalable-llm/kubeai-values.yaml
+++ b/scalable-llm/kubeai-values.yaml
@@ -32,7 +32,9 @@ resourceProfiles:
     requests:
       squat.io/tenstorrent: "1"
       cpu: "4"
-      memory: "48Gi" # headroom for the 8B host-side weight load + TT runtime
+      # 8B BF16 weights ≈ 16GB + TT runtime. 32Gi fits the node's ~50Gi
+      # allocatable alongside the existing pods; 48Gi did not (Insufficient memory).
+      memory: "32Gi"
     # shion-ubuntu-2605 carries no TT-specific taint today. If one is added,
     # mirror it here (confirm with `kubectl describe node shion-ubuntu-2605`):
     # tolerations:


### PR DESCRIPTION
Follow-up to #410. The HF token is now in Vault and `model-tt-llama` schedules onto the device — but stays **Pending** with `Insufficient memory`.

## Cause

#410 set the `tenstorrent-blackhole` profile memory **request to 48Gi**. Node `shion-ubuntu-2605` has ~50Gi allocatable, and existing pods already request ~7.4Gi → 48 + 7.4 > 50, so the scheduler can't place it.

## Fix

Lower the request to **32Gi**. Llama-3.1-8B BF16 weights are ~16GB; 32Gi covers them + the TT runtime and fits alongside the node's other workloads.

## Verification

- `scripts/render-validate.sh` → EXIT=0.
- Confirmed live: device-plugin now advertises `squat.io/tenstorrent: 2`; the only scheduling blocker is this memory request.

After merge, `model-tt-llama` should schedule onto a p150 card and begin the weight download + TT-Metal compile.