### PR TITLE
fix(envoy-gateway): keep escaped slashes so ArgoCD repo UI works

### DIFF
--- a/envoy-gateway/client-traffic-policy.yaml
+++ b/envoy-gateway/client-traffic-policy.yaml
@@ -1,0 +1,24 @@
+# Envoy Gateway defaults escapedSlashesAction to UnescapeAndRedirect, which
+# 307-redirects any path containing %2F and rewrites it to a literal slash.
+# ArgoCD encodes the repo URL into one path segment
+# (/api/v1/repositories/https%3A%2F%2F...), so the redirect splits it and the
+# request no longer matches the grpc-gateway {repo} route — every UI repo
+# disconnect/refresh 404s. KeepUnchanged forwards the path verbatim.
+#
+# Attached to the external Gateway's `https` section, not the whole Gateway:
+# mergeGateways merges the external+internal plain HTTP :80 listeners onto one
+# port, and Envoy Gateway rejects a policy touching multiple non-TLS listeners
+# on a shared port. TLS listeners are exempt, and all published apps are HTTPS.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: keep-escaped-slashes
+  namespace: envoy-gateway-system
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: external
+      sectionName: https
+  path:
+    escapedSlashesAction: KeepUnchanged

--- a/envoy-gateway/kustomization.yaml
+++ b/envoy-gateway/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - certificates.yaml
   - gateway-internal.yaml
   - gateway-external.yaml
+  - client-traffic-policy.yaml


### PR DESCRIPTION
## Problem

Disconnecting or refreshing a repository from the **ArgoCD UI**
(`/settings/repos`) fails with a toast:

> Unable to disconnect repository: **Not Found**

The repo shows as `Successful` in the list, yet any UI delete/refresh 404s.
The `argocd` CLI deletes the same repo fine.

## Root cause — Envoy Gateway, not ArgoCD

The ArgoCD UI encodes a repository's git URL into a single path segment:

```
DELETE /api/v1/repositories/https%3A%2F%2Fgithub.com%2FShion1305%2Fk8s-GitOps.git?appProject=default
```

Envoy Gateway's `ClientTrafficPolicy.path.escapedSlashesAction` defaults to
**`UnescapeAndRedirect`**. Envoy answers the request with a **307** whose
`Location` rewrites `%2F` → `/`:

```
location: /api/v1/repositories/https%3A/github.com/Shion1305/k8s-GitOps.git/...
```

The browser follows it, but the now-split path no longer matches the
grpc-gateway `{repo}` **single-segment** route, so argocd-server returns
**404**. The CLI is unaffected because it speaks gRPC and never crosses this
HTTP path normalization.

Confirmed by bypassing Envoy: the identical fully-encoded request sent
straight to `argocd-server` via port-forward returns **200** with no
redirect — the decode happens at the gateway.

## Fix

Add a `ClientTrafficPolicy` with `escapedSlashesAction: KeepUnchanged` so the
path is forwarded verbatim.

It targets the **external Gateway's `https` section** rather than the whole
Gateway: `mergeGateways: true` merges the external + internal plain HTTP `:80`
listeners onto one port, and Envoy Gateway rejects a policy that touches
multiple non-TLS listeners sharing a port (`applied to multiple http (non
https) listeners on the same port`). TLS listeners get their own filter chain
and are exempt, and every published app is served over HTTPS — so the `https`
section is both accepted and the right scope.

`KeepUnchanged` is harmless for other apps; their request paths don't carry
encoded slashes.

## Verification (live)

- Policy `Accepted=True` on `external/https`.
- Public URL stopped 307-redirecting.
- Authenticated `GET /refs` with a fully `%2F`-encoded repo URL → **200**.
- Repo **Disconnect from the ArgoCD UI now succeeds** (tested with a
  disposable repo; row removed, no error toast).