### PR TITLE
feat(github-actions-runner): bundle Rust toolchain in runner image

### DIFF
--- a/github-actions-runner/runner-image/Dockerfile
+++ b/github-actions-runner/runner-image/Dockerfile
@@ -38,6 +38,17 @@ RUN curl -fsSL "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VE
       | tar -xz -C /usr/local bin/buildctl \
     && buildctl --version
 
+# Rust toolchain — parity with GitHub-hosted ubuntu-latest, which preinstalls it
+# (the actions-runner base image does not). Installed system-wide so every job
+# sees cargo/rustc on PATH; CARGO_HOME is world-writable for the runner user.
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs \
+      | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable \
+    && chmod -R a+w "$RUSTUP_HOME" "$CARGO_HOME" \
+    && rustc --version && cargo --version
+
 COPY --chown=runner:docker entrypoint.sh /entrypoint.sh
 
 RUN chmod 0755 /entrypoint.sh \


### PR DESCRIPTION
## What
Install the Rust toolchain (rustup + stable) system-wide in the GARM runner image.

## Why
`ghcr.io/actions/actions-runner` is the minimal runner agent, not the fat `ubuntu-latest` VM image — it has no Rust. Jobs that assumed `cargo` was present (it's preinstalled on GitHub-hosted) fail on self-hosted with `FileNotFoundError: 'cargo'` (e.g. crypto-auto-trading's `python` suite builds a Rust backend at test time). Bundling it in the image gives parity, so those workflows run **unchanged** — no per-job toolchain step needed.

`CARGO_HOME`/`RUSTUP_HOME` are system paths on `PATH`; `CARGO_HOME` is world-writable so the `runner` user's builds can use the cargo cache.

## Note
The runner-image build workflow runs on this PR (paths under `runner-image/**`), exercising the rustup install for both amd64 and arm64.