### PR TITLE
feat(scalable-llm): card-arbiter to share 2 TT cards across models

### DIFF
--- a/apps/scalable-llm-app.yaml
+++ b/apps/scalable-llm-app.yaml
@@ -8,6 +8,18 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: scalable-llm
+  # The card-arbiter (scalable-llm/card-arbiter) evicts an idle model to free a
+  # Tenstorrent card for a waiting model by patching Model maxReplicas (and KubeAI
+  # then rewrites replicas). Those fields are managed live at runtime, so exclude
+  # them from self-heal — otherwise ArgoCD reverts the patch within seconds and
+  # the arbiter can never free a card. The git value of maxReplicas stays the
+  # normal-operation ceiling that the arbiter restores to.
+  ignoreDifferences:
+    - group: kubeai.org
+      kind: Model
+      jqPathExpressions:
+        - '.spec.maxReplicas'
+        - '.spec.replicas'
   syncPolicy:
     automated:
       prune: true

--- a/scalable-llm/README.md
+++ b/scalable-llm/README.md
@@ -39,7 +39,9 @@ scalable-llm/
 ├── device-plugin.yaml      # generic-device-plugin: 1 card = 1 unit -> squat.io/tenstorrent:2
 ├── kubeai-values.yaml      # KubeAI Helm values: resourceProfile + tt image + cache/HF/hugepages patches
 ├── llama-hf-token.yaml     # ESO: Vault scalable-llm/llama → HF_TOKEN Secret (gated Llama-3.1-8B)
