### PR TITLE
fix(github-actions-runner): always re-pull runner image

### DIFF
--- a/github-actions-runner/configmap.yaml
+++ b/github-actions-runner/configmap.yaml
@@ -14,6 +14,11 @@ data:
       spec:
         nodeSelector:
           kubernetes.io/arch: amd64
+        # Re-pull the mutable image tag on every cold start so runners pick up
+        # image rebuilds (e.g. the buildx wiring) instead of a stale cached layer.
+        containers:
+          - name: runner
+            imagePullPolicy: Always
     flavors:
       default:
         requests:
@@ -31,6 +36,11 @@ data:
       spec:
         nodeSelector:
           kubernetes.io/arch: arm64
+        # Re-pull the mutable image tag on every cold start so runners pick up
+        # image rebuilds (e.g. the buildx wiring) instead of a stale cached layer.
+        containers:
+          - name: runner
+            imagePullPolicy: Always
     flavors:
       default:
         requests:


### PR DESCRIPTION
## What

Sets `imagePullPolicy: Always` on the GARM runner container, via the `runner`-named container in each provider `podTemplate` (amd64 + arm64). garm-provider-k8s strategic-merges the podTemplate into the runner pod, so this applies to every ephemeral runner.

## Why

Pools pin the **mutable** tag `garm-runner:2.335.1-ubuntu24.04` with the default `IfNotPresent`. After a runner-image rebuild (e.g. the buildx/buildctl wiring in #433), nodes that already cached the old tag keep serving the stale image. `Always` makes each cold-start pull the current image.

Follow-up to #433 as discussed.

## Validation

`kustomize build github-actions-runner` renders; the runner container in both provider configs now carries `imagePullPolicy: Always`.