### PR TITLE
[codex] add GARM GitHub Actions runners

### DIFF
--- a/.github/workflows/build-garm-runner-image.yaml
+++ b/.github/workflows/build-garm-runner-image.yaml
@@ -1,0 +1,29 @@
+name: garm-runner - build & push image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "github-actions-runner/runner-image/**"
+      - ".github/workflows/build-garm-runner-image.yaml"
+      - ".github/actions/harbor-build-push/**"
+  pull_request:
+    paths:
+      - "github-actions-runner/runner-image/**"
+      - ".github/workflows/build-garm-runner-image.yaml"
+      - ".github/actions/harbor-build-push/**"
+  workflow_dispatch:
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/harbor-build-push
+        with:
+          image: harbor.shion1305.com/shion1305/garm-runner
+          context: ./github-actions-runner/runner-image
+          extra-tags: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && '2.335.1-ubuntu24.04,latest' || '' }}

--- a/apps/github-actions-runner-app.yaml
+++ b/apps/github-actions-runner-app.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: github-actions-runner
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Shion1305/k8s-GitOps.git
+    targetRevision: HEAD
+    path: github-actions-runner
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: github-actions-runner
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/github-actions-runner/.env.example
+++ b/github-actions-runner/.env.example
@@ -1,0 +1,17 @@
+GARM_NAMESPACE=github-actions-runner
+GARM_DEPLOYMENT=deploy/garm-server
+GARM_OWNER=Shion1305
+
+GARM_PROFILE_NAME=shion1305-k8s
+GARM_CREDENTIALS_NAME=shion1305-github-app
+GARM_API_URL=http://127.0.0.1:9997
+
+GARM_RUNNER_IMAGE=harbor.shion1305.com/shion1305/garm-runner:2.335.1-ubuntu24.04
+GARM_MAX_RUNNERS=6
+GARM_MIN_IDLE_RUNNERS=0
+GARM_FLAVOR=default
+
+GARM_AMD_PROVIDER=kubernetes_amd64
+GARM_ARM_PROVIDER=kubernetes_arm64
+GARM_AMD_TAGS=shion1305-amd
+GARM_ARM_TAGS=shion1305-arm

