### PR TITLE
feat(buildkit): multi-arch builds via hardened binfmt

### DIFF
--- a/buildkit/README.md
+++ b/buildkit/README.md
@@ -62,24 +62,48 @@ build and `--push` in one step.
   `endpoint: tcp://buildkitd.buildkit.svc.cluster.local:1234` on that step if
   you must keep it.
 
-## Security
-
-The TCP listener is **unauthenticated** (no TLS). Access is restricted at the
-network layer instead: `networkpolicy.yaml` (a `CiliumNetworkPolicy`, additive
-to the Kyverno-generated default-deny-ingress) allows ingress to `:1234` **only
-from the `github-actions-runner-pods` namespace**. If you ever need to reach the
-daemon from elsewhere, prefer enabling mTLS over widening the policy.
-
 ## Multi-arch
 
-This deploys a single **amd64** `buildkitd`, which builds amd64 images natively.
-For arm64:
+A single `buildkitd` on an amd64 node builds **both** arches:
 
-- **Native:** copy `deployment.yaml`/`service.yaml` to an `arm64` variant
-  (`nodeSelector: kubernetes.io/arch: arm64`, `name: buildkitd-arm64`) and set
-  `BUILDKIT_REMOTE_ENDPOINT` on the arm64 pool to that service.
-- **Emulated:** register binfmt on the nodes (e.g. a `tonistiigi/binfmt`
-  DaemonSet) and build with `--platform linux/amd64,linux/arm64`.
+- `linux/amd64` natively,
+- `linux/arm64` via **QEMU emulation**. `binfmt-daemonset.yaml` registers the
+  aarch64 `binfmt_misc` handler on the amd64 build nodes, so `buildkitd`
+  advertises both platforms and `--platform linux/amd64,linux/arm64` just works.
+
+The cluster's arm64 nodes (a control-plane box, the internal-gateway SPOF, and a
+Raspberry Pi) are unsuitable as build hosts, so emulation on the strong amd64
+worker is the deliberate choice over a native arm64 builder.
+
+## Security
+
+**Build path is non-privileged.** `buildkitd` runs rootless (non-root UID, no
+`privileged`, no added capabilities). It does need `seccomp`/`AppArmor:
+Unconfined` to set up its user-namespaced worker — that is *not* a privileged
+container, but it does relax syscall/LSM filtering (below PSS Baseline). A
+malicious `RUN` therefore tops out at this non-root pod; it cannot reach the node
+as root.
+
+**The only privileged component is binfmt registration**, confined to the
+one-shot `install` initContainer in `binfmt-daemonset.yaml` (fixed command, no
+build input, exits immediately, image digest-pinned). It is *out of the build
+path* — a malicious build can never reach it. This is categorically smaller than
+DinD, which would run privileged *in* the build path on every build.
+
+**Hardening applied** to limit a malicious `RUN`:
+
+- `automountServiceAccountToken: false` on `buildkitd` — no SA token to abuse
+  against the apiserver.
+- `egressDeny` to `169.254.169.254/32` — blocks cloud-metadata SSRF.
+- TCP listener is **unauthenticated**; reachable only from
+  `github-actions-runner-pods` (ingress policy). Prefer mTLS over widening it.
+
+**Still your responsibility:** the runner is shared with the **public**
+`k8s-GitOps` repo. Never run untrusted/fork PRs on the self-hosted runners
+(require approval for outside collaborators); a fork PR that builds here runs
+arbitrary code in this non-privileged—but networked—pod. A full egress
+allow-list (registries only) would further curb exfiltration and is a sensible
+follow-up.
 
 ## Advanced: buildctl directly
 

--- a/buildkit/binfmt-daemonset.yaml
+++ b/buildkit/binfmt-daemonset.yaml
@@ -1,0 +1,60 @@
+# Registers QEMU binfmt_misc handlers on the amd64 build nodes so the single
+# rootless buildkitd can build arm64 images via emulation (multi-arch) — with no
+# privilege in the build path.
+#
+# Security model: the ONLY privileged component is the one-shot `install`
+# initContainer (fixed command, no build input, exits immediately). buildkitd and
+# the runner pods stay non-privileged, so a malicious build can never reach this
+# container. The image is digest-pinned to remove the tag-mutation supply-chain
+# vector, and the SA token is not mounted. See README "Security".
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: binfmt
+  namespace: buildkit
+  labels:
+    app.kubernetes.io/name: binfmt
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: binfmt
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: binfmt
+    spec:
+      # Only the amd64 build nodes (where buildkitd runs) need emulation.
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      automountServiceAccountToken: false
+      initContainers:
+        - name: install
+          # Pinned by digest (qemu-v10.2.3). Renovate keeps the tag+digest in sync.
+          image: tonistiigi/binfmt:qemu-v10.2.3@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
+          # Register only aarch64 — keep the emulator surface minimal.
+          args: ["--install", "arm64"]
+          securityContext:
+            # Registering binfmt_misc mounts the binfmt fs and writes host kernel
+            # state, which needs node privilege. Confined to this one-shot install;
+            # nothing in the build path is privileged.
+            privileged: true
+      containers:
+        # Non-privileged keepalive so the DaemonSet pod stays scheduled and the
+        # init re-registers binfmt after a node reboot.
+        - name: keepalive
+          image: registry.k8s.io/pause:3.10
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65535
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 32Mi

