### PR TITLE
fix(harbor-build-push): skip qemu/buildx setup on self-hosted runners

### DIFF
--- a/.github/actions/harbor-build-push/action.yml
+++ b/.github/actions/harbor-build-push/action.yml
@@ -128,13 +128,19 @@ outputs:
 runs:
   using: composite
   steps:
-    # QEMU registers arm64 emulation on the amd64 GitHub-hosted runner so
-    # buildx can produce arm64 layers from the same Dockerfile.
-    - uses: docker/setup-qemu-action@v4
+    # setup-qemu / setup-buildx talk to a local Docker daemon, which the
+    # self-hosted shion1305 runners don't have. There QEMU is already
+    # registered cluster-wide by the binfmt DaemonSet and a remote buildx
+    # builder (pointed at the in-cluster rootless BuildKit) is pre-registered
+    # at runner startup, so both steps would only fail. Run them on
+    # GitHub-hosted runners only; the build step below works on both.
+    - if: runner.environment == 'github-hosted'
+      uses: docker/setup-qemu-action@v4
       with:
         platforms: arm64
 
-    - uses: docker/setup-buildx-action@v4
+    - if: runner.environment == 'github-hosted'
+      uses: docker/setup-buildx-action@v4
 
     # cosign signs the image keyless via Fulcio + Rekor. SBOM generation
     # is intentionally NOT done in CI — Harbor v2.15's UI does not surface


### PR DESCRIPTION
## What

Gate `docker/setup-qemu-action` and `docker/setup-buildx-action` in the shared `harbor-build-push` composite action on `runner.environment == 'github-hosted'`.

## Why

Both steps talk to a local Docker daemon, which the daemonless self-hosted `shion1305-amd/arm` runners don't have — so any repo calling `harbor-build-push@main` from a self-hosted runner fails immediately at `docker version` (seen in [fde-knowledge-engine#13](https://github.com/Shion1305/fde-knowledge-engine/pull/13) build-push jobs).

On self-hosted there's no need for either:
- **QEMU** is already registered cluster-wide by the `buildkit` binfmt DaemonSet (on the node where buildkitd actually runs the build).
- A **remote buildx builder** pointed at the in-cluster rootless BuildKit is pre-registered at runner startup (`github-actions-runner` entrypoint).

The `docker buildx build` step itself is unchanged and works on both runner types. GitHub-hosted behaviour is identical (the `if` is true there), so existing consumers are unaffected.

## Ordering

Consumers that reference `@main` (e.g. fde-knowledge-engine) only go green on their build-push jobs **after this merges**.