### PR TITLE
feat(scalable-llm): 2-replica horizontal scale + benchmark tooling

### DIFF
--- a/scalable-llm/README.md
+++ b/scalable-llm/README.md
@@ -166,9 +166,40 @@ curl https://ai.i.shion1305.com/v1/chat/completions \
   -d '{"model":"tt-llama","messages":[{"role":"user","content":"hello"}]}'
 ```
 
-Cold-start (`minReplicas: 0`) measurement, latency/throughput baseline, and the
-prefix-aware LB question are deferred to Phase 7; the PoC ships warm
-(`minReplicas: 1`) so weight load + TT-Metal compile stays off the request path.
+## Benchmarking & scale (Phase 7)
+
+Two dependency-free load tools live in `bench/`:
+
+```bash
+kubectl -n scalable-llm port-forward svc/kubeai 8000:80 &
+# throughput / latency sweep across concurrency levels
+python3 scalable-llm/bench/llm_bench.py --base-url http://localhost:8000/openai/v1 \
+    --model tt-llama --concurrency 1 8 16 32 --requests-per-level 16 --max-tokens 128
+# scale-from-zero cold start (run when at 0 replicas)
+python3 scalable-llm/bench/coldstart.py --base-url http://localhost:8000/openai/v1 --model tt-llama
+```
+
+Measured on one **p150a** card (Llama-3.1-8B-Instruct, BF16):
+
+| concurrency | TTFT med | agg tok/s | note |
+|-------------|----------|-----------|------|
+| 1  | 170 ms | 28  | single-stream |
+| 16 | 930 ms | ~212 | **saturation** (continuous batching full) |
+| 32 | 980 ms | ~212 | flat — batch is full |
+| 128 | 14 s | ~250 | TTFT explodes; 0 errors (requests queue, don't drop) |
+
+So one card saturates around **concurrency 16 / ~212 tok/s**; beyond that TTFT grows
+while throughput is flat — the signal to scale out to the second card.
+
+**Cold start:** first ever start ~10 min (16 GB weight download + TT-Metal compile).
+Subsequent starts reuse the hostPath cache — checkpoint load <1 s, full warmup
+~2–2.5 min. This is what makes warm (`minReplicas: 1`) cheap to keep and
+scale-from-zero viable.
+
+**Horizontal scale:** the node has two cards, so `maxReplicas: 2` lets KubeAI run
+a replica per card under load. The memory request is **8Gi** (a replica uses only
+~3.3Gi of host RAM — weights live in card VRAM); the old 32Gi request was ~10×
+reality and blocked the second replica from scheduling (2×32Gi > the node's ~52Gi).
 
 ## Network model
 

--- a/scalable-llm/bench/.gitignore
+++ b/scalable-llm/bench/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/scalable-llm/bench/coldstart.py
+++ b/scalable-llm/bench/coldstart.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Measure scale-from-zero cold start for a KubeAI model.
+
+Sends one chat request to a model that may be scaled to zero and reports the
+wall time until the first token arrives. KubeAI holds (does not drop) the request
+while it spins up a replica, so this captures: pod schedule + weight load (from
+the persistent cache) + TT-Metal compile (from cache) + warmup + first decode.
+
+Run it when the model is at zero replicas to get the true cold start; run it
+again immediately after (warm) to get the baseline to subtract.
+
+Usage:
+  kubectl -n scalable-llm port-forward svc/kubeai 8000:80 &
+  python3 scalable-llm/bench/coldstart.py \
+      --base-url http://localhost:8000/openai/v1 --model tt-llama
+"""
+import argparse
+import json
+import time
+import urllib.request
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base-url", required=True)
+    ap.add_argument("--model", default="tt-llama")
+    ap.add_argument("--api-key", default=None)
+    ap.add_argument("--max-tokens", type=int, default=16)
+    ap.add_argument("--timeout", type=int, default=900)
+    args = ap.parse_args()
+
+    body = json.dumps({
+        "model": args.model,
+        "messages": [{"role": "user", "content": "Say hi."}],
+        "max_tokens": args.max_tokens,
+        "stream": True,
+    }).encode()
+    headers = {"Content-Type": "application/json"}
+    if args.api_key:
+        headers["Authorization"] = f"Bearer {args.api_key}"
+    req = urllib.request.Request(
+        args.base_url.rstrip("/") + "/chat/completions", data=body, headers=headers
+    )
+
+    print(f"# sending one request to {args.model} (cold start if at 0 replicas)...")
+    start = time.perf_counter()
+    first = None
+    out = 0
+    with urllib.request.urlopen(req, timeout=args.timeout) as resp:
+        for raw in resp:
+            line = raw.decode("utf-8", "ignore").strip()
+            if not line.startswith("data:"):
+                continue
+            payload = line[len("data:"):].strip()
+            if payload == "[DONE]":
+                break
+            try:
+                chunk = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            delta = chunk.get("choices", [{}])[0].get("delta", {})
+            if delta.get("content"):
+                if first is None:
+                    first = time.perf_counter() - start
+                out += 1
+    total = time.perf_counter() - start
+    print(f"time_to_first_token_s : {first:.1f}" if first else "no tokens")
+    print(f"total_s               : {total:.1f}")
+    print(f"output_tokens         : {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scalable-llm/bench/llm_bench.py
+++ b/scalable-llm/bench/llm_bench.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Minimal dependency-free load benchmark for an OpenAI-compatible endpoint.
+
+Measures TTFT (time to first token, via streaming), end-to-end latency, output
+tokens/sec, and aggregate throughput across a sweep of concurrency levels. Uses
+only the Python stdlib so it runs anywhere (no aiohttp/httpx needed).
+
+Usage (against KubeAI via port-forward):
+  kubectl -n scalable-llm port-forward svc/kubeai 8000:80 &
+  python3 scalable-llm/bench/llm_bench.py \
+      --base-url http://localhost:8000/openai/v1 \
+      --model tt-llama \
+      --concurrency 1 2 4 8 \
+      --requests-per-level 16 \
+      --max-tokens 128
+
+Through LiteLLM instead (needs the master key):
+  --base-url https://ai.i.shion1305.com/v1 --api-key sk-...
+"""
+import argparse
+import json
+import statistics
+import threading
+import time
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+
+PROMPT = (
+    "Explain, in a few sentences, what a Kubernetes operator is and why it is "
+    "useful. Then give one concrete example."
+)
+
+
+def stream_one(base_url, model, api_key, max_tokens, prompt):
+    """Fire one streaming chat completion. Returns (ttft, total, out_tokens) or raises."""
+    body = json.dumps(
+        {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": max_tokens,
+            "temperature": 0.7,
+            "stream": True,
+        }
+    ).encode()
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    req = urllib.request.Request(
+        base_url.rstrip("/") + "/chat/completions", data=body, headers=headers
+    )
+    start = time.perf_counter()
+    ttft = None
+    out_tokens = 0
+    with urllib.request.urlopen(req, timeout=600) as resp:
+        for raw in resp:
+            line = raw.decode("utf-8", "ignore").strip()
+            if not line.startswith("data:"):
+                continue
+            payload = line[len("data:"):].strip()
+            if payload == "[DONE]":
+                break
+            try:
+                chunk = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            delta = chunk.get("choices", [{}])[0].get("delta", {})
+            if delta.get("content"):
+                if ttft is None:
+                    ttft = time.perf_counter() - start
+                out_tokens += 1
+    total = time.perf_counter() - start
+    if ttft is None:
+        ttft = total
+    return ttft, total, out_tokens
+
+
+def run_level(base_url, model, api_key, max_tokens, concurrency, n_requests):
+    """Run n_requests through `concurrency` workers; return aggregate stats."""
+    results = []
+    errors = []
+    lock = threading.Lock()
+
+    def task(_):
+        try:
+            r = stream_one(base_url, model, api_key, max_tokens, PROMPT)
+            with lock:
+                results.append(r)
+        except Exception as e:  # noqa: BLE001 - benchmark, report and continue
+            with lock:
+                errors.append(str(e))
+
+    wall_start = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=concurrency) as ex:
+        list(ex.map(task, range(n_requests)))
+    wall = time.perf_counter() - wall_start
+
+    if not results:
+        return {"concurrency": concurrency, "ok": 0, "errors": len(errors),
+                "sample_error": errors[0] if errors else ""}
+
+    ttfts = [r[0] for r in results]
+    totals = [r[1] for r in results]
+    toks = [r[2] for r in results]
+    total_out = sum(toks)
+    # per-request decode tokens/sec (excludes ttft)
+    tps = [t / max(tot - ttf, 1e-6) for (ttf, tot, t) in results if t > 0]
+
+    def p(vals, q):
+        return statistics.quantiles(vals, n=100)[q - 1] if len(vals) > 1 else vals[0]
+
+    return {
+        "concurrency": concurrency,
+        "ok": len(results),
+        "errors": len(errors),
+        "ttft_ms_med": round(statistics.median(ttfts) * 1000, 1),
+        "ttft_ms_p95": round(p(ttfts, 95) * 1000, 1),
+        "latency_s_med": round(statistics.median(totals), 2),
+        "latency_s_p95": round(p(totals, 95), 2),
+        "decode_tps_med": round(statistics.median(tps), 1) if tps else 0,
+        "agg_out_tps": round(total_out / wall, 1),
+        "wall_s": round(wall, 1),
+        "sample_error": errors[0] if errors else "",
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base-url", required=True, help="OpenAI base, e.g. http://localhost:8000/openai/v1")
+    ap.add_argument("--model", default="tt-llama")
+    ap.add_argument("--api-key", default=None)
+    ap.add_argument("--concurrency", type=int, nargs="+", default=[1, 2, 4, 8])
+    ap.add_argument("--requests-per-level", type=int, default=16)
+    ap.add_argument("--max-tokens", type=int, default=128)
+    args = ap.parse_args()
+
+    print(f"# endpoint={args.base_url} model={args.model} max_tokens={args.max_tokens}")
+    print(f"# requests_per_level={args.requests_per_level}")
+    cols = ["concurrency", "ok", "errors", "ttft_ms_med", "ttft_ms_p95",
+            "latency_s_med", "latency_s_p95", "decode_tps_med", "agg_out_tps", "wall_s"]
+    print("\t".join(cols))
+    rows = []
+    for c in args.concurrency:
+        stats = run_level(args.base_url, args.model, args.api_key,
+                          args.max_tokens, c, args.requests_per_level)
+        rows.append(stats)
+        print("\t".join(str(stats.get(k, "")) for k in cols))
+        if stats.get("sample_error"):
+            print(f"  # sample error @ c={c}: {stats['sample_error'][:160]}")
+    # scaling summary: aggregate throughput vs concurrency
+    print("\n# scaling (aggregate output tokens/sec):")
+    base = next((r["agg_out_tps"] for r in rows if r["concurrency"] == args.concurrency[0] and r["ok"]), None)
+    for r in rows:
+        if r.get("ok"):
+            factor = f"{r['agg_out_tps']/base:.2f}x" if base else "-"
+            print(f"  c={r['concurrency']:>3}: {r['agg_out_tps']:>7} tok/s  ({factor} vs c={args.concurrency[0]})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scalable-llm/kubeai-values.yaml
+++ b/scalable-llm/kubeai-values.yaml
@@ -32,9 +32,12 @@ resourceProfiles:
     requests:
       squat.io/tenstorrent: "1"
       cpu: "4"
-      # 8B BF16 weights ≈ 16GB + TT runtime. 32Gi fits the node's ~50Gi
-      # allocatable alongside the existing pods; 48Gi did not (Insufficient memory).
-      memory: "32Gi"
+      # The model weights load into the CARD's VRAM, not host RAM — a running
+      # replica uses only ~3.3Gi of node memory (measured via kubectl top). The
+      # old 32Gi request was ~10x reality and blocked a 2nd replica from
+      # scheduling (2×32Gi > the node's ~52Gi). 8Gi gives ample headroom and lets
+      # both p150a cards run a replica for horizontal scale.
+      memory: "8Gi"
     # shion-ubuntu-2605 carries no TT-specific taint today. If one is added,
     # mirror it here (confirm with `kubectl describe node shion-ubuntu-2605`):
     # tolerations:

--- a/scalable-llm/models/tt-llama.yaml
+++ b/scalable-llm/models/tt-llama.yaml
@@ -32,10 +32,14 @@ spec:
 
   image: "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.0-555f240-22be241"
 
-  # PoC runs warm so the TT-Metal compile + weight load stays off the request
-  # path. With two cards available, maxReplicas: 2 is possible later.
+  # PoC runs warm (minReplicas 1) so the TT-Metal compile + weight load stays off
+  # the request path. The node has two p150a cards, so scale out to a second
+  # replica (the second card) under load. targetRequests is the per-replica
+  # in-flight target before KubeAI adds a replica; TT serves a small batch, so
+  # keep it low (default 100 would never scale here).
   minReplicas: 1
-  maxReplicas: 1
+  maxReplicas: 2
+  targetRequests: 4
 
   env:
     # The tenstorrent/vllm fork asserts HF_MODEL (separately from --model) and a


### PR DESCRIPTION
Benchmarked the in-cluster model and enabled horizontal scale to the second card.

## Benchmark results (one p150a, Llama-3.1-8B-Instruct, BF16)

| concurrency | TTFT med | agg tok/s | note |
|---|---|---|---|
| 1 | 170 ms | 28 | single-stream |
| 16 | 930 ms | **~212** | saturation (continuous batching full) |
| 32 | 980 ms | ~212 | flat |
| 128 | 14 s | ~250 | TTFT explodes; **0 errors** (requests queue, not dropped) |

One card saturates at **~concurrency 16 / ~212 tok/s**; past that, TTFT grows while throughput is flat → the signal to scale out.

**Cold start:** first ever ~10 min (16 GB download + TT-Metal compile); subsequent starts reuse the hostPath cache — checkpoint load <1 s, full warmup ~2–2.5 min. Verified live: the 2nd replica skipped the download entirely (`Loading checkpoint shards: 100% [00:00, 386 it/s]`).

## The scale-out blocker (found & fixed)

The memory request was **32Gi** on the (wrong) assumption that 8B BF16 weights need ~16GB host RAM. They don't — weights load into the **card's VRAM**; a running replica uses only **~3.3Gi** of node memory (`kubectl top`). At 32Gi a 2nd replica couldn't schedule (2×32Gi > the node's ~52Gi → `Insufficient memory`, Pending). **Lowering to 8Gi let the 2nd replica schedule and run** — verified live (both pods `mem=8Gi`, both assigned to the node).

## Changes

- `kubeai-values.yaml`: memory request **32Gi → 8Gi**.
- `models/tt-llama.yaml`: `maxReplicas` **1 → 2**, `targetRequests` **100 → 4** (TT serves a small batch; default 100 would never trigger scale-out).
- `bench/`: `llm_bench.py` (concurrency sweep: TTFT, latency, decode tps, aggregate throughput) and `coldstart.py` (scale-from-zero TTFT) — stdlib-only, no deps.
- `README`: results, saturation point, cold-start timings, memory/scale rationale.

## Verification

- `scripts/render-validate.sh` → EXIT=0.
- Single-replica baseline + saturation measured live (table above).
- 2nd replica confirmed to **schedule and warm from cache** once memory was 8Gi (ArgoCD selfHeal reverts live patches, so the clean 2-replica throughput number needs this merged — I'll re-run the scaling benchmark after merge and post the 1-vs-2 replica numbers).