--- a/buildkit/deployment.yaml
+++ b/buildkit/deployment.yaml
@@ -17,11 +17,14 @@ spec:
       labels:
         app.kubernetes.io/name: buildkitd
     spec:
-      # Builds run natively on amd64. For native arm64 builds, run a second
-      # deployment+service pinned to arch arm64 (see README), or register
-      # binfmt on the nodes for emulated cross-builds.
+      # Single builder for both arches: amd64 builds natively, arm64 builds via
+      # QEMU emulation (binfmt registered on the node by binfmt-daemonset.yaml).
       nodeSelector:
         kubernetes.io/arch: amd64
+      # buildkitd talks only to registries (creds forwarded per-build) and the
+      # Actions cache — never the Kubernetes API. Drop the SA token so a
+      # malicious build cannot use it against the apiserver.
+      automountServiceAccountToken: false
       containers:
         - name: buildkitd
           image: moby/buildkit:v0.30.0-rootless

--- a/buildkit/kustomization.yaml
+++ b/buildkit/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - networkpolicy.yaml
+  - binfmt-daemonset.yaml

--- a/buildkit/networkpolicy.yaml
+++ b/buildkit/networkpolicy.yaml
@@ -1,7 +1,14 @@
 # BuildKit's TCP listener is unauthenticated, so access is restricted at the
 # network layer: only pods in the GARM runner-pods namespace may reach :1234.
-# This is additive to the Kyverno-generated default-deny-ingress; egress is left
-# open so buildkitd can pull base images and push to Harbor.
+# This is additive to the Kyverno-generated default-deny-ingress.
+#
+# Egress stays open so buildkitd can pull base images and push to registries,
+# but the cloud metadata endpoint is explicitly denied: a malicious Dockerfile
+# executes inside this pod, so blocking 169.254.169.254 stops it from SSRF-ing
+# node credentials. Paired with automountServiceAccountToken:false on the pod,
+# this removes the two cheapest credential-theft paths. (A full egress allow-list
+# would also curb exfiltration, but is left as a follow-up to avoid breaking
+# base-image pulls.)
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -22,3 +29,6 @@ spec:
         - ports:
             - port: "1234"
               protocol: TCP
+  egressDeny:
+    - toCIDR:
+        - 169.254.169.254/32


### PR DESCRIPTION
## What

Makes the in-cluster BuildKit build **multi-arch** (`linux/amd64,linux/arm64`) and tightens the blast radius of a malicious build on the shared daemon.

## Multi-arch (binfmt emulation)

`binfmt-daemonset.yaml` registers the QEMU aarch64 `binfmt_misc` handler on the amd64 build nodes, so the single rootless `buildkitd` advertises both platforms — `--platform linux/amd64,linux/arm64` then works (amd64 native, arm64 emulated). The cluster's arm64 nodes (control-plane box, the internal-gateway SPOF, a Raspberry Pi) are unsuitable build hosts, so emulation on the strong amd64 worker is the deliberate choice over a native arm64 builder.

## Security posture (discussed at length)

- **Privilege is confined to one place, out of the build path:** the binfmt `install` initContainer (fixed command, no build input, exits immediately). Image is **digest-pinned** (`tonistiigi/binfmt:qemu-v10.2.3@sha256:400a48…`) to kill the tag-mutation supply-chain vector. The keepalive is a non-root, `drop: ALL`, `RuntimeDefault`, read-only pause. This is categorically smaller than DinD (privileged *in* the build path, every build).
- **buildkitd stays non-privileged** (rootless, no caps). It keeps `seccomp/AppArmor: Unconfined` (needed for the rootless worker — not privileged, but below PSS Baseline; disclosed in the README).
- **Malicious-`RUN` hardening:** `automountServiceAccountToken: false` (no SA token to abuse) + `egressDeny 169.254.169.254/32` (block cloud-metadata SSRF).

## Operational note

Self-hosted runners are shared with the **public** `k8s-GitOps` repo. Do not run untrusted/fork PRs on them (require approval for outside collaborators). A full egress allow-list (registries only) is a sensible follow-up to also curb exfiltration.

## Validation

`kustomize build buildkit` renders; `kubeconform -strict -kubernetes-version 1.31.0` passes (DaemonSet/Deployment/Service/Namespace valid, CRD skipped).

Pairs with the crypto-auto-trading workflow change (drop `docker/setup-buildx-action` so the runner's default remote builder is used).