### PR TITLE
feat(atc): deploy atc-reprice service from internal Harbor

### DIFF
--- a/atc/kustomization.yaml
+++ b/atc/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - vault-secret-store.yaml
   - external-secret.yaml
   - deployment-gmocoin-exec-alert.yaml
+  - reprice-deployment.yaml
   - seaweedfs-external-secret.yaml
   - seaweedfs-statefulset.yaml
   - seaweedfs-service.yaml

--- a/atc/reprice-deployment.yaml
+++ b/atc/reprice-deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: atc-reprice
+  namespace: atc
+  labels:
+    app: atc-reprice
+spec:
+  replicas: 1
+  # The service holds in-memory order state and two live WebSocket sessions; a second
+  # replica would double-manage the same GMO orders. Keep it a singleton, recreate on
+  # update (never two pods re-pricing the same order concurrently).
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: atc-reprice
+  template:
+    metadata:
+      labels:
+        app: atc-reprice
+      annotations:
+        # Restart the pod when the GMO API secret rotates (stakater reloader).
+        reloader.stakater.com/auto: "true"
+    spec:
+      containers:
+        - name: atc-reprice
+          # Internal Harbor image (pushed by docker-publish-reprice.yml). Pull creds are
+          # auto-injected cluster-wide by the Kyverno harbor-pull-injection policy.
+          image: harbor.shion1305.com/shion1305/atc-reprice:main
+          imagePullPolicy: Always
+          # Manage every active LIMIT order and adopt newly-placed ones (default behavior).
+          # 逆指値/STOP orders are excluded automatically. Add --dry-run to validate first.
+          args:
+            - "--symbol"
+            - "ETH_JPY"
+            - "--adopt-all-active"
+            - "--watch"
+          env:
+            - name: GMO_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: gmo-coin-api-secret
+                  key: API_KEY
+            - name: GMO_API_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: gmo-coin-api-secret
+                  key: API_SECRET
+            - name: RUST_LOG
+              value: "info"
+          resources:
+            # Single static binary, no interpreter heap — a tight, predictable footprint.
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "128Mi"
+              cpu: "250m"


### PR DESCRIPTION
## What

Deploy the new **atc-reprice** service (standalone Rust GMO order re-pricing binary) into the `atc` namespace, pulling from the internal Harbor registry.

- `atc/reprice-deployment.yaml` — Deployment (singleton, `Recreate` strategy: never two pods re-pricing the same order). Args `--symbol ETH_JPY --adopt-all-active --watch` (manage all active LIMIT orders + adopt newly-placed ones; 逆指値/STOP excluded).
- `atc/kustomization.yaml` — add the resource.

## Conventions followed

- **Image**: `harbor.shion1305.com/shion1305/atc-reprice:main` (internal Harbor, per the project convention). Pull creds auto-injected by the Kyverno `harbor-pull-injection` policy — no `imagePullSecrets` needed.
- **Secret**: reuses the existing `gmo-coin-api-secret` ExternalSecret (`API_KEY`/`API_SECRET` → `GMO_API_KEY`/`GMO_API_SECRET`). No new secret.
- **Reload**: stakater reloader annotation restarts on secret rotation.

## 🟡 Draft — do not merge until the image exists

The image is built/pushed by the `crypto-auto-trading` workflow `docker-publish-reprice.yml` (PR Shion1305/crypto-auto-trading#231). Merging this before that image is in Harbor → ImagePullBackOff.

**Before un-drafting / merging:**
1. Merge crypto-auto-trading#231 so CI pushes `harbor.shion1305.com/shion1305/atc-reprice`.
2. Pin the `image:` tag to the pushed `sha-<commit>` (recommended over the moving `main` tag for auditability).
3. Verify the service authenticates against live GMO (HMAC signing, private-WS fields) — it is tolerant/fail-closed but unverified offline. Consider a first rollout with `--dry-run` added to args.