### PR TITLE
fix(scalable-llm): card-arbiter evicts via min+max, shorter idle grace

### DIFF
--- a/apps/scalable-llm-app.yaml
+++ b/apps/scalable-llm-app.yaml
@@ -9,15 +9,17 @@ spec:
     server: https://kubernetes.default.svc
     namespace: scalable-llm
   # The card-arbiter (scalable-llm/card-arbiter) evicts an idle model to free a
-  # Tenstorrent card for a waiting model by patching Model maxReplicas (and KubeAI
-  # then rewrites replicas). Those fields are managed live at runtime, so exclude
-  # them from self-heal — otherwise ArgoCD reverts the patch within seconds and
-  # the arbiter can never free a card. The git value of maxReplicas stays the
-  # normal-operation ceiling that the arbiter restores to.
+  # Tenstorrent card for a waiting model by pinning that Model's minReplicas AND
+  # maxReplicas to 0 (KubeAI clamps max before min, so min must drop too or a warm
+  # holder re-clamps back up; KubeAI then rewrites replicas). These fields are
+  # managed live at runtime, so exclude them from self-heal — otherwise ArgoCD
+  # reverts the patch within seconds and the arbiter can never free a card. The
+  # git values stay the normal-operation bounds the arbiter restores to.
   ignoreDifferences:
     - group: kubeai.org
       kind: Model
       jqPathExpressions:
+        - '.spec.minReplicas'
         - '.spec.maxReplicas'
         - '.spec.replicas'
   syncPolicy:

--- a/scalable-llm/README.md
+++ b/scalable-llm/README.md
@@ -227,22 +227,32 @@ tick (~5s) it reads:
   it prints this every autoscale interval.
 
 When a model needs a card and none is free, it evicts the **idlest** holder
-(longest with `sum==0`, i.e. LRU) by patching that Model's `maxReplicas` to 0.
-KubeAI's own autoscaler then scales it to 0 and releases the card; the waiter
-schedules. When the pressure clears, the holder's `maxReplicas` is restored.
+(longest with `sum==0`, i.e. LRU) by pinning that Model's `minReplicas` **and**
+`maxReplicas` to 0. KubeAI's own autoscaler then scales it to 0 and releases the
+card; the waiter schedules. When the pressure clears, both bounds are restored.
 
-Why `maxReplicas`, not `spec.replicas`: KubeAI owns `spec.replicas` and rewrites
-it every loop, but it clamps its target to `maxReplicas`, so pinning that to 0
-sticks. ArgoCD self-heal would otherwise revert the live patch within seconds, so
-`apps/scalable-llm-app.yaml` lists Model `spec.maxReplicas`/`spec.replicas` under
-`ignoreDifferences`; the git value of `maxReplicas` stays the normal-operation
-ceiling the arbiter restores to.
+Why **both** bounds, not `spec.replicas`: KubeAI owns `spec.replicas` and
+rewrites it every loop, but clamps its target to the Model's bounds. Its
+`enforceReplicaBounds` applies `maxReplicas` *before* `minReplicas`, so **min
+wins** — pinning only `maxReplicas:0` leaves a warm holder (`minReplicas ≥ 1`)
+re-clamped back up, never releasing its card. Pinning both to 0 sticks for any
+holder. ArgoCD self-heal would otherwise revert the live patch within seconds, so
+`apps/scalable-llm-app.yaml` lists Model `spec.minReplicas`/`maxReplicas`/`replicas`
+under `ignoreDifferences`; the git bounds stay the normal-operation values the
+arbiter restores to.
 
-Guards: a holder must be idle ≥ `IDLE_GRACE` (60s) before it's evictable (so a
+Guards: a holder must be idle ≥ `IDLE_GRACE` before it's evictable (so a
 bursty-but-active client isn't cut off between requests), and an evicted holder
 stays pinned ≥ `EVICT_HOLD` (120s) so the freed card is actually taken by the
-waiter before it can reclaim. The arbiter talks to the API server directly with
-its ServiceAccount token (no kubectl; image is plain `python:alpine`).
+waiter before it can reclaim. **`IDLE_GRACE` defaults to 20s, deliberately below
+KubeAI's own idle scale-down (~60–70s = `timeWindow` 60s + `scaleDownDelay` 30s).**
+That matters: a `minReplicas:0` holder that just went idle self-scales to 0 on
+KubeAI's schedule and frees its own card, so a *longer* grace would mean the
+arbiter never needs to act for idle holders — its real value is freeing a card
+from a holder that stays Running while idle (a warm/pinned model, or one under
+trickle load) and winning the race when a card is genuinely contended. The
+arbiter talks to the API server directly with its ServiceAccount token (no
+kubectl; image is plain `python:alpine`).
 
 > Hardware note: the single p150 officially serves only **Llama-3.1-8B**
 > (tenstorrent/tt-inference-server model support matrix). `tt-llama-b` is the

