### PR TITLE
feat(buildkit): daemonless image builds for self-hosted runners

### DIFF
--- a/apps/buildkit-app.yaml
+++ b/apps/buildkit-app.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: buildkit
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Shion1305/k8s-GitOps.git
+    targetRevision: HEAD
+    path: buildkit
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: buildkit
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/buildkit/README.md
+++ b/buildkit/README.md
@@ -1,0 +1,98 @@
+# BuildKit (daemonless image builds for self-hosted runners)
+
+Rootless [BuildKit](https://github.com/moby/buildkit) daemon used by the GARM
+self-hosted runners (`github-actions-runner-pods`) to build and push container
+images **without a Docker daemon and without privileged runner pods**.
+
+Runner pods stay clean: they carry only the Docker CLI / `buildx` (from the
+actions-runner base image) and talk to this shared `buildkitd` over TCP.
+`buildkitd` itself runs rootless (`--oci-worker-no-process-sandbox`, non-root
+UID, no `privileged`).
+
+## Architecture
+
+```text
+runner pod (github-actions-runner-pods)        buildkit ns
+┌───────────────────────────────┐             ┌────────────────────────┐
+│ docker buildx build --push     │   tcp:1234  │ buildkitd (rootless)   │
+│   (default builder = remote)   ├────────────▶│  - builds the image    │
+│ ~/.docker/config.json auth ────┼─(forwarded)─│  - pushes to Harbor ───┼──▶ harbor.shion1305.com
+└───────────────────────────────┘             └────────────────────────┘
+```
+
+The runner entrypoint registers a default `buildx` builder pointed at this
+daemon (`--driver remote`) and runs `docker buildx install`, so `docker build`
+and `docker buildx build` transparently execute on the in-cluster BuildKit. The
+build/push runs on `buildkitd`; registry credentials are read from the runner's
+`~/.docker/config.json` and forwarded over the build session, so the daemon
+holds no standing registry credentials.
+
+## Using it from CI (no workflow changes)
+
+Because the runner image pre-configures the remote builder, **build-and-push
+workflows run unchanged** on `runs-on: shion1305-amd` / `shion1305-arm`:
+
+```yaml
+jobs:
+  build:
+    runs-on: shion1305-amd
+    steps:
+      - uses: actions/checkout@v4
+      # however the workflow already authenticates to its registry, e.g. a
+      # docker login or docker/login-action step, stays the same
+      - run: |
+          docker buildx build --push \
+            -t harbor.shion1305.com/shion1305/<image>:${{ github.sha }} .
+```
+
+`docker/build-push-action` (with `push: true`) and `docker build --push` work
+the same way — they use the pre-registered default builder.
+
+**What works** (no daemon needed): `docker build` / `docker buildx build` that
+build and `--push` in one step.
+
+**What does not work daemonless** (keep these on `ubuntu-latest`):
+
+- building an image then using it locally — `docker run`, a second-step
+  `docker push`, or `--load` (no local daemon to load into)
+- `services:` / `container:` jobs (the runner requires a daemon at job start)
+- a job that explicitly runs `docker/setup-buildx-action` with the **default**
+  driver — it creates a `docker-container` builder (needs a daemon) and
+  overrides the default. Set `driver: remote`,
+  `endpoint: tcp://buildkitd.buildkit.svc.cluster.local:1234` on that step if
+  you must keep it.
+
+## Security
+
+The TCP listener is **unauthenticated** (no TLS). Access is restricted at the
+network layer instead: `networkpolicy.yaml` (a `CiliumNetworkPolicy`, additive
+to the Kyverno-generated default-deny-ingress) allows ingress to `:1234` **only
+from the `github-actions-runner-pods` namespace**. If you ever need to reach the
+daemon from elsewhere, prefer enabling mTLS over widening the policy.
+
+## Multi-arch
+
+This deploys a single **amd64** `buildkitd`, which builds amd64 images natively.
+For arm64:
+
+- **Native:** copy `deployment.yaml`/`service.yaml` to an `arm64` variant
+  (`nodeSelector: kubernetes.io/arch: arm64`, `name: buildkitd-arm64`) and set
+  `BUILDKIT_REMOTE_ENDPOINT` on the arm64 pool to that service.
+- **Emulated:** register binfmt on the nodes (e.g. a `tonistiigi/binfmt`
+  DaemonSet) and build with `--platform linux/amd64,linux/arm64`.
+
+## Advanced: buildctl directly
+
+The lower-level `buildctl` client is also baked into the runner image for cases
+that need explicit cache control or OCI export:
+
+```bash
+buildctl --addr tcp://buildkitd.buildkit.svc.cluster.local:1234 \
+  build --frontend dockerfile.v0 \
+  --local context=. --local dockerfile=. \
+  --output type=image,name=harbor.shion1305.com/shion1305/<image>:<tag>,push=true
+```
+
+The daemon's local cache is an `emptyDir` and is lost on pod restart; add
+`--export-cache type=registry,...` / `--import-cache` (or buildx `--cache-to/-from`)
+for persistent cross-build caching.

--- a/buildkit/deployment.yaml
+++ b/buildkit/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: buildkitd
+  namespace: buildkit
+  labels:
+    app.kubernetes.io/name: buildkitd
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: buildkitd
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: buildkitd
+    spec:
+      # Builds run natively on amd64. For native arm64 builds, run a second
+      # deployment+service pinned to arch arm64 (see README), or register
+      # binfmt on the nodes for emulated cross-builds.
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      containers:
+        - name: buildkitd
+          image: moby/buildkit:v0.30.0-rootless
+          args:
+            # Local socket plus an unauthenticated TCP listener. The TCP port is
+            # only reachable from the runner-pods namespace (see networkpolicy.yaml).
+            - --addr
+            - unix:///run/user/1000/buildkit/buildkitd.sock
+            - --addr
+            - tcp://0.0.0.0:1234
+            # Rootless mode cannot create a nested process sandbox without extra
+            # privileges; disable it so builds run unprivileged in this pod.
+            - --oci-worker-no-process-sandbox
+          readinessProbe:
+            exec:
+              command: ["buildctl", "debug", "workers"]
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          livenessProbe:
+            exec:
+              command: ["buildctl", "debug", "workers"]
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          securityContext:
+            # Rootless buildkitd needs unconfined seccomp/AppArmor to set up the
+            # user-namespaced OCI worker. It still runs as a non-root UID and the
+            # pod is not privileged.
+            runAsUser: 1000
+            runAsGroup: 1000
+            seccompProfile:
+              type: Unconfined
+            appArmorProfile:
+              type: Unconfined
+          ports:
+            - name: tcp
+              containerPort: 1234
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 4Gi
+            limits:
+              memory: 8Gi
+          volumeMounts:
+            - name: buildkitd-cache
+              mountPath: /home/user/.local/share/buildkit
+      volumes:
+        - name: buildkitd-cache
+          emptyDir: {}

--- a/buildkit/kustomization.yaml
+++ b/buildkit/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - networkpolicy.yaml

--- a/buildkit/namespace.yaml
+++ b/buildkit/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: buildkit
+  labels:
+    app.kubernetes.io/name: buildkit

--- a/buildkit/networkpolicy.yaml
+++ b/buildkit/networkpolicy.yaml
@@ -1,0 +1,24 @@
+# BuildKit's TCP listener is unauthenticated, so access is restricted at the
+# network layer: only pods in the GARM runner-pods namespace may reach :1234.
+# This is additive to the Kyverno-generated default-deny-ingress; egress is left
+# open so buildkitd can pull base images and push to Harbor.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-buildkit-from-runner-pods
+  namespace: buildkit
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: buildkitd
+  enableDefaultDeny:
+    ingress: false
+    egress: false
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: github-actions-runner-pods
+      toPorts:
+        - ports:
+            - port: "1234"
+              protocol: TCP

--- a/buildkit/service.yaml
+++ b/buildkit/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: buildkitd
+  namespace: buildkit
+  labels:
+    app.kubernetes.io/name: buildkitd
+spec:
+  selector:
+    app.kubernetes.io/name: buildkitd
+  ports:
+    - name: tcp
+      port: 1234
+      targetPort: tcp

--- a/github-actions-runner/runner-image/Dockerfile
+++ b/github-actions-runner/runner-image/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
 
 # buildctl client for daemonless image builds against the in-cluster rootless
 # BuildKit (see ../../buildkit). No Docker daemon is bundled in these runners.
-ARG BUILDKIT_VERSION=v0.18.2
+ARG BUILDKIT_VERSION=v0.30.0
 ARG TARGETARCH
 RUN curl -fsSL "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-${TARGETARCH}.tar.gz" \
       | tar -xz -C /usr/local bin/buildctl \

--- a/github-actions-runner/runner-image/Dockerfile
+++ b/github-actions-runner/runner-image/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update \
       build-essential \
       ca-certificates \
       cmake \
+      curl \
       file \
       git-lfs \
       gzip \
@@ -28,6 +29,14 @@ RUN apt-get update \
       zstd \
     && git lfs install --system \
     && rm -rf /var/lib/apt/lists/*
+
+# buildctl client for daemonless image builds against the in-cluster rootless
+# BuildKit (see ../../buildkit). No Docker daemon is bundled in these runners.
+ARG BUILDKIT_VERSION=v0.18.2
+ARG TARGETARCH
+RUN curl -fsSL "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-${TARGETARCH}.tar.gz" \
+      | tar -xz -C /usr/local bin/buildctl \
+    && buildctl --version
 
 COPY --chown=runner:docker entrypoint.sh /entrypoint.sh
 

--- a/github-actions-runner/runner-image/entrypoint.sh
+++ b/github-actions-runner/runner-image/entrypoint.sh
@@ -187,6 +187,17 @@ else
     set -e
 fi
 
+# Point Docker Buildx at the in-cluster rootless BuildKit (../../buildkit) so
+# workflows can run `docker build` / `docker buildx build --push` unchanged with
+# no Docker daemon in this pod. The remote driver only records the endpoint (it
+# starts nothing locally), and `buildx install` aliases `docker build` to buildx.
+# Failures here must never block runner startup.
+BUILDKIT_REMOTE_ENDPOINT=${BUILDKIT_REMOTE_ENDPOINT:-tcp://buildkitd.buildkit.svc.cluster.local:1234}
+if command -v docker >/dev/null 2>&1; then
+  docker buildx create --name incluster --driver remote "$BUILDKIT_REMOTE_ENDPOINT" --use >/dev/null 2>&1 || true
+  docker buildx install >/dev/null 2>&1 || true
+fi
+
 check_runner &
 
 ./run.sh "$@"


### PR DESCRIPTION
## What

Adds an in-cluster **rootless BuildKit** so the GARM self-hosted runners can build & push container images **without a Docker daemon and without privileged runner pods**.

## Why

K8s runner pods (garm-provider-k8s) have no Docker daemon, so any `docker build` / `container:` / `services:` job fails with `dial unix /var/run/docker.sock: no such file`. Rather than a privileged DinD sidecar (node-root blast radius), this runs builds on a shared rootless `buildkitd` that runners reach over TCP.

## How it works

- `buildkit/` — rootless `buildkitd` Deployment (non-root UID, **not** privileged, `--oci-worker-no-process-sandbox`, seccomp/AppArmor `Unconfined`), `ClusterIP` on `:1234`, and a Cilium `NetworkPolicy` that admits ingress **only from `github-actions-runner-pods`** (the TCP listener is unauthenticated, so it's locked down at the network layer, additive to the Kyverno default-deny-ingress).
- `apps/buildkit-app.yaml` — ArgoCD app, auto-registered by `root-app`.
- **Runner image** — the entrypoint registers a default buildx `remote` builder at the in-cluster daemon and runs `docker buildx install`, so **build-and-push workflows run unchanged** (`docker build` / `docker buildx build --push` / `docker/build-push-action`). `buildctl` is also baked in for advanced use.
- **Credentials** — Harbor push creds are read from the runner's `~/.docker/config.json` and forwarded over the build session (same Vault `harbor/robot-pusher` path as `harbor-build-push`); the daemon holds no standing registry credentials.

## Scope / limits

- Only **build+push** is daemonless. `docker run` / `--load` / `services:` / `container:` still need a daemon — keep those on `ubuntu-latest`.
- amd64-only `buildkitd` for now; arm64 = a second arch-pinned deployment (see `buildkit/README.md`).
- Cache is an `emptyDir` (lost on restart); registry cache documented for persistence.

## Validation

- `kustomize build buildkit` renders; `kubeconform -strict -kubernetes-version 1.31.0` passes (Namespace/Service/Deployment valid, CRD skipped).
- The runner-image build workflow runs on this PR (paths under `github-actions-runner/runner-image/**`), exercising the `buildctl` download.

## Follow-up note

Existing pools pin the mutable tag `garm-runner:2.335.1-ubuntu24.04` with `IfNotPresent`, so cached nodes won't pick up the rebuilt image (with the buildx wiring) until forced. Set `imagePullPolicy: Always` on the pool podTemplate or pin to the fresh sha after merge.