--- a/github-actions-runner/Justfile
+++ b/github-actions-runner/Justfile
@@ -1,0 +1,140 @@
+set dotenv-load := true
+set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
+
+namespace := env_var_or_default("GARM_NAMESPACE", "github-actions-runner")
+deployment := env_var_or_default("GARM_DEPLOYMENT", "deploy/garm-server")
+owner := env_var_or_default("GARM_OWNER", "Shion1305")
+profile := env_var_or_default("GARM_PROFILE_NAME", "shion1305-k8s")
+credentials := env_var_or_default("GARM_CREDENTIALS_NAME", "shion1305-github-app")
+runner_image := env_var_or_default("GARM_RUNNER_IMAGE", "harbor.shion1305.com/shion1305/garm-runner:2.335.1-ubuntu24.04")
+max_runners := env_var_or_default("GARM_MAX_RUNNERS", "6")
+min_idle_runners := env_var_or_default("GARM_MIN_IDLE_RUNNERS", "0")
+amd_provider := env_var_or_default("GARM_AMD_PROVIDER", "kubernetes_amd64")
+arm_provider := env_var_or_default("GARM_ARM_PROVIDER", "kubernetes_arm64")
+amd_tags := env_var_or_default("GARM_AMD_TAGS", "shion1305-amd")
+arm_tags := env_var_or_default("GARM_ARM_TAGS", "shion1305-arm")
+flavor := env_var_or_default("GARM_FLAVOR", "default")
+api_url := env_var_or_default("GARM_API_URL", "http://127.0.0.1:9997")
+
+default:
+  @just --list
+
+# Run garm-cli inside the garm-server pod.
+cli *args:
+  kubectl exec -n {{namespace}} {{deployment}} -- /opt/garm/bin/garm-cli {{args}}
+
+# Add the local garm-cli profile inside the garm-server pod.
+profile-add:
+  kubectl exec -n {{namespace}} {{deployment}} -- sh -ec '\
+    /opt/garm/bin/garm-cli profile add \
+      --name {{profile}} \
+      --url {{api_url}} \
+      --username "$GARM_ADMIN_USERNAME" \
+      --password "$GARM_ADMIN_PASSWORD"'
+
+# Add the GitHub App credentials to GARM.
+credentials-add:
+  kubectl exec -n {{namespace}} {{deployment}} -- sh -ec '\
+    printf "%s" "$GITHUB_APP_PRIVATE_KEY" > /tmp/github-app.pem; \
+    /opt/garm/bin/garm-cli github credentials add \
+      --name {{credentials}} \
+      --description "GitHub App for {{owner}} repository runners" \
+      --endpoint github.com \
+      --auth-type app \
+      --app-id "$GITHUB_APP_ID" \
+      --app-installation-id "$GITHUB_APP_INSTALLATION_ID" \
+      --private-key-path /tmp/github-app.pem'
+
+# Add both the garm-cli profile and GitHub App credentials.
+init-github: profile-add credentials-add
+
+# Register GARM management for a repository and install its webhook.
+repo-add target:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  target='{{target}}'
+  if [[ "$target" == */* ]]; then
+    target_owner="${target%%/*}"
+    target_repo="${target#*/}"
+  else
+    target_owner='{{owner}}'
+    target_repo="$target"
+  fi
+  if [[ -z "$target_owner" || -z "$target_repo" || "$target_repo" == */* ]]; then
+    echo "usage: just repo-add <repo|owner/repo>" >&2
+    exit 2
+  fi
+  kubectl exec -n {{namespace}} {{deployment}} -- /opt/garm/bin/garm-cli repo add \
+    --owner "$target_owner" \
+    --name "$target_repo" \
+    --credentials {{credentials}} \
+    --random-webhook-secret \
+    --install-webhook \
+    --pool-balancer-type roundrobin
+
+# Add the amd64 runner pool for a repository.
+pool-add-amd target:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  target='{{target}}'
+  if [[ "$target" == */* ]]; then
+    target_owner="${target%%/*}"
+    target_repo="${target#*/}"
+  else
+    target_owner='{{owner}}'
+    target_repo="$target"
+  fi
+  if [[ -z "$target_owner" || -z "$target_repo" || "$target_repo" == */* ]]; then
+    echo "usage: just pool-add-amd <repo|owner/repo>" >&2
+    exit 2
+  fi
+  kubectl exec -n {{namespace}} {{deployment}} -- /opt/garm/bin/garm-cli pool add \
+    --repo "$target_owner/$target_repo" \
+    --enabled \
+    --provider-name {{amd_provider}} \
+    --flavor {{flavor}} \
+    --image "{{runner_image}}" \
+    --max-runners {{max_runners}} \
+    --min-idle-runners {{min_idle_runners}} \
+    --os-type linux \
+    --os-arch amd64 \
+    --tags {{amd_tags}}
+
+# Add the arm64 runner pool for a repository.
+pool-add-arm target:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  target='{{target}}'
+  if [[ "$target" == */* ]]; then
+    target_owner="${target%%/*}"
+    target_repo="${target#*/}"
+  else
+    target_owner='{{owner}}'
+    target_repo="$target"
+  fi
+  if [[ -z "$target_owner" || -z "$target_repo" || "$target_repo" == */* ]]; then
+    echo "usage: just pool-add-arm <repo|owner/repo>" >&2
+    exit 2
+  fi
+  kubectl exec -n {{namespace}} {{deployment}} -- /opt/garm/bin/garm-cli pool add \
+    --repo "$target_owner/$target_repo" \
+    --enabled \
+    --provider-name {{arm_provider}} \
+    --flavor {{flavor}} \
+    --image "{{runner_image}}" \
+    --max-runners {{max_runners}} \
+    --min-idle-runners {{min_idle_runners}} \
+    --os-type linux \
+    --os-arch arm64 \
+    --tags {{arm_tags}}
+
+# Register one repository and add both amd64/arm64 pools.
+bootstrap-repo target: (repo-add target) (pool-add-amd target) (pool-add-arm target)
+
+# Show registered repositories.
+repo-list:
+  kubectl exec -n {{namespace}} {{deployment}} -- /opt/garm/bin/garm-cli repo list
+
+# Show runner pools.
+pool-list:
+  kubectl exec -n {{namespace}} {{deployment}} -- /opt/garm/bin/garm-cli pool list

--- a/github-actions-runner/README.md
+++ b/github-actions-runner/README.md
@@ -1,0 +1,139 @@
+# GARM GitHub Actions Runners
+
+This directory deploys [GARM](https://github.com/cloudbase/garm) with
+`mercedes-benz/garm-provider-k8s` so GARM can create ephemeral GitHub Actions
+runner pods in this cluster.
+
+## Scope
+
+GitHub does not provide a personal-account-wide self-hosted runner scope.
+GARM works around that by registering each repository as a GARM repository entity
+and installing a `workflow_job` webhook for that repository. Add each
+`Shion1305/<repo>` repository you want to use.
+
+## Vault Secret
+
+Create the Vault secret before syncing this app:
+
+```bash
+vault kv put github-app-shared/garm \
+  database_passphrase="$(openssl rand -base64 48 | tr -dc A-Za-z0-9 | head -c 32)" \
+  jwt_secret="$(openssl rand -base64 48)" \
+  admin_username="admin" \
+  admin_password="<replace-me>" \
+  admin_email="<replace-me>" \
+  github_app_id="<app-id>" \
+  github_app_installation_id="<installation-id>" \
+  github_app_private_key=@private-key.pem
+```
+
+The GitHub App must be installed on the repositories you want GARM to manage and
+needs these permissions:
+
+- Repository Administration: read/write
+- Repository Metadata: read-only
+- Repository Webhooks: read/write
+
+## Initial Login
+
+The `garm-init` Job creates the first admin user and writes the controller URLs.
+After it succeeds, open:
+
+```text
+https://garm.i.shion1305.com
+```
+
+Only the webhook endpoint is exposed on the public Gateway:
+
+```text
+https://garm.shion1305.com/webhooks
+```
+
+You can also use the CLI inside the server pod:
+
+```bash
+kubectl exec -n github-actions-runner deploy/garm-server -- /opt/garm/bin/garm-cli --help
+```
+
+## Runner Image
+
+Use this fixed multi-arch image for both amd64 and arm64 pools:
+
+```text
+harbor.shion1305.com/shion1305/garm-runner:2.335.1-ubuntu24.04
+```
+
+The image is built from GitHub's official self-hosted runner image
+`ghcr.io/actions/actions-runner:2.335.1`, which currently provides Ubuntu
+24.04 based amd64 and arm64 variants. It adds the GARM-compatible entrypoint
+plus common build tools such as Git LFS, Python, Node.js/npm, build-essential,
+cmake, zip/unzip, zstd, rsync, and OpenSSH client.
+
+Build and publish it with the `garm-runner - build & push image` GitHub Actions
+workflow. On `main`, that workflow publishes:
+
+- `harbor.shion1305.com/shion1305/garm-runner:<commit-sha>`
+- `harbor.shion1305.com/shion1305/garm-runner:2.335.1-ubuntu24.04`
+- `harbor.shion1305.com/shion1305/garm-runner:latest`
+
+This is close to the GitHub official self-hosted runner environment, but it is
+not a full clone of GitHub-hosted `ubuntu-latest` VM images. The Docker CLI and
+buildx are present from the official base image, but these Kubernetes runner
+pods do not include a Docker daemon by default.
+
+## Add Repositories
+
+Local operational commands live in `Justfile` and read defaults from `.env`.
+The local `.env` is ignored by Git; `.env.example` is the tracked template.
+Secrets stay in the `garm-server` pod via Kubernetes Secret environment
+variables.
+
+Run this once after the `garm-init` Job has completed. The private key is
+mounted from the Kubernetes Secret only for copying into GARM's encrypted
+database:
+
+```bash
+cd github-actions-runner
+just init-github
+```
+
+Then register a repository and add both amd64/arm64 pools. The repository
+argument is required.
+
+```bash
+just bootstrap-repo k8s-GitOps
+```
+
+If the repository is under `GARM_OWNER` from `.env` (`Shion1305` by default),
+pass only the repository name:
+
+```bash
+just bootstrap-repo another-repo
+```
+
+For a different owner or organization, pass `owner/repo`:
+
+```bash
+just bootstrap-repo Shion1305Dev/another-repo
+```
+
+Workflows can then target:
+
+```yaml
+runs-on: shion1305-amd
+```
+
+or:
+
+```yaml
+runs-on: shion1305-arm
+```
+
+## Notes
+
+- `min-idle-runners: 0` scales runner pods to zero when no jobs are queued.
+- The `kubernetes_amd64` and `kubernetes_arm64` providers use separate provider
+  config files so their pods get different `kubernetes.io/arch` node selectors.
+- The runner image is pulled from Harbor. The existing cluster-wide
+  `harbor-pull-injection` Kyverno policy should inject the `harbor-pull`
+  imagePullSecret into runner pods on admission.

--- a/github-actions-runner/configmap.yaml
+++ b/github-actions-runner/configmap.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: garm-provider-config
+  namespace: github-actions-runner
+data:
+  garm-provider-k8s-amd64.yaml: |
+    kubeConfigPath: ""
+    runnerNamespace: "github-actions-runner-pods"
+    podTemplate:
+      metadata:
+        labels:
+          app.kubernetes.io/managed-by: garm
+      spec:
+        nodeSelector:
+          kubernetes.io/arch: amd64
+    flavors:
+      default:
+        requests:
+          cpu: 500m
+          memory: 1Gi
+        limits:
+          memory: 4Gi
+  garm-provider-k8s-arm64.yaml: |
+    kubeConfigPath: ""
+    runnerNamespace: "github-actions-runner-pods"
+    podTemplate:
+      metadata:
+        labels:
+          app.kubernetes.io/managed-by: garm
+      spec:
+        nodeSelector:
+          kubernetes.io/arch: arm64
+    flavors:
+      default:
+        requests:
+          cpu: 500m
+          memory: 1Gi
+        limits:
+          memory: 4Gi

--- a/github-actions-runner/deployment.yaml
+++ b/github-actions-runner/deployment.yaml
@@ -1,0 +1,184 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: garm-server
+  namespace: github-actions-runner
+  labels:
+    app.kubernetes.io/name: garm-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: garm-server
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: garm-server
+    spec:
+      serviceAccountName: garm-server
+      initContainers:
+        - name: download-garm
+          image: curlimages/curl:8.11.1
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 0
+          command:
+            - sh
+            - -ec
+            - |
+              case "$(uname -m)" in
+                x86_64) garm_arch="amd64"; provider_arch="x86_64" ;;
+                aarch64|arm64) garm_arch="arm64"; provider_arch="arm64" ;;
+                *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+              esac
+
+              curl -fsSL "https://github.com/cloudbase/garm/releases/download/v0.2.1/garm-linux-${garm_arch}.tgz" \
+                | tar -xz -C /opt/garm/bin
+              curl -fsSL "https://github.com/cloudbase/garm/releases/download/v0.2.1/garm-cli-linux-${garm_arch}.tgz" \
+                | tar -xz -C /opt/garm/bin
+              curl -fsSL "https://github.com/mercedes-benz/garm-provider-k8s/releases/download/v0.3.2/garm-provider-k8s_Linux_${provider_arch}.tar.gz" \
+                | tar -xz -C /opt/garm/bin
+              chmod 0755 /opt/garm/bin/garm /opt/garm/bin/garm-cli /opt/garm/bin/garm-provider-k8s
+          volumeMounts:
+            - name: garm-bin
+              mountPath: /opt/garm/bin
+      containers:
+        - name: garm-server
+          image: alpine:3.22
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -ec
+            - |
+              cat > /opt/garm/generated/config.toml <<EOF
+              [default]
+              enable_webhook_management = true
+
+              [logging]
+              enable_log_streamer = true
+              log_format = "json"
+              log_level = "info"
+              log_source = false
+
+              [metrics]
+              enable = true
+              disable_auth = false
+
+              [jwt_auth]
+              secret = "${GARM_JWT_SECRET}"
+              time_to_live = "8760h"
+
+              [apiserver]
+              bind = "0.0.0.0"
+              port = 9997
+              use_tls = false
+              cors_origins = ["https://garm.i.shion1305.com"]
+                [apiserver.webui]
+                enable = true
+
+              [database]
+              backend = "sqlite3"
+              passphrase = "${GARM_DATABASE_PASSPHRASE}"
+                [database.sqlite3]
+                db_file = "/opt/garm/data/garm.db"
+
+              [[provider]]
+              name = "kubernetes_amd64"
+              description = "Kubernetes provider for amd64 runner pods"
+              provider_type = "external"
+                [provider.external]
+                config_file = "/opt/garm/provider-config/garm-provider-k8s-amd64.yaml"
+                provider_executable = "/opt/garm/bin/garm-provider-k8s"
+                environment_variables = ["KUBERNETES_"]
+
+              [[provider]]
+              name = "kubernetes_arm64"
+              description = "Kubernetes provider for arm64 runner pods"
+              provider_type = "external"
+                [provider.external]
+                config_file = "/opt/garm/provider-config/garm-provider-k8s-arm64.yaml"
+                provider_executable = "/opt/garm/bin/garm-provider-k8s"
+                environment_variables = ["KUBERNETES_"]
+              EOF
+
+              exec /opt/garm/bin/garm -config /opt/garm/generated/config.toml
+          env:
+            - name: GARM_DATABASE_PASSPHRASE
+              valueFrom:
+                secretKeyRef:
+                  name: garm-secrets
+                  key: database_passphrase
+            - name: GARM_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: garm-secrets
+                  key: jwt_secret
+            - name: GARM_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: garm-secrets
+                  key: admin_username
+            - name: GARM_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: garm-secrets
+                  key: admin_password
+            - name: GITHUB_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: garm-secrets
+                  key: github_app_id
+            - name: GITHUB_APP_INSTALLATION_ID
+              valueFrom:
+                secretKeyRef:
+                  name: garm-secrets
+                  key: github_app_installation_id
+            - name: GITHUB_APP_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: garm-secrets
+                  key: github_app_private_key
+          ports:
+            - name: http
+              containerPort: 9997
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+          volumeMounts:
+            - name: garm-bin
+              mountPath: /opt/garm/bin
+            - name: garm-data
+              mountPath: /opt/garm/data
+            - name: garm-generated
+              mountPath: /opt/garm/generated
+            - name: garm-provider-config
+              mountPath: /opt/garm/provider-config
+              readOnly: true
+      volumes:
+        - name: garm-bin
+          emptyDir: {}
+        - name: garm-generated
+          emptyDir: {}
+        - name: garm-provider-config
+          configMap:
+            name: garm-provider-config
+        - name: garm-data
+          persistentVolumeClaim:
+            claimName: garm-data

--- a/github-actions-runner/external-secret.yaml
+++ b/github-actions-runner/external-secret.yaml
@@ -1,0 +1,66 @@
+# Secrets for GARM.
+#
+# Expected Vault data:
+#   vault kv put github-app-shared/garm \
+#     database_passphrase="<exactly 32 random chars>" \
+#     jwt_secret="<32+ random chars>" \
+#     admin_username="admin" \
+#     admin_password="<admin password>" \
+#     admin_email="<admin email>" \
+#     github_app_id="<app id>" \
+#     github_app_installation_id="<installation id>" \
+#     github_app_private_key=@private-key.pem
+#
+# The GitHub App needs repository Administration read/write, Metadata read-only,
+# and Webhooks read/write for every repository you want GARM to manage.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: garm-secrets
+  namespace: github-actions-runner
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: vault-github-app
+    kind: ClusterSecretStore
+  target:
+    name: garm-secrets
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+  data:
+    - secretKey: database_passphrase
+      remoteRef:
+        key: garm
+        property: database_passphrase
+    - secretKey: jwt_secret
+      remoteRef:
+        key: garm
+        property: jwt_secret
+    - secretKey: admin_username
+      remoteRef:
+        key: garm
+        property: admin_username
+    - secretKey: admin_password
+      remoteRef:
+        key: garm
+        property: admin_password
+    - secretKey: admin_email
+      remoteRef:
+        key: garm
+        property: admin_email
+    - secretKey: github_app_id
+      remoteRef:
+        key: garm
+        property: github_app_id
+    - secretKey: github_app_installation_id
+      remoteRef:
+        key: garm
+        property: github_app_installation_id
+    - secretKey: github_app_private_key
+      remoteRef:
+        key: garm
+        property: github_app_private_key

--- a/github-actions-runner/httproute-external.yaml
+++ b/github-actions-runner/httproute-external.yaml
@@ -1,0 +1,20 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: garm-webhook-external
+  namespace: github-actions-runner
+spec:
+  parentRefs:
+    - name: external
+      namespace: envoy-gateway-system
+      sectionName: https
+  hostnames:
+    - garm.shion1305.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /webhooks
+      backendRefs:
+        - name: garm-server
+          port: 9997

--- a/github-actions-runner/httproute-internal.yaml
+++ b/github-actions-runner/httproute-internal.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: garm-internal
+  namespace: github-actions-runner
+spec:
+  parentRefs:
+    - name: internal
+      namespace: envoy-gateway-system
+      sectionName: https
+  hostnames:
+    - garm.i.shion1305.com
+  rules:
+    - backendRefs:
+        - name: garm-server
+          port: 9997

--- a/github-actions-runner/init-job.yaml
+++ b/github-actions-runner/init-job.yaml
@@ -1,0 +1,91 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: garm-init
+  namespace: github-actions-runner
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  backoffLimit: 6
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: garm-init
+    spec:
+      restartPolicy: OnFailure
+      initContainers:
+        - name: download-garm-cli
+          image: curlimages/curl:8.11.1
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 0
+          command:
+            - sh
+            - -ec
+            - |
+              case "$(uname -m)" in
+                x86_64) garm_arch="amd64" ;;
+                aarch64|arm64) garm_arch="arm64" ;;
+                *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+              esac
+              curl -fsSL "https://github.com/cloudbase/garm/releases/download/v0.2.1/garm-cli-linux-${garm_arch}.tgz" \
+                | tar -xz -C /opt/garm/bin
+              chmod 0755 /opt/garm/bin/garm-cli
+          volumeMounts:
+            - name: garm-bin
+              mountPath: /opt/garm/bin
+      containers:
+        - name: init
+          image: curlimages/curl:8.11.1
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 0
+          command:
+            - sh
+            - -ec
+            - |
+              api_url="http://garm-server.github-actions-runner.svc.cluster.local:9997"
+              callback_url="http://garm-server.github-actions-runner.svc.cluster.local:9997/api/v1/callbacks"
+              metadata_url="http://garm-server.github-actions-runner.svc.cluster.local:9997/api/v1/metadata"
+              agent_url="http://garm-server.github-actions-runner.svc.cluster.local:9997/agent"
+              webhook_url="https://garm.shion1305.com/webhooks"
+
+              until curl -fsS "${api_url}/" >/dev/null; do
+                sleep 5
+              done
+
+              /opt/garm/bin/garm-cli init \
+                --name shion1305-k8s \
+                --url "${api_url}" \
+                --username "${GARM_ADMIN_USERNAME}" \
+                --password "${GARM_ADMIN_PASSWORD}" \
+                --email "${GARM_ADMIN_EMAIL}" \
+                --full-name "GARM Admin" \
+                --callback-url "${callback_url}" \
+                --metadata-url "${metadata_url}" \
+                --webhook-url "${webhook_url}" \
+                --agent-url "${agent_url}"
+          env:
+            - name: HOME
+              value: /tmp
+            - name: GARM_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: garm-secrets
+                  key: admin_username
+            - name: GARM_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: garm-secrets
+                  key: admin_password
+            - name: GARM_ADMIN_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: garm-secrets
+                  key: admin_email
+          volumeMounts:
+            - name: garm-bin
+              mountPath: /opt/garm/bin
+      volumes:
+        - name: garm-bin
+          emptyDir: {}

--- a/github-actions-runner/kustomization.yaml
+++ b/github-actions-runner/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - external-secret.yaml
+  - configmap.yaml
+  - rbac.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute-external.yaml
+  - httproute-internal.yaml
+  - reference-grant.yaml
+  - networkpolicy.yaml
+  - init-job.yaml

--- a/github-actions-runner/namespace.yaml
+++ b/github-actions-runner/namespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: github-actions-runner
+  labels:
+    app.kubernetes.io/name: garm
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: github-actions-runner-pods
+  labels:
+    app.kubernetes.io/name: github-actions-runner-pods

--- a/github-actions-runner/networkpolicy.yaml
+++ b/github-actions-runner/networkpolicy.yaml
@@ -1,0 +1,20 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-garm-callbacks-from-runner-pods
+  namespace: github-actions-runner
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: garm-server
+  enableDefaultDeny:
+    ingress: false
+    egress: false
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: github-actions-runner-pods
+      toPorts:
+        - ports:
+            - port: "9997"
+              protocol: TCP

--- a/github-actions-runner/pvc.yaml
+++ b/github-actions-runner/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: garm-data
+  namespace: github-actions-runner
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/github-actions-runner/rbac.yaml
+++ b/github-actions-runner/rbac.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: garm-server
+  namespace: github-actions-runner
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: garm-provider-k8s-namespace
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: garm-provider-k8s-namespace
+subjects:
+  - kind: ServiceAccount
+    namespace: github-actions-runner
+    name: garm-server
+roleRef:
+  kind: ClusterRole
+  name: garm-provider-k8s-namespace
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: garm-provider-k8s-runner-pods
+  namespace: github-actions-runner-pods
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: garm-provider-k8s-runner-pods
+  namespace: github-actions-runner-pods
+subjects:
+  - kind: ServiceAccount
+    namespace: github-actions-runner
+    name: garm-server
+roleRef:
+  kind: Role
+  name: garm-provider-k8s-runner-pods
+  apiGroup: rbac.authorization.k8s.io

--- a/github-actions-runner/reference-grant.yaml
+++ b/github-actions-runner/reference-grant.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ReferenceGrant
+metadata:
+  name: allow-envoy-gateway
+  namespace: github-actions-runner
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: envoy-gateway-system
+  to:
+    - group: ""
+      kind: Service

--- a/github-actions-runner/runner-image/.dockerignore
+++ b/github-actions-runner/runner-image/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.github
+README.md

--- a/github-actions-runner/runner-image/Dockerfile
+++ b/github-actions-runner/runner-image/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1.7
+FROM ghcr.io/actions/actions-runner:2.335.1
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      build-essential \
+      ca-certificates \
+      cmake \
+      file \
+      git-lfs \
+      gzip \
+      jq \
+      nodejs \
+      npm \
+      openssh-client \
+      pkg-config \
+      python3 \
+      python3-pip \
+      python3-venv \
+      rsync \
+      tar \
+      unzip \
+      wget \
+      xz-utils \
+      zip \
+      zstd \
+    && git lfs install --system \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --chown=runner:docker entrypoint.sh /entrypoint.sh
+
+RUN chmod 0755 /entrypoint.sh \
+    && mkdir -p /runner \
+    && chown runner:docker /runner
+
+USER runner
+ENV RUNNER_ASSETS_DIR=/home/runner \
+    RUNNER_HOME=/runner
+ENTRYPOINT ["/entrypoint.sh"]

--- a/github-actions-runner/runner-image/entrypoint.sh
+++ b/github-actions-runner/runner-image/entrypoint.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+#
+# GARM-compatible entrypoint, based on the upstream garm-provider-k8s runner
+# entrypoint. Keep this image on the official actions/runner base, but let
+# GARM provide the metadata and callback URLs needed for ephemeral runners.
+
+set -e
+set -o pipefail
+
+RUNNER_ASSETS_DIR=${RUNNER_ASSETS_DIR:-/home/runner}
+RUNNER_HOME=${RUNNER_HOME:-/runner}
+
+if [ ! -d "${RUNNER_HOME}" ]; then
+  echo "$RUNNER_HOME should be an emptyDir mount. Please fix the pod spec."
+  exit 1
+fi
+
+if [ -z "$METADATA_URL" ]; then
+    echo "no token is available and METADATA_URL is not set"
+    exit 1
+fi
+
+if [ -z "$CALLBACK_URL" ]; then
+    echo "CALLBACK_URL is not set"
+    exit 1
+fi
+
+function call() {
+    PAYLOAD="$1"
+    local cb_url=$CALLBACK_URL
+    [[ $cb_url =~ ^(.*)/status(/)?$ ]] || cb_url="${cb_url}/status"
+    curl --retry 5 --retry-delay 5 --retry-connrefused --fail -s -X POST -d "${PAYLOAD}" -H 'Accept: application/json' -H "Authorization: Bearer ${BEARER_TOKEN}" "${cb_url}" || echo "failed to call home: exit code ($?)"
+}
+
+function systemInfo() {
+    if [ -f "/etc/os-release" ]; then
+        . /etc/os-release
+    fi
+    local cb_url=$CALLBACK_URL
+    OS_NAME=${NAME:-""}
+    OS_VERSION=${VERSION_ID:-""}
+    AGENT_ID=${1:-null}
+    [[ $cb_url =~ ^(.*)/status(/)?$ ]] && cb_url="${BASH_REMATCH[1]}" || true
+    SYSINFO_URL="${cb_url}/system-info/"
+    PAYLOAD="{\"os_name\": \"$OS_NAME\", \"os_version\": \"$OS_VERSION\", \"agent_id\": $AGENT_ID}"
+    curl --retry 5 --retry-delay 5 --retry-connrefused --fail -s -X POST -d "${PAYLOAD}" -H 'Accept: application/json' -H "Authorization: Bearer ${BEARER_TOKEN}" "${SYSINFO_URL}" || true
+}
+
+function sendStatus() {
+    MSG="$1"
+    call "{\"status\": \"installing\", \"message\": \"$MSG\"}"
+}
+
+function fail() {
+    MSG="$1"
+    call "{\"status\": \"failed\", \"message\": \"$MSG\"}"
+    exit 1
+}
+
+function success() {
+    MSG="$1"
+    ID=${2:-null}
+    if [ "$JIT_CONFIG_ENABLED" != "true" ] && [ "$ID" == "null" ]; then
+        fail "agent ID is required when JIT_CONFIG_ENABLED is not true"
+    fi
+
+    call "{\"status\": \"idle\", \"message\": \"$MSG\", \"agent_id\": $ID}"
+}
+
+function getRunnerFile() {
+    curl --retry 5 --retry-delay 5 \
+        --retry-connrefused --fail -s \
+        -X GET -H 'Accept: application/json' \
+        -H "Authorization: Bearer ${BEARER_TOKEN}" \
+        "${METADATA_URL}/$1" -o "$2"
+}
+
+function check_runner {
+    set +e
+    echo "Checking runner health..."
+    RETRIES=0
+    MAX_RETRIES=15
+
+    while true; do
+        if [[ $RETRIES -eq $MAX_RETRIES ]]; then
+          echo "failed to start runner"
+          fail "failed to start runner"
+        fi
+
+        AGENT_ID=""
+        if [ -f "$RUNNER_HOME"/.runner ]; then
+
+          AGENT_ID=$(grep -io '"[aA]gent[iI]d": [0-9]*' "$RUNNER_HOME"/.runner | sed 's/.*[aA]gent[iI]d": \([0-9]*\).*/\1/')
+          if [ "$JIT_CONFIG_ENABLED" == "true" ]; then
+            AGENT_ID=$(grep -ioE '"[aA]gent[iI]d":"?[0-9]+"?' "$RUNNER_HOME"/.runner | sed -E 's/.*[aA]gent[iI]d"?: ?"([0-9]+)".*/\1/')
+          fi
+
+          echo "Calling $CALLBACK_URL with $AGENT_ID"
+          systemInfo "$AGENT_ID"
+          success "runner successfully installed" "$AGENT_ID"
+          break
+        fi
+
+        RETRIES=$(expr $RETRIES + 1)
+        echo "RETRIES: $RETRIES"
+        sleep 10
+    done
+    set -e
+}
+
+shopt -s dotglob
+cp -r "$RUNNER_ASSETS_DIR"/* "$RUNNER_HOME"/
+shopt -u dotglob
+
+pushd "$RUNNER_HOME"
+
+sendStatus "configuring runner"
+if [ "$JIT_CONFIG_ENABLED" == "true" ]; then
+    sendStatus "downloading JIT credentials"
+    getRunnerFile "credentials/runner" "$RUNNER_HOME/.runner" || fail "failed to get runner file"
+    getRunnerFile "credentials/credentials" "$RUNNER_HOME/.credentials" || fail "failed to get credentials file"
+    getRunnerFile "credentials/credentials_rsaparams" "$RUNNER_HOME/.credentials_rsaparams" || fail "failed to get credentials_rsaparams file"
+else
+    if [ -n "${RUNNER_ORG}" ] && [ -n "${RUNNER_REPO}" ]; then
+        ATTACH="${RUNNER_ORG}/${RUNNER_REPO}"
+    elif [ -n "${RUNNER_ORG}" ]; then
+        ATTACH="${RUNNER_ORG}"
+    elif [ -n "${RUNNER_REPO}" ]; then
+        ATTACH="${RUNNER_REPO}"
+    elif [ -n "${RUNNER_ENTERPRISE}" ]; then
+        ATTACH="enterprises/${RUNNER_ENTERPRISE}"
+    else
+        fail 'At least one of RUNNER_ORG, RUNNER_REPO, or RUNNER_ENTERPRISE must be set'
+        exit 1
+    fi
+
+    REPO_URL="${GITHUB_URL}/${ATTACH}"
+
+    config_args=()
+    if [ "${RUNNER_FEATURE_FLAG_ONCE:-}" != "true" ] && [ "${RUNNER_EPHEMERAL}" == "true" ]; then
+      config_args+=(--ephemeral)
+    fi
+    if [ "${DISABLE_RUNNER_UPDATE:-}" == "true" ]; then
+      config_args+=(--disableupdate)
+    fi
+    if [ "${RUNNER_NO_DEFAULT_LABELS:-}" == "true" ]; then
+      config_args+=(--no-default-labels)
+    fi
+    if [ -n "$RUNNER_GROUP" ] && [ "$RUNNER_GROUP" != "default" ]; then
+        config_args+=(--runnergroup "$RUNNER_GROUP")
+    fi
+
+    GITHUB_TOKEN=$(curl --retry 5 --retry-delay 5 --retry-connrefused --fail -s -X GET -H 'Accept: application/json' -H "Authorization: Bearer ${BEARER_TOKEN}" "${METADATA_URL}/runner-registration-token/")
+    set +e
+    attempt=1
+    while true; do
+        ERROUT=$(mktemp)
+
+        if ./config.sh --unattended \
+            --url "$REPO_URL" \
+            --token "$GITHUB_TOKEN" \
+            --name "$RUNNER_NAME" \
+            --labels "$RUNNER_LABELS" \
+            --work "${RUNNER_WORKDIR}" "${config_args[@]}" 2>"$ERROUT"
+        then
+            rm "$ERROUT" || true
+            sendStatus "runner successfully configured after $attempt attempt(s)"
+            break
+        fi
+
+        LAST_ERR=$(cat "$ERROUT")
+        echo "$LAST_ERR"
+
+        ./config.sh remove --token "$GITHUB_TOKEN" || true
+
+        if [ $attempt -gt 5 ]; then
+            rm "$ERROUT" || true
+            fail "failed to configure runner: $LAST_ERR"
+        fi
+
+        sendStatus "failed to configure runner (attempt $attempt): $LAST_ERR (retrying in 5 seconds)"
+        attempt=$((attempt + 1))
+        rm "$ERROUT" || true
+        sleep 5
+    done
+    set -e
+fi
+
+check_runner &
+
+./run.sh "$@"

--- a/github-actions-runner/service.yaml
+++ b/github-actions-runner/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: garm-server
+  namespace: github-actions-runner
+  labels:
+    app.kubernetes.io/name: garm-server
+spec:
+  selector:
+    app.kubernetes.io/name: garm-server
+  ports:
+    - name: http
+      port: 9997
+      targetPort: http


### PR DESCRIPTION
## Summary

- Add a GARM-based GitHub Actions runner deployment managed by Argo CD.
- Configure amd64 and arm64 Kubernetes providers with separate node selectors and runner labels.
- Add a GARM-compatible runner image based on GitHub's official `actions-runner` image and a workflow to build/push it to Harbor.
- Add local `just` commands and `.env.example` for registering repositories and runner pools.

## Operational Notes

- Public exposure is limited to `https://garm.shion1305.com/webhooks`.
- The GARM UI/API is routed through `https://garm.i.shion1305.com`.
- Repository bootstrap is explicit: `just bootstrap-repo <repo|owner/repo>`.
- Runner pools use `max-runners 6`, `min-idle-runners 0`, and labels `shion1305-amd` / `shion1305-arm`.

## Validation

- `./scripts/render-validate.sh`
- `actionlint .github/workflows/build-garm-runner-image.yaml`
- `just --justfile github-actions-runner/Justfile --working-directory github-actions-runner --dry-run bootstrap-repo k8s-GitOps`
- `just --justfile github-actions-runner/Justfile --working-directory github-actions-runner --dry-run bootstrap-repo Shion1305Dev/another-repo`
- `bash -n github-actions-runner/runner-image/entrypoint.sh`
- `git diff --check`

## Not Run

- Local Docker image build, because the Docker daemon was not running in the local environment. The image build is covered by the added GitHub Actions workflow.