--- a/scalable-llm/bench/preempt_warm.sh
+++ b/scalable-llm/bench/preempt_warm.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Preemption demo, warm-primary variant. Assumes PRIMARY is already a warm
+# holder of cards (e.g. minReplicas pinned so KubeAI won't self-release), and
+# currently idle. Fires one WAITER request and records the arbiter freeing a
+# card: WAITER goes Pending, the arbiter evicts an idle PRIMARY replica
+# (maxReplicas->0), the card frees, WAITER becomes Ready.
+#
+# This is the scenario the arbiter exists for: a Running-but-idle holder that
+# KubeAI will NOT scale down on its own. (With every model at minReplicas:0 an
+# idle holder self-scales to 0 in ~60s, before the arbiter's idle grace, so the
+# arbiter rarely needs to act — it matters for warm/pinned or trickle-loaded
+# holders.)
+#
+# Usage (after pinning PRIMARY warm and letting it reach its replica count):
+#   kubectl -n scalable-llm port-forward svc/kubeai 8000:80 &
+#   ./scalable-llm/bench/preempt_warm.sh
+set -uo pipefail
+
+NS=scalable-llm
+PRIMARY=${PRIMARY:-tt-llama}
+WAITER=${WAITER:-tt-llama-b}
+BASE=${BASE:-http://localhost:8000/openai/v1}
+# How long to wait for the idle grace + eviction + waiter cold start.
+PREEMPT_SECS=${PREEMPT_SECS:-360}
+
+T0=$(date +%s.%N)
+rel() { awk "BEGIN{printf \"%6.1f\", $(date +%s.%N) - $T0}"; }
+log() { echo "[$(rel)s] $*"; }
+ready() { kubectl get model -n "$NS" "$1" -o jsonpath='{.status.replicas.ready}' 2>/dev/null; }
+allrep() { kubectl get model -n "$NS" "$1" -o jsonpath='{.status.replicas.all}' 2>/dev/null; }
+maxrep() { kubectl get model -n "$NS" "$1" -o jsonpath='{.spec.maxReplicas}' 2>/dev/null; }
+pending_for_card() {
+  kubectl get pods -n "$NS" -l "model=$1" -o json 2>/dev/null | python3 -c '
+import json,sys
+n=0
+for p in json.load(sys.stdin).get("items",[]):
+    if p.get("status",{}).get("phase")=="Pending":
+        for c in p.get("status",{}).get("conditions",[]):
+            if c.get("type")=="PodScheduled" and c.get("status")=="False" and "Insufficient" in (c.get("message","") or ""):
+                n+=1
+print(n)'
+}
+
+echo "=== preemption (warm primary) ==="
+log "start: $PRIMARY ready=$(ready $PRIMARY) max=$(maxrep $PRIMARY) | $WAITER ready=$(ready $WAITER)"
+
+# Background pollers (state + arbiter decisions) on one clock.
+(
+  prev=""
+  while :; do
+    cur="$PRIMARY ready=$(ready $PRIMARY) all=$(allrep $PRIMARY) max=$(maxrep $PRIMARY) | $WAITER ready=$(ready $WAITER) all=$(allrep $WAITER) pending=$(pending_for_card $WAITER)"
+    [ "$cur" != "$prev" ] && { log "STATE  $cur"; prev="$cur"; }
+    sleep 2
+  done
+) & POLL=$!
+(
+  kubectl logs -n "$NS" -l app=card-arbiter -f --tail=0 2>/dev/null | while IFS= read -r line; do
+    case "$line" in *EVICT*|*restore*|*PRESSURE*) log "ARBITER $line";; esac
+  done
+) & ALOG=$!
+trap 'kill $POLL $ALOG 2>/dev/null' EXIT
+
+log "firing one $WAITER request (it has no free card -> must preempt)"
+curl -s -m 300 "$BASE/chat/completions" -H 'Content-Type: application/json' \
+  -d '{"model":"'"$WAITER"'","messages":[{"role":"user","content":"Say hello in one sentence."}],"max_tokens":32,"stream":false}' \
+  >/tmp/waiter_resp.json 2>&1 &
+REQ=$!
+
+end=$(( $(date +%s) + PREEMPT_SECS ))
+saw_pending=0
+while [ "$(date +%s)" -lt "$end" ]; do
+  [ "$(pending_for_card $WAITER)" -ge 1 ] && [ "$saw_pending" = 0 ] && { saw_pending=1; log ">> $WAITER PENDING for a card (contention) — arbiter should now act"; }
+  if [ "$(ready $WAITER)" = "1" ]; then
+    log ">> $WAITER READY — preemption succeeded, card was freed by the arbiter"
+    break
+  fi
+  sleep 3
+done
+
+wait "$REQ" 2>/dev/null
+log "waiter response: $(head -c 200 /tmp/waiter_resp.json 2>/dev/null)"
+log "final: $PRIMARY ready=$(ready $PRIMARY) max=$(maxrep $PRIMARY) | $WAITER ready=$(ready $WAITER)"
+log "=== done ==="

--- a/scalable-llm/card-arbiter/arbiter.py
+++ b/scalable-llm/card-arbiter/arbiter.py
@@ -53,8 +53,12 @@ KUBEAI_SELECTOR = os.environ.get(
 INTERVAL = float(os.environ.get("ARBITER_INTERVAL_SECONDS", "5"))
 # A holder must have read sum==0 for this long before it is evictable. Guards
 # against evicting a model between two requests of a bursty-but-active client.
-IDLE_GRACE = float(os.environ.get("ARBITER_IDLE_GRACE_SECONDS", "60"))
-# After eviction, keep maxReplicas pinned at 0 at least this long so the freed
+# Keep this BELOW KubeAI's own idle scale-down (timeWindow + scaleDownDelay,
+# ~60-70s): an idle minReplicas:0 holder self-scales to 0 on that schedule, so a
+# longer grace means KubeAI frees the card before the arbiter ever acts. A
+# shorter grace lets the arbiter win the race when the card is genuinely needed.
+IDLE_GRACE = float(os.environ.get("ARBITER_IDLE_GRACE_SECONDS", "20"))
+# After eviction, keep the holder pinned at 0 at least this long so the freed
 # card is actually consumed by the waiter before the victim can reclaim it.
 EVICT_HOLD = float(os.environ.get("ARBITER_EVICT_HOLD_SECONDS", "120"))
 # How many log lines to scan for the latest per-model in-flight counts.
@@ -166,21 +170,27 @@ def in_flight_by_model():
     return counts
 
 
-def model_max_replicas(model):
+def model_bounds(model):
+    """Return (minReplicas, maxReplicas) from the Model spec; None on error."""
     try:
-        m = api(f"/apis/kubeai.org/v1/namespaces/{NS}/models/{model}")
-        v = m.get("spec", {}).get("maxReplicas")
-        return None if v is None else int(v)
+        spec = api(f"/apis/kubeai.org/v1/namespaces/{NS}/models/{model}").get("spec", {})
+        mn = spec.get("minReplicas")
+        mx = spec.get("maxReplicas")
+        return (0 if mn is None else int(mn), None if mx is None else int(mx))
     except Exception as e:
-        log(f"read maxReplicas error for {model}: {e!r}")
+        log(f"read bounds error for {model}: {e!r}")
         return None
 
 
-def set_max_replicas(model, value):
+def set_bounds(model, minr, maxr):
+    # Pin BOTH bounds. maxReplicas alone is not enough: KubeAI's
+    # enforceReplicaBounds applies max first then min, so min wins — a warm
+    # holder (minReplicas>=1) re-clamps back up and never releases its card
+    # unless minReplicas is lowered too. Restoring puts both back.
     api(
         f"/apis/kubeai.org/v1/namespaces/{NS}/models/{model}",
         method="PATCH",
-        body={"spec": {"maxReplicas": value}},
+        body={"spec": {"minReplicas": minr, "maxReplicas": maxr}},
         content_type="application/merge-patch+json",
     )
 
@@ -194,7 +204,7 @@ def main():
 
     # model -> monotonic time it was first observed idle (reset whenever busy).
     idle_since = {}
-    # model -> (original maxReplicas, monotonic time pinned) for evicted holders.
+    # model -> (orig_min, orig_max, monotonic time pinned) for evicted holders.
     evicted = {}
 
     while True:
@@ -234,11 +244,11 @@ def tick(idle_since, evicted):
 
     # Restore any evicted holder once pressure is gone and the hold has elapsed.
     for m in list(evicted):
-        orig, pinned_at = evicted[m]
+        orig_min, orig_max, pinned_at = evicted[m]
         if not pending_for_card and (now - pinned_at) >= EVICT_HOLD:
-            log(f"restore: model={m} maxReplicas 0->{orig} (pressure cleared)")
+            log(f"restore: model={m} bounds ->(min={orig_min},max={orig_max}) (pressure cleared)")
             try:
-                set_max_replicas(m, orig)
+                set_bounds(m, orig_min, orig_max)
                 evicted.pop(m, None)
             except Exception as e:
                 log(f"restore failed for {m}: {e!r}")
@@ -274,17 +284,21 @@ def tick(idle_since, evicted):
     # LRU: evict the holder idle the longest.
     candidates.sort(reverse=True)
     idle_for, victim = candidates[0]
-    orig = model_max_replicas(victim)
-    if orig is None or orig == 0:
-        log(f"victim={victim} has maxReplicas={orig}; skip")
+    bounds = model_bounds(victim)
+    if bounds is None:
+        log(f"victim={victim}: could not read bounds; skip")
+        return
+    orig_min, orig_max = bounds
+    if orig_max == 0:
+        log(f"victim={victim} already has maxReplicas=0; skip")
         return
     log(
-        f"EVICT victim={victim} (idle {round(idle_for)}s) maxReplicas {orig}->0 "
-        f"to free a card for {pending_for_card}"
+        f"EVICT victim={victim} (idle {round(idle_for)}s) "
+        f"bounds (min={orig_min},max={orig_max})->(0,0) to free a card for {pending_for_card}"
     )
     try:
-        set_max_replicas(victim, 0)
-        evicted[victim] = (orig, now)
+        set_bounds(victim, 0, 0)
+        evicted[victim] = (orig_min, orig_max, now)
     except Exception as e:
         log(f"evict failed for {victim}: {e!r}")
 

--- a/scalable-llm/card-arbiter/deployment.yaml
+++ b/scalable-llm/card-arbiter/deployment.yaml
@@ -41,8 +41,10 @@ spec:
               value: shion-ubuntu-2605
             - name: ARBITER_INTERVAL_SECONDS
               value: "5"
+            # Below KubeAI's own idle scale-down (~60-70s) so the arbiter can win
+            # the race and free a card when one is genuinely contended.
             - name: ARBITER_IDLE_GRACE_SECONDS
-              value: "60"
+              value: "20"
             - name: ARBITER_EVICT_HOLD_SECONDS
               value: "120"
           resources:


### PR DESCRIPTION
## What

Live testing of the card-arbiter (#418) surfaced **two real defects** that made it unable to free a card in the cases that matter most. This fixes both.

### Defect 1 — warm holder couldn't be evicted (min wins over max)

The arbiter evicted a holder by pinning `maxReplicas: 0`. But KubeAI's `enforceReplicaBounds` (`internal/modelclient/scale.go`) applies `maxReplicas` **before** `minReplicas`, so min wins. With `min:2, max:0`, desired-0 clamps to max (0), then `0 < min(2)` → returns 2. A warm holder (`minReplicas ≥ 1`) re-clamps straight back up and never releases its card — exactly the case the arbiter most needs to handle.

**Fix:** evict by pinning **both** `minReplicas` and `maxReplicas` to 0; remember and restore the original `(min, max)`. Add `spec.minReplicas` to the app's `ignoreDifferences`.

### Defect 2 — idle grace lost the race against KubeAI's own scale-down

`IDLE_GRACE` defaulted to 60s, but an idle `minReplicas:0` holder self-scales to 0 on KubeAI's own ~60–70s schedule (`timeWindow` 60s + `scaleDownDelay` 30s). Measured: `tt-llama` went 2→0 in 63s after load stopped. So the holder was usually gone before the grace elapsed and the arbiter never acted.

**Fix:** `IDLE_GRACE` default 60s → 20s, below KubeAI's idle scale-down, so the arbiter wins the race when a card is genuinely contended.

## Where the arbiter actually adds value

With every model at `min:0`, an idle holder frees its own card in ~60s — so the arbiter isn't needed for idle holders that self-scale. Its real value is freeing a card from a holder that stays Running while idle: a warm/pinned model, or one under trickle load. Defect 1's fix is what makes the warm case work at all.

## Validation

- Scenario harness: warm-primary (min:2/max:2) evict→restore now passes; regression scenarios still pass.
- `kustomize build` + `kubeconform` clean. Adds `bench/preempt_warm.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
