### PR TITLE
fix(scalable-llm): grant DAC_OVERRIDE so the TT model pod can start

### DIFF
--- a/scalable-llm/kubeai-values.yaml
+++ b/scalable-llm/kubeai-values.yaml
@@ -62,6 +62,13 @@ modelServerPods:
     capabilities:
       drop:
         - ALL
+      # The TT image runs as root and writes runtime dirs it owns as
+      # container_app_user (tt-metal/generated, logs/generated). Dropping ALL
+      # also drops CAP_DAC_OVERRIDE, so root loses its permission-bypass and the
+      # engine crashes with "Permission denied" creating those dirs. Add back
+      # only DAC_OVERRIDE — the one cap needed — keeping the rest dropped.
+      add:
+        - DAC_OVERRIDE
   # NOTE: `add /spec/volumes/-` (append) requires spec.volumes to already exist.
   # KubeAI's vLLM engine always adds a `dshm` volume + the server container's
   # volumeMount, so both arrays exist on every model Pod and these appends are


### PR DESCRIPTION
After #412 merged, the in-cluster `model-tt-llama` pod crashlooped (5 restarts) at engine init — the docker smoke test never hit this because it ran as unrestricted root.

## Root cause

The MeshDevice opens fine (`Inter-mesh mapping succeeded`), then the TT runtime fails to create its runtime dirs:

```
Permission denied [/home/container_app_user/tt-metal/generated/fabric]
Permission denied [/home/container_app_user/logs/generated/inspector]
→ RuntimeError: Engine core initialization failed
```

The TT image runs **as root** but writes dirs it owns as `container_app_user`. KubeAI's `modelServerPods.securityContext` drops **ALL** caps, which removes **`CAP_DAC_OVERRIDE`** — the cap that lets root bypass file permissions. Without it, even root gets "Permission denied".

## Fix

Add back only `DAC_OVERRIDE`, keeping everything else dropped (minimal relaxation, not full privilege).

Reproduced and verified on s2605:
- `docker run --cap-drop ALL` → `mkdir generated` **fails**
- `docker run --cap-drop ALL --cap-add DAC_OVERRIDE` → **succeeds**

## Verification
- `scripts/render-validate.sh` → EXIT=0; rendered securityContext shows `drop: [ALL]` + `add: [DAC_OVERRIDE]`.

After merge the model pod should pass engine init and proceed to weight download + compile (first start, ~minutes), then serve. This unblocks the benchmarking/scale work.