### PR TITLE
fix(garm-runner): add gettext-base (envsubst) to runner image

### DIFF
--- a/github-actions-runner/runner-image/Dockerfile
+++ b/github-actions-runner/runner-image/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
       cmake \
       curl \
       file \
+      gettext-base \
       git-lfs \
       gzip \
       jq \


### PR DESCRIPTION
## What
Add `gettext-base` (provides `envsubst`) to the GARM runner image apt list.

## Why
`sigstore/cosign-installer`, invoked by the shared `harbor-build-push` action, shells out to `envsubst`. GitHub-hosted runners ship it; our runner image didn't — so the first self-hosted `harbor-build-push` consumer ([fde-knowledge-engine#13](https://github.com/Shion1305/fde-knowledge-engine/pull/13)) failed its build-push jobs with `envsubst: command not found` (exit 127), right after the (now-skipped) qemu/buildx steps from #437.

This is a runner-environment parity gap, so fixing it once in the image covers every future self-hosted `harbor-build-push` consumer — no per-repo workflow change needed.

## Rollout
On merge, `build-garm-runner-image.yaml` (ubuntu-latest, which has envsubst) rebuilds and re-tags the mutable `2.335.1-ubuntu24.04`; runner pods pull `Always`, so the next ephemeral runner picks it up. Then re-run fde-knowledge-engine#13's build-push jobs.