### PR TITLE
fix(scalable-llm): run TT model pod as uid 1000 instead of root DAC_OVERRIDE

### DIFF
--- a/scalable-llm/README.md
+++ b/scalable-llm/README.md
@@ -74,8 +74,11 @@ tt-smi                                              # expect 2x Blackhole
 tt-topology                                         # configure + verify the 2-card mesh
 ls -l /dev/tenstorrent/ /dev/tenstorrent/by-id/     # devices 0 and 1
 
-# Pre-create the node-local TT compile/weights cache (mounted by every model Pod)
-sudo mkdir -p /var/local-storage/tt-cache && sudo chmod 1777 /var/local-storage/tt-cache
+# Pre-create the node-local TT compile/weights cache (mounted by every model Pod).
+# Owned by uid 1000 because the model Pod runs as the TT image's container_app_user
+# (uid 1000) with ALL caps dropped — it must be able to write here. Use chown -R
+# so any root-owned leftovers from a docker smoke test don't block writes.
+sudo mkdir -p /var/local-storage/tt-cache && sudo chown -R 1000:1000 /var/local-storage/tt-cache
 ```
 
 ### Phase 1-3 — cluster side (from your kubectl host)

--- a/scalable-llm/kubeai-values.yaml
+++ b/scalable-llm/kubeai-values.yaml
@@ -56,19 +56,25 @@ modelServers:
 # PoC pins Pods to shion-ubuntu-2605, these patches only ever land on the TT
 # node. They attach the TT compile/program cache and the device directory.
 modelServerPods:
+  # The TT image is built so its files (tt-metal, logs, app) are owned by
+  # container_app_user (uid 1000), even though its default USER is root. KubeAI
+  # drops ALL caps, which also drops CAP_DAC_OVERRIDE — so the default root user
+  # loses its permission-bypass and the engine crashes with "Permission denied"
+  # creating tt-metal/generated and logs/generated.
+  #
+  # Run as the image's own uid 1000 instead: it owns those dirs, so no extra cap
+  # is needed and the container stays non-root with ALL caps dropped (tighter
+  # than re-adding DAC_OVERRIDE to root). The hostPath cache must then be
+  # writable by uid 1000 — done out-of-band on the host (see README):
+  #   sudo chown -R 1000:1000 /var/local-storage/tt-cache
   securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
     readOnlyRootFilesystem: false
     allowPrivilegeEscalation: false
     capabilities:
       drop:
         - ALL
-      # The TT image runs as root and writes runtime dirs it owns as
-      # container_app_user (tt-metal/generated, logs/generated). Dropping ALL
-      # also drops CAP_DAC_OVERRIDE, so root loses its permission-bypass and the
-      # engine crashes with "Permission denied" creating those dirs. Add back
-      # only DAC_OVERRIDE — the one cap needed — keeping the rest dropped.
-      add:
-        - DAC_OVERRIDE
   # NOTE: `add /spec/volumes/-` (append) requires spec.volumes to already exist.
   # KubeAI's vLLM engine always adds a `dshm` volume + the server container's
   # volumeMount, so both arrays exist on every model Pod and these appends are


### PR DESCRIPTION
Supersedes the approach merged in #413. Same root cause, cleaner fix — and it's what addresses the "can't we fix this via host-side permissions instead?" question.

## Why change #413's approach

#413 re-added `CAP_DAC_OVERRIDE` so the **root** user could bypass file permissions. That works, but running the pod as root is a weaker posture than necessary. The TT image's files (`tt-metal`, `logs`) are owned by **`container_app_user` (uid 1000)** — so we can just run as that user, no caps needed.

## Fix

- `securityContext`: `runAsUser: 1000`, `runAsGroup: 1000`, keep `drop: [ALL]`, **remove** the `add: [DAC_OVERRIDE]`. Container is now **non-root with all caps dropped** — tighter than #413.
- The node-local hostPath cache must be writable by uid 1000, so chown it on the host (the host-side permission change):
  ```
  sudo chown -R 1000:1000 /var/local-storage/tt-cache
  ```
  `-R` clears any root-owned leftovers from earlier docker smoke tests (which was the one gotcha — a stale root-owned `huggingface/` subdir blocked writes until chowned recursively). Documented in the README.

## Verification (on s2605)

| run | generated dirs | hostPath cache |
|-----|----------------|----------------|
| `--cap-drop ALL` (root) | ❌ Permission denied | — |
| `--cap-drop ALL --cap-add DAC_OVERRIDE` (root, = #413) | ✅ | ✅ |
| **`--user 1000 --cap-drop ALL`** + host chown -R | ✅ | ✅ |

- `scripts/render-validate.sh` → EXIT=0; rendered securityContext shows `runAsUser: 1000` + `drop: [ALL]`, no cap add.

After merge + the host chown (already applied on s2605), the model pod should pass engine init → weight download + compile → serve, unblocking benchmarking/scale.