-├── models/tt-llama.yaml    # KubeAI Model: Llama-3.1-8B on one p150 card
+├── models/tt-llama.yaml    # KubeAI Model: Llama-3.1-8B on one p150 card (warm primary, max 2)
+├── models/tt-llama-b.yaml  # KubeAI Model: same Llama-3.1-8B, second name (sleep-mode, max 1)
+├── card-arbiter/           # frees an idle model's card for a model waiting on one
 └── litellm/                # LiteLLM front + DB (shared Postgres) + Vault key + HTTPRoute
 ```
 
@@ -200,6 +202,53 @@ scale-from-zero viable.
 a replica per card under load. The memory request is **8Gi** (a replica uses only
 ~3.3Gi of host RAM — weights live in card VRAM); the old 32Gi request was ~10×
 reality and blocked the second replica from scheduling (2×32Gi > the node's ~52Gi).
+
+## Multi-model card sharing (card-arbiter)
+
+The goal is to host several models that mostly sleep (`minReplicas: 0`) and run
+1–2 at a time on the 2 cards, scaling by load. The hard part: **KubeAI has no
+global accelerator arbitration** (verified against v0.23.2). It autoscales every
+Model independently — desired replicas = `ceil(avgActiveRequests / targetRequests)`
+clamped to that model's min/max, with no awareness of free cards or other models.
+So when both cards are busy and a third model gets a request, its Pod sits
+`Pending` (Insufficient `squat.io/tenstorrent`) forever; KubeAI never scales
+another model down to make room. Its only priority lever, `priorityClassName`,
+delegates to the Kubernetes scheduler, which preempts by *priority* and is blind
+to *idleness* — it would evict a low-priority pod that is actively serving and
+never evict an equal-priority idle one. That does not match the requirement.
+
+`card-arbiter/` is a small single-replica controller that closes the gap. Each
+tick (~5s) it reads:
+
+- **Pending-for-card model Pods** (the waiters), from the pod list.
+- **Card-holders** (Running model Pods) and the node's card capacity.
+- **Per-model in-flight requests**, parsed from the KubeAI controller's own log
+  line (`current requests: sum([N])`) — KubeAI exposes no metrics endpoint, but
+  it prints this every autoscale interval.
+
+When a model needs a card and none is free, it evicts the **idlest** holder
+(longest with `sum==0`, i.e. LRU) by patching that Model's `maxReplicas` to 0.
+KubeAI's own autoscaler then scales it to 0 and releases the card; the waiter
+schedules. When the pressure clears, the holder's `maxReplicas` is restored.
+
+Why `maxReplicas`, not `spec.replicas`: KubeAI owns `spec.replicas` and rewrites
+it every loop, but it clamps its target to `maxReplicas`, so pinning that to 0
+sticks. ArgoCD self-heal would otherwise revert the live patch within seconds, so
+`apps/scalable-llm-app.yaml` lists Model `spec.maxReplicas`/`spec.replicas` under
+`ignoreDifferences`; the git value of `maxReplicas` stays the normal-operation
+ceiling the arbiter restores to.
+
+Guards: a holder must be idle ≥ `IDLE_GRACE` (60s) before it's evictable (so a
+bursty-but-active client isn't cut off between requests), and an evicted holder
+stays pinned ≥ `EVICT_HOLD` (120s) so the freed card is actually taken by the
+waiter before it can reclaim. The arbiter talks to the API server directly with
+its ServiceAccount token (no kubectl; image is plain `python:alpine`).
+
+> Hardware note: the single p150 officially serves only **Llama-3.1-8B**
+> (tenstorrent/tt-inference-server model support matrix). `tt-llama-b` is the
+> same model under a second name — a distinct Model that competes for a card,
+> which is what the arbiter arbitrates. Swap in genuinely different models here
+> once the TT stack supports more on a single Blackhole card.
 
 ## Network model
 

--- a/scalable-llm/card-arbiter/.gitignore
+++ b/scalable-llm/card-arbiter/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/scalable-llm/card-arbiter/arbiter.py
+++ b/scalable-llm/card-arbiter/arbiter.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Card-arbiter: free a Tenstorrent card for a model that is waiting on one.
+
+KubeAI autoscales every Model independently and has no global accelerator
+arbitration (verified against KubeAI v0.23.2). With N cards and more than N
+Models that can each want a card, a Model whose request arrives when all cards
+are busy gets a Pod stuck Pending (Insufficient squat.io/tenstorrent) forever —
+KubeAI never scales another Model down to make room.
+
+This controller closes that gap. Each tick it asks: is some Model's Pod Pending
+for a card while every card is held, and is one of the card-holding Models
+idle (no in-flight requests)? If so it evicts the *idlest* holder (LRU) by
+pinning its maxReplicas to 0, which makes KubeAI's own autoscaler scale it to 0
+and release the card; the waiting Pod then schedules. When the pressure clears
+the holder's maxReplicas is restored so it can serve again.
+
+Idleness comes from KubeAI's own per-model in-flight count, which the autoscaler
+prints every interval (KubeAI exposes no metrics endpoint):
+    Calculated target replicas for model "X": ceil(0/4) = 0, current requests: sum([0]) = 0
+The `sum([...])` is the live in-flight request total for that model.
+
+Actuation is maxReplicas (not spec.replicas): KubeAI owns spec.replicas and
+rewrites it every loop, but it clamps its target to maxReplicas, so 0 sticks.
+ArgoCD self-heal would otherwise revert the live patch, so the scalable-llm app
+lists Model spec.maxReplicas/replicas under ignoreDifferences.
+
+Talks to the Kubernetes API directly over HTTPS with the in-cluster
+ServiceAccount token — no kubectl, so the image is plain python:alpine. All
+state is in-memory and re-derived each tick; a restart re-derives it.
+"""
+
+import json
+import os
+import re
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+NS = os.environ.get("ARBITER_NAMESPACE", "scalable-llm")
+# The extended resource one card is advertised as (device-plugin.yaml).
+CARD_RESOURCE = os.environ.get("ARBITER_CARD_RESOURCE", "squat.io/tenstorrent")
+# The node that carries the cards; total capacity is read from its allocatable.
+CARD_NODE = os.environ.get("ARBITER_CARD_NODE", "shion-ubuntu-2605")
+# KubeAI controller pods carry the per-model in-flight counts in their log.
+KUBEAI_SELECTOR = os.environ.get(
+    "ARBITER_KUBEAI_SELECTOR", "app.kubernetes.io/name=kubeai"
+)
+# Poll period. The reaction floor is one tick; cold start is ~140s, so a few
+# seconds of arbiter latency is noise against that.
+INTERVAL = float(os.environ.get("ARBITER_INTERVAL_SECONDS", "5"))
+# A holder must have read sum==0 for this long before it is evictable. Guards
+# against evicting a model between two requests of a bursty-but-active client.
+IDLE_GRACE = float(os.environ.get("ARBITER_IDLE_GRACE_SECONDS", "60"))
+# After eviction, keep maxReplicas pinned at 0 at least this long so the freed
+# card is actually consumed by the waiter before the victim can reclaim it.
+EVICT_HOLD = float(os.environ.get("ARBITER_EVICT_HOLD_SECONDS", "120"))
+# How many log lines to scan for the latest per-model in-flight counts.
+LOG_TAIL_LINES = os.environ.get("ARBITER_LOG_TAIL_LINES", "40")
+
+API = "https://kubernetes.default.svc"
+SA = "/var/run/secrets/kubernetes.io/serviceaccount"
+
+# `sum([12, 0, 3]) = 15` from the autoscaler line — capture the model name and
+# the bracketed list; we sum it ourselves rather than trust the printed total.
+_SUM_RE = re.compile(
+    r'Calculated target replicas for model "([^"]+)".*current requests: sum\(\[([^\]]*)\]\)'
+)
+
+
+def log(msg):
+    print(f"[arbiter] {msg}", flush=True)
+
+
+def _token():
+    with open(f"{SA}/token") as f:
+        return f.read().strip()
+
+
+_ssl_ctx = None
+
+
+def _ssl_context():
+    # Built lazily, not at import, so the module imports off-cluster (where the
+    # SA cert is absent) — keeps the logic unit-testable and avoids a crash if
+    # the cert is briefly unreadable at startup.
+    global _ssl_ctx
+    if _ssl_ctx is None:
+        _ssl_ctx = ssl.create_default_context(cafile=f"{SA}/ca.crt")
+    return _ssl_ctx
+
+
+def api(path, method="GET", body=None, content_type="application/json", raw=False):
+    """Call the in-cluster Kubernetes API. Returns parsed JSON, or text if raw."""
+    url = API + path
+    data = None
+    headers = {"Authorization": f"Bearer {_token()}", "Accept": "application/json"}
+    if body is not None:
+        data = body if isinstance(body, bytes) else json.dumps(body).encode()
+        headers["Content-Type"] = content_type
+    if raw:
+        headers["Accept"] = "*/*"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(req, timeout=15, context=_ssl_context()) as resp:
+        text = resp.read().decode("utf-8", "replace")
+    return text if raw else json.loads(text)
+
+
+def card_capacity():
+    """Total cards advertised by the node (allocatable). 0 if unreadable."""
+    try:
+        node = api(f"/api/v1/nodes/{CARD_NODE}")
+        return int(node.get("status", {}).get("allocatable", {}).get(CARD_RESOURCE, 0))
+    except Exception as e:
+        log(f"card_capacity error: {e!r}")
+        return 0
+
+
+def model_pods():
+    """KubeAI model Pods in the namespace: list of (model, phase, reason)."""
+    sel = urllib.parse.quote("app.kubernetes.io/managed-by=kubeai")
+    try:
+        data = api(f"/api/v1/namespaces/{NS}/pods?labelSelector={sel}")
+    except Exception as e:
+        log(f"model_pods error: {e!r}")
+        return []
+    pods = []
+    for p in data.get("items", []):
+        model = p["metadata"].get("labels", {}).get("model")
+        if not model:
+            continue
+        phase = p.get("status", {}).get("phase", "")
+        reason = ""
+        for c in p.get("status", {}).get("conditions", []):
+            if c.get("type") == "PodScheduled" and c.get("status") == "False":
+                reason = (c.get("reason", "") or "") + ":" + (c.get("message", "") or "")
+        pods.append((model, phase, reason))
+    return pods
+
+
+def in_flight_by_model():
+    """Per-model live in-flight request count, parsed from the KubeAI log tail."""
+    sel = urllib.parse.quote(KUBEAI_SELECTOR)
+    try:
+        data = api(f"/api/v1/namespaces/{NS}/pods?labelSelector={sel}")
+        names = [p["metadata"]["name"] for p in data.get("items", [])]
+    except Exception as e:
+        log(f"kubeai pod lookup error: {e!r}")
+        return {}
+    counts = {}
+    for name in names:
+        try:
+            logs = api(
+                f"/api/v1/namespaces/{NS}/pods/{name}/log?tailLines={LOG_TAIL_LINES}",
+                raw=True,
+            )
+        except Exception as e:
+            log(f"log read error for {name}: {e!r}")
+            continue
+        for m in _SUM_RE.finditer(logs):
+            model, body = m.group(1), m.group(2).strip()
+            nums = [int(x) for x in re.findall(r"-?\d+", body)]
+            counts[model] = sum(nums)  # last (most recent) line for a model wins
+    return counts
+
+
+def model_max_replicas(model):
+    try:
+        m = api(f"/apis/kubeai.org/v1/namespaces/{NS}/models/{model}")
+        v = m.get("spec", {}).get("maxReplicas")
+        return None if v is None else int(v)
+    except Exception as e:
+        log(f"read maxReplicas error for {model}: {e!r}")
+        return None
+
+
+def set_max_replicas(model, value):
+    api(
+        f"/apis/kubeai.org/v1/namespaces/{NS}/models/{model}",
+        method="PATCH",
+        body={"spec": {"maxReplicas": value}},
+        content_type="application/merge-patch+json",
+    )
+
+
+def main():
+    log(
+        f"start ns={NS} resource={CARD_RESOURCE} node={CARD_NODE} "
+        f"interval={INTERVAL}s idle_grace={IDLE_GRACE}s evict_hold={EVICT_HOLD}s"
+    )
+    log(f"card capacity = {card_capacity()}")
+
+    # model -> monotonic time it was first observed idle (reset whenever busy).
+    idle_since = {}
+    # model -> (original maxReplicas, monotonic time pinned) for evicted holders.
+    evicted = {}
+
+    while True:
+        try:
+            tick(idle_since, evicted)
+        except Exception as e:  # never let one bad tick kill the loop
+            log(f"tick error: {e!r}")
+        time.sleep(INTERVAL)
+
+
+def tick(idle_since, evicted):
+    now = time.monotonic()
+    capacity = card_capacity()
+    pods = model_pods()
+    inflight = in_flight_by_model()
+
+    running = [m for (m, phase, _) in pods if phase == "Running"]
+    pending_for_card = [
+        m for (m, phase, reason) in pods
+        if phase == "Pending" and (
+            "Insufficient" in reason or CARD_RESOURCE in reason
+        )
+    ]
+    # Cards in use = running model pods (one card each). Pending pods hold none.
+    free_cards = capacity - len(running)
+
+    # Track idleness for every running holder.
+    for m in running:
+        if inflight.get(m, 0) > 0:
+            idle_since.pop(m, None)
+        else:
+            idle_since.setdefault(m, now)
+    # Drop idleness state for models no longer running.
+    for m in list(idle_since):
+        if m not in running:
+            idle_since.pop(m, None)
+
+    # Restore any evicted holder once pressure is gone and the hold has elapsed.
+    for m in list(evicted):
+        orig, pinned_at = evicted[m]
+        if not pending_for_card and (now - pinned_at) >= EVICT_HOLD:
+            log(f"restore: model={m} maxReplicas 0->{orig} (pressure cleared)")
+            try:
+                set_max_replicas(m, orig)
+                evicted.pop(m, None)
+            except Exception as e:
+                log(f"restore failed for {m}: {e!r}")
+
+    if not pending_for_card:
+        return
+    if free_cards > 0:
+        # A card is free; the scheduler will place the waiter on its own.
+        log(f"waiters={pending_for_card} free_cards={free_cards}; scheduler will place")
+        return
+
+    # Pressure: a model needs a card and none is free. Evictable holders are
+    # running, not already evicted, and idle for >= IDLE_GRACE.
+    candidates = []
+    for m in running:
+        if m in evicted:
+            continue
+        since = idle_since.get(m)
+        if since is None:
+            continue  # currently serving
+        idle_for = now - since
+        if idle_for >= IDLE_GRACE:
+            candidates.append((idle_for, m))
+
+    if not candidates:
+        ages = {k: round(now - v) for k, v in idle_since.items()}
+        log(
+            f"PRESSURE waiters={pending_for_card} free=0 holders={running} "
+            f"— no idle-enough victim (idle_for={ages}); waiting"
+        )
+        return
+
+    # LRU: evict the holder idle the longest.
+    candidates.sort(reverse=True)
+    idle_for, victim = candidates[0]
+    orig = model_max_replicas(victim)
+    if orig is None or orig == 0:
+        log(f"victim={victim} has maxReplicas={orig}; skip")
+        return
+    log(
+        f"EVICT victim={victim} (idle {round(idle_for)}s) maxReplicas {orig}->0 "
+        f"to free a card for {pending_for_card}"
+    )
+    try:
+        set_max_replicas(victim, 0)
+        evicted[victim] = (orig, now)
+    except Exception as e:
+        log(f"evict failed for {victim}: {e!r}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/scalable-llm/card-arbiter/deployment.yaml
+++ b/scalable-llm/card-arbiter/deployment.yaml
@@ -1,0 +1,66 @@
+# Single-replica controller that frees a Tenstorrent card for a model waiting on
+# one, by evicting the idlest card-holder (see arbiter.py for the full rationale).
+# One replica only: two arbiters would race on eviction decisions. Talks to the
+# API server with the card-arbiter ServiceAccount token; no kubectl in the image.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: card-arbiter
+  namespace: scalable-llm
+  labels:
+    app: card-arbiter
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: card-arbiter
+  template:
+    metadata:
+      labels:
+        app: card-arbiter
+    spec:
+      serviceAccountName: card-arbiter
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: arbiter
+          image: python:3.12-alpine
+          command: ["python3", "/app/arbiter.py"]
+          env:
+            - name: ARBITER_NAMESPACE
+              value: scalable-llm
+            - name: ARBITER_CARD_RESOURCE
+              value: squat.io/tenstorrent
+            - name: ARBITER_CARD_NODE
+              value: shion-ubuntu-2605
+            - name: ARBITER_INTERVAL_SECONDS
+              value: "5"
+            - name: ARBITER_IDLE_GRACE_SECONDS
+              value: "60"
+            - name: ARBITER_EVICT_HOLD_SECONDS
+              value: "120"
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          volumeMounts:
+            - name: script
+              mountPath: /app
+              readOnly: true
+      volumes:
+        - name: script
+          configMap:
+            name: card-arbiter-script

--- a/scalable-llm/card-arbiter/kustomization.yaml
+++ b/scalable-llm/card-arbiter/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Stamp the namespace at this layer so the generated ConfigMap shares it with
+# the Deployment — otherwise kustomize sees a namespace mismatch and skips
+# rewriting the volume's configMap name to the hashed name. (Cluster-scoped
+# RBAC in rbac.yaml ignores this.)
+namespace: scalable-llm
+
+resources:
+  - rbac.yaml
+  - deployment.yaml
+
+# The arbiter script ships as a ConfigMap. The generator appends a content hash
+# to the name and rewrites the Deployment's volume reference, so editing
+# arbiter.py rolls the pod automatically.
+configMapGenerator:
+  - name: card-arbiter-script
+    files:
+      - arbiter.py

--- a/scalable-llm/card-arbiter/rbac.yaml
+++ b/scalable-llm/card-arbiter/rbac.yaml
@@ -1,0 +1,65 @@
+# RBAC for the card-arbiter: read model Pods + the KubeAI controller log to
+# judge idleness, read the card node's allocatable capacity, and patch Model
+# maxReplicas to evict/restore an idle card-holder. Namespaced except the node
+# read, which needs a ClusterRole.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: card-arbiter
+  namespace: scalable-llm
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: card-arbiter
+  namespace: scalable-llm
+rules:
+  # Detect Pending model Pods and which models hold a card.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  # Read the KubeAI controller log (the per-model in-flight signal).
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  # Read Model state and patch maxReplicas to evict/restore.
+  - apiGroups: ["kubeai.org"]
+    resources: ["models"]
+    verbs: ["get", "list", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: card-arbiter
+  namespace: scalable-llm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: card-arbiter
+subjects:
+  - kind: ServiceAccount
+    name: card-arbiter
+    namespace: scalable-llm
+---
+# Node allocatable (card capacity) is cluster-scoped — minimal get/list on nodes.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: card-arbiter-node-reader
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: card-arbiter-node-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: card-arbiter-node-reader
+subjects:
+  - kind: ServiceAccount
+    name: card-arbiter
+    namespace: scalable-llm

--- a/scalable-llm/kustomization.yaml
+++ b/scalable-llm/kustomization.yaml
@@ -6,4 +6,6 @@ resources:
   - device-plugin.yaml
   - llama-hf-token.yaml
   - models/tt-llama.yaml
+  - models/tt-llama-b.yaml
+  - card-arbiter
   - litellm

--- a/scalable-llm/litellm/config.yaml
+++ b/scalable-llm/litellm/config.yaml
@@ -17,6 +17,14 @@ data:
           api_base: http://kubeai.scalable-llm.svc.cluster.local/openai/v1
           api_key: "ignored" # KubeAI does not auth; LiteLLM is the gate
           timeout: 600 # large: cold start = weight load + TT-Metal compile (R4)
+      # Second model sharing the 2 cards; the card-arbiter frees a card for it
+      # under contention. Same KubeAI endpoint, distinct served model name.
+      - model_name: tt-llama-b
+        litellm_params:
+          model: openai/tt-llama-b
+          api_base: http://kubeai.scalable-llm.svc.cluster.local/openai/v1
+          api_key: "ignored"
+          timeout: 600
 
     general_settings:
       # Body audit off by default; opt-in with consent (CLAUDE.md: public repo).

--- a/scalable-llm/models/tt-llama-b.yaml
+++ b/scalable-llm/models/tt-llama-b.yaml
@@ -1,0 +1,46 @@
+# Second KubeAI Model, identical to tt-llama, used to exercise multi-model card
+# sharing on the 2-card node. The single p150 officially serves only one LLM —
+# Llama-3.1-8B (tenstorrent/tt-inference-server model support matrix) — so a
+# genuinely different architecture isn't a safe second model on this hardware.
+# Running the SAME proven Llama-3.1-8B under a distinct name is still a distinct
+# Model that competes for a card, which is exactly what the card-arbiter
+# (scalable-llm/card-arbiter) arbitrates: when both cards are busy and this model
+# gets a request, the arbiter evicts the idlest holder to free a card for it.
+#
+# It shares tt-llama's hostPath weight/kernel cache (same weights), so its cold
+# start is the fast cached path. See models/tt-llama.yaml for the full rationale
+# behind every field; this file only differs in metadata.name.
+apiVersion: kubeai.org/v1
+kind: Model
+metadata:
+  name: tt-llama-b # OpenAI `model` name; keep in sync with litellm/config.yaml
+  namespace: scalable-llm
+spec:
+  features: [TextGeneration]
+
+  url: hf://NousResearch/Meta-Llama-3.1-8B-Instruct
+
+  engine: VLLM
+
+  resourceProfile: tenstorrent-blackhole:1
+
+  image: "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.0-555f240-22be241"
+
+  # Sleep-mode by default (scale-to-zero). maxReplicas:1 so it never claims both
+  # cards on its own — in a 2-card / many-model world each model gets at most one
+  # card unless it is the only active one. (tt-llama keeps maxReplicas:2 as the
+  # warm primary; tune per-model as more models are added.)
+  minReplicas: 0
+  maxReplicas: 1
+  targetRequests: 4
+
+  env:
+    HF_MODEL: "NousResearch/Meta-Llama-3.1-8B-Instruct"
+    MESH_DEVICE: "P150"
+    CACHE_ROOT: "/cache/tt"
+    HF_HOME: "/cache/tt/huggingface"
+
+  args:
+    - "--max-num-seqs=32"
+    - "--block-size=64"
+    - "--max-model-len=32768"


### PR DESCRIPTION
## Problem

The multi-model goal is ~5 models hosted in sleep mode (`minReplicas: 0`), 1–2 active at a time on the 2 p150a cards, scaling by load — and **yielding a card to another model on demand**.

KubeAI can't do the last part. Verified against **v0.23.2**: it autoscales every Model independently — desired replicas = `ceil(avgActiveRequests / targetRequests)` clamped to that model's own min/max, with **no awareness of free cards or other models** (`internal/modelautoscaler/autoscaler.go:139-163`). So when both cards are busy and a third model gets a request, its Pod sits `Pending` (Insufficient `squat.io/tenstorrent`) forever; nothing scales another model down to make room. Its only priority lever, `priorityClassName`, just delegates to the Kubernetes scheduler, which preempts by **priority** and is blind to **idleness** — it would evict a low-priority pod that's actively serving and never evict an equal-priority idle one. That doesn't match the requirement.

## Solution — `scalable-llm/card-arbiter/`

A small single-replica controller. Each ~5s tick it reads the waiters (model Pods Pending for a card), the holders (Running model Pods) + card capacity, and per-model in-flight counts. When a model needs a card and none is free, it evicts the **idlest** holder (LRU) by patching that Model's `maxReplicas` to 0 — KubeAI's own autoscaler then scales it to 0 and releases the card, so the waiter schedules. `maxReplicas` is restored when the pressure clears.

Key design points:
- **Idleness signal** = the KubeAI controller log's per-model `current requests: sum([N])` line. KubeAI exposes no metrics endpoint, but prints this every autoscale interval.
- **Actuation via `maxReplicas`**, not `spec.replicas` (KubeAI rewrites the latter each loop, but clamps its target to `maxReplicas`). ArgoCD self-heal is told to ignore Model `spec.maxReplicas`/`spec.replicas` (`apps/scalable-llm-app.yaml` `ignoreDifferences`) so the live patch isn't reverted; the git `maxReplicas` stays the steady-state ceiling the arbiter restores to.
- **Guards**: a holder must be idle ≥ 60s before it's evictable (a bursty-but-active client isn't cut off); an evicted holder stays pinned ≥ 120s so the freed card is taken before it can reclaim.
- Talks to the API server directly with its ServiceAccount token (no kubectl; image is plain `python:3.12-alpine`), minimal RBAC.

## Second model

`tt-llama-b` = the same Llama-3.1-8B under a second name. The single p150 officially serves only **Llama-3.1-8B** (tenstorrent/tt-inference-server support matrix), so a genuinely different architecture isn't a safe second model on this hardware. A second Model competing for a card is exactly what the arbiter arbitrates. Registered in LiteLLM.

## Validation

- Arbiter logic verified off-cluster with a scenario harness: pressure→evict idlest, busy holder never evicted, free-card→no-evict, restore-on-clear — all pass.
- `kustomize build` + `kubeconform` clean (23 resources).

## Note on requirements

This implements R6+R7 (the user clarified these collapse into one requirement: *evict an instance that isn't serving requests when another model needs the card* — pressure-and-idleness, not a time-based 1→0 delay). R1–R5 (sleep mode, scale-from-zero, load-based scaling to 2 cards, fast 2→1) are already in place from the prior autoscale work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)