### PR TITLE
fix(scalable-llm): card-arbiter evicts to maxReplicas:1 not 0 (CRD rejects 0)

### DIFF
--- a/scalable-llm/README.md
+++ b/scalable-llm/README.md
@@ -227,16 +227,23 @@ tick (~5s) it reads:
   it prints this every autoscale interval.
 
 When a model needs a card and none is free, it evicts the **idlest** holder
-(longest with `sum==0`, i.e. LRU) by pinning that Model's `minReplicas` **and**
-`maxReplicas` to 0. KubeAI's own autoscaler then scales it to 0 and releases the
-card; the waiter schedules. When the pressure clears, both bounds are restored.
+(longest with `sum==0`, i.e. LRU) by pinning that Model's bounds to
+`minReplicas: 0` / `maxReplicas: 1`. KubeAI's own autoscaler then scales the idle
+holder to 0 and releases the card; the waiter schedules. When the pressure
+clears, the holder's original bounds are restored.
+
+Why `maxReplicas: 1` and not 0: the Model CRD enforces `maxReplicas >= 1` — a 0
+is rejected with **HTTP 422** (an earlier revision pinned `(0, 0)` and the patch
+silently failed every tick, so no card ever freed). With `minReplicas: 0` the
+cap of 1 is enough: an idle holder's desired replicas is `ceil(0/target) = 0`,
+which sits inside `[0, 1]`, so it still drops to 0 and frees its card.
 
 Why **both** bounds, not `spec.replicas`: KubeAI owns `spec.replicas` and
 rewrites it every loop, but clamps its target to the Model's bounds. Its
 `enforceReplicaBounds` applies `maxReplicas` *before* `minReplicas`, so **min
-wins** — pinning only `maxReplicas:0` leaves a warm holder (`minReplicas ≥ 1`)
-re-clamped back up, never releasing its card. Pinning both to 0 sticks for any
-holder. ArgoCD self-heal would otherwise revert the live patch within seconds, so
+wins** — lowering only `maxReplicas` leaves a warm holder (`minReplicas ≥ 1`)
+re-clamped back up, never releasing its card. Lowering `minReplicas` to 0 too
+makes it stick for any holder. ArgoCD self-heal would otherwise revert the live patch within seconds, so
 `apps/scalable-llm-app.yaml` lists Model `spec.minReplicas`/`maxReplicas`/`replicas`
 under `ignoreDifferences`; the git bounds stay the normal-operation values the
 arbiter restores to.

--- a/scalable-llm/bench/preempt_warm.sh
+++ b/scalable-llm/bench/preempt_warm.sh
@@ -55,7 +55,7 @@ log "start: $PRIMARY ready=$(ready $PRIMARY) max=$(maxrep $PRIMARY) | $WAITER re
 ) & POLL=$!
 (
   kubectl logs -n "$NS" -l app=card-arbiter -f --tail=0 2>/dev/null | while IFS= read -r line; do
-    case "$line" in *EVICT*|*restore*|*PRESSURE*) log "ARBITER $line";; esac
+    case "$line" in *EVICT*|*restore*|*PRESSURE*|*failed*|*error*) log "ARBITER $line";; esac
   done
 ) & ALOG=$!
 trap 'kill $POLL $ALOG 2>/dev/null' EXIT

--- a/scalable-llm/card-arbiter/arbiter.py
+++ b/scalable-llm/card-arbiter/arbiter.py
@@ -10,19 +10,28 @@ KubeAI never scales another Model down to make room.
 This controller closes that gap. Each tick it asks: is some Model's Pod Pending
 for a card while every card is held, and is one of the card-holding Models
 idle (no in-flight requests)? If so it evicts the *idlest* holder (LRU) by
-pinning its maxReplicas to 0, which makes KubeAI's own autoscaler scale it to 0
-and release the card; the waiting Pod then schedules. When the pressure clears
-the holder's maxReplicas is restored so it can serve again.
+pinning its bounds to minReplicas:0 / maxReplicas:1, which makes KubeAI's own
+autoscaler scale the idle holder to 0 and release the card; the waiting Pod then
+schedules. When the pressure clears the holder's original bounds are restored so
+it can serve again.
+
+The eviction cap is 1, not 0: the Model CRD enforces maxReplicas >= 1 (a 0 is
+rejected with HTTP 422). With minReplicas:0 that is enough — an idle holder's
+desired replicas is ceil(0/target) = 0, which sits inside [0, 1], so it still
+drops to 0 and frees its card. Lowering minReplicas matters too: KubeAI's
+enforceReplicaBounds applies max before min, so a warm holder (minReplicas >= 1)
+would re-clamp straight back up if only max were touched.
 
 Idleness comes from KubeAI's own per-model in-flight count, which the autoscaler
 prints every interval (KubeAI exposes no metrics endpoint):
     Calculated target replicas for model "X": ceil(0/4) = 0, current requests: sum([0]) = 0
 The `sum([...])` is the live in-flight request total for that model.
 
-Actuation is maxReplicas (not spec.replicas): KubeAI owns spec.replicas and
-rewrites it every loop, but it clamps its target to maxReplicas, so 0 sticks.
-ArgoCD self-heal would otherwise revert the live patch, so the scalable-llm app
-lists Model spec.maxReplicas/replicas under ignoreDifferences.
+Actuation is min/maxReplicas (not spec.replicas): KubeAI owns spec.replicas and
+rewrites it every loop, but it clamps its target into [minReplicas, maxReplicas],
+so the bounds stick. ArgoCD self-heal would otherwise revert the live patch, so
+the scalable-llm app lists Model spec.minReplicas/maxReplicas/replicas under
+ignoreDifferences.
 
 Talks to the Kubernetes API directly over HTTPS with the in-cluster
 ServiceAccount token — no kubectl, so the image is plain python:alpine. All
@@ -61,6 +70,11 @@ IDLE_GRACE = float(os.environ.get("ARBITER_IDLE_GRACE_SECONDS", "20"))
 # After eviction, keep the holder pinned at 0 at least this long so the freed
 # card is actually consumed by the waiter before the victim can reclaim it.
 EVICT_HOLD = float(os.environ.get("ARBITER_EVICT_HOLD_SECONDS", "120"))
+# maxReplicas the arbiter pins an evicted holder to. The Model CRD enforces
+# maxReplicas >= 1 (0 is rejected with HTTP 422), so eviction caps at 1, not 0.
+# Combined with minReplicas:0 that is enough: an idle holder still scales to 0
+# and frees its card, because desired = ceil(0/target) = 0 sits within [0, 1].
+EVICT_MAX = 1
 # How many log lines to scan for the latest per-model in-flight counts.
 LOG_TAIL_LINES = os.environ.get("ARBITER_LOG_TAIL_LINES", "40")
 
@@ -187,6 +201,8 @@ def set_bounds(model, minr, maxr):
     # enforceReplicaBounds applies max first then min, so min wins — a warm
     # holder (minReplicas>=1) re-clamps back up and never releases its card
     # unless minReplicas is lowered too. Restoring puts both back.
+    # NOTE: the Model CRD requires maxReplicas >= 1; passing 0 is rejected with
+    # HTTP 422. Evict to (0, EVICT_MAX=1), not (0, 0).
     api(
         f"/apis/kubeai.org/v1/namespaces/{NS}/models/{model}",
         method="PATCH",
@@ -289,15 +305,18 @@ def tick(idle_since, evicted):
         log(f"victim={victim}: could not read bounds; skip")
         return
     orig_min, orig_max = bounds
-    if orig_max == 0:
-        log(f"victim={victim} already has maxReplicas=0; skip")
+    # Nothing to gain if the holder is already at (or below) our eviction floor:
+    # min:0 lets it scale to 0 and max<=EVICT_MAX caps it at one card already.
+    if orig_min == 0 and orig_max is not None and orig_max <= EVICT_MAX:
+        log(f"victim={victim} already at (0,{orig_max}) <= evict floor; skip")
         return
     log(
         f"EVICT victim={victim} (idle {round(idle_for)}s) "
-        f"bounds (min={orig_min},max={orig_max})->(0,0) to free a card for {pending_for_card}"
+        f"bounds (min={orig_min},max={orig_max})->(0,{EVICT_MAX}) "
+        f"to free a card for {pending_for_card}"
     )
     try:
-        set_bounds(victim, 0, 0)
+        set_bounds(victim, 0, EVICT_MAX)
         evicted[victim] = (orig_min, orig_max, now)
     except Exception as e:
         log(f"evict failed for {victim}: {e!r}")


### PR DESCRIPTION
## What

Live verification of the card-arbiter (#418 / #419) on the actual hardware surfaced a **third, blocking defect**: the eviction patch from #419 never actuates. This fixes it.

## The defect

#419 evicts a holder via `set_bounds(model, 0, 0)` — pinning both `minReplicas` and `maxReplicas` to 0. But the KubeAI **Model CRD enforces `maxReplicas >= 1`**:

```
spec.maxReplicas: Invalid value: 0: spec.maxReplicas in body should be greater than or equal to 1
```

So every eviction PATCH was rejected with **HTTP 422**. The arbiter logged `EVICT …` each tick but the bound never changed, the card never freed, and the waiter stayed `Pending` indefinitely. The failure was **invisible** in the demo because `preempt_warm.sh`'s arbiter-log filter only matched `EVICT|restore|PRESSURE` — not the `evict failed for …: <HTTPError 422>` line the arbiter was emitting all along.

## The fix

Evict to `(minReplicas: 0, maxReplicas: 1)` instead of `(0, 0)`:

- `maxReplicas: 1` is the CRD's legal floor.
- With `minReplicas: 0`, an idle holder's desired replicas is `ceil(0/target) = 0`, which sits inside `[0, 1]` — so KubeAI still scales it to **0** and frees its card.
- Lowering `minReplicas` is still required: `enforceReplicaBounds` applies max before min, so a warm holder (`minReplicas ≥ 1`) would re-clamp straight back up if only max were touched. (This was the correct half of #419.)

Also widens `preempt_warm.sh`'s arbiter-log filter to surface `failed`/`error` lines, so a non-actuating eviction can't loop silently again.

## Live verification

On `shion-ubuntu-2605` (2× Blackhole p150a, `squat.io/tenstorrent: 2`):

1. Paused `scalable-llm` auto-sync; pinned `tt-llama` to `min:2/max:2` → both cards held, idle (warm-primary, the arbiter-only case). Reached 2/2 Ready in ~140s.
2. Fired one `tt-llama-b` request → its Pod went `Pending` (Insufficient `squat.io/tenstorrent`).
3. **Before the fix:** arbiter logged `EVICT victim=tt-llama … ->(0,0)` every tick for 6+ min; `tt-llama` stayed `2/2`; 422 in the (unfiltered) logs.
4. **With the fix's bound:** patching `tt-llama` to `(0,1)` dropped it `2→1` (max clamp, immediate) then `1→0` (idle scale-down, ~30s) — **both cards freed**.

CRD constraint confirmed directly:

```
minReplicas: {minimum: 0}   # 0 is valid
maxReplicas: {minimum: 1}   # 0 rejected; empty = no limit
```

## Validation

- `python3 -m ast` parse clean; `kustomize build scalable-llm/card-arbiter` clean.
- Cluster restored to steady state after the test: both models `min:0`, auto-sync re-enabled, cards free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
