### PR TITLE
feat(outline): deploy Outline knowledge base in outline namespace

### DIFF
--- a/apps/outline-app.yaml
+++ b/apps/outline-app.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: outline
+  namespace: argocd
+spec:
+  project: default
+  # Single-source raw-manifest pattern: Outline has no maintained upstream Helm
+  # chart, so the Deployment/Service/PVC/Redis and all wiring live in the
+  # `outline/` directory and are applied via Kustomize.
+  source:
+    repoURL: https://github.com/Shion1305/k8s-GitOps.git
+    targetRevision: HEAD
+    path: outline
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: outline
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/keycloak-operator/user-realm.yaml
+++ b/keycloak-operator/user-realm.yaml
@@ -174,3 +174,24 @@ spec:
           - https://keycloak.shion1305.com/realms/harbor/broker/user/endpoint
         webOrigins:
           - https://keycloak.shion1305.com
+      # Outline is NOT a child realm broker but a direct OIDC relying party:
+      # the Outline app authenticates human users straight against this
+      # passkey realm. Its callback is Outline's OIDC strategy endpoint
+      # (<URL>/auth/oidc.callback). The Keycloak-generated client secret must
+      # be copied post-import into Vault at secret/shared/outline
+      # (OIDC_CLIENT_SECRET) so External Secrets can deliver it to the app;
+      # see outline/README.md. Do NOT commit the actual secret to git.
+      - clientId: outline
+        name: "Outline knowledge base"
+        description: "Direct OIDC client for the Outline app (outline.shion1305.com)."
+        protocol: openid-connect
+        publicClient: false
+        clientAuthenticatorType: client-secret
+        secret: PLACEHOLDER_REPLACE_AFTER_REALM_IMPORT
+        standardFlowEnabled: true
+        directAccessGrantsEnabled: false
+        serviceAccountsEnabled: false
+        redirectUris:
+          - https://outline.shion1305.com/auth/oidc.callback
+        webOrigins:
+          - https://outline.shion1305.com

--- a/outline/README.md
+++ b/outline/README.md
@@ -1,0 +1,71 @@
+# Outline
+
+Self-hosted [Outline](https://www.getoutline.com/) knowledge base.
+
+- **URL**: <https://outline.shion1305.com>
+- **Namespace**: `outline`
+- **Auth**: OIDC against the Keycloak `user` realm (passkey human-user pool)
+
+## Architecture
+
+| Concern        | Implementation                                                                 |
+| -------------- | ------------------------------------------------------------------------------ |
+| App            | `outlinewiki/outline` Deployment (single replica, `Recreate`) + ClusterIP Svc  |
+| Database       | `outline` user/db on the shared `postgres-shared` cluster (in-cluster, no SSL) |
+| Redis          | Disposable in-namespace `outline-redis` (no persistence)                       |
+| File storage   | `FILE_STORAGE=local` on a 20Gi Longhorn RWO PVC at `/var/lib/outline/data`     |
+| Ingress        | `HTTPRoute` on the `external` Gateway → `outline.shion1305.com`                 |
+| App secrets    | Vault `secret/shared/outline` → ESO → `outline-secrets` Secret                 |
+| DB credentials | postgres-operator Secret → ESO (k8s provider) → `outline-db` Secret            |
+
+Config is split: non-secret env in `configmap.yaml` (`outline-config`),
+secrets in the `outline-secrets` / `outline-db` Secrets. Schema migrations run
+in an initContainer (`yarn db:migrate`) before the web container starts.
+
+Outline is reached only via the Gateway, so no app-specific `NetworkPolicy` is
+needed (the generated default-deny allows same-namespace ingress, and
+`postgres-shared`'s Cilium policy lists the `outline` namespace). Egress is
+open, so the pod can reach Postgres and Keycloak.
+
+## One-time bootstrap (out-of-band, before/at first sync)
+
+These steps handle secrets that intentionally never live in this public repo.
+
+1. **Generate the app secrets and write them to Vault.** `OIDC_CLIENT_SECRET`
+   comes from Keycloak in step 2 — write the two random keys first, then patch
+   in the client secret.
+
+   ```bash
+   vault kv put secret/shared/outline \
+     SECRET_KEY="$(openssl rand -hex 32)" \
+     UTILS_SECRET="$(openssl rand -hex 32)" \
+     OIDC_CLIENT_SECRET="PLACEHOLDER_UNTIL_STEP_2"
+   ```
+
+2. **Retrieve the Keycloak client secret.** The `outline` client is declared in
+   `keycloak-operator/user-realm.yaml` with a placeholder secret that Keycloak
+   replaces on import. In the admin UI: realm `user` → Clients → `outline` →
+   Credentials → "Client secret". Patch it into Vault:
+
+   ```bash
+   vault kv patch secret/shared/outline OIDC_CLIENT_SECRET="<value-from-keycloak>"
+   ```
+
+3. **Register the Vault ESO policy/role** (already added to
+   `vault/scripts/setup-eso-policies.sh` — re-run it, or apply just the
+   `eso-outline` policy + role):
+
+   ```bash
+   bash vault/scripts/setup-eso-policies.sh
+   ```
+
+After these, ArgoCD syncs the app: ESO materializes `outline-secrets` and
+`outline-db`, the initContainer migrates the schema, and the web pod starts.
+
+## Notes
+
+- The first user to sign in via OIDC becomes the workspace admin; subsequent
+  users are added as members. Manage roles in Outline's own settings.
+- The image tag is pinned and bumped by Renovate.
+- To rotate `SECRET_KEY`/`UTILS_SECRET`, update Vault and restart the Deployment
+  (ESO refreshes the Secret within `refreshInterval`).

--- a/outline/configmap.yaml
+++ b/outline/configmap.yaml
@@ -1,0 +1,42 @@
+# Non-secret Outline configuration. Secrets (SECRET_KEY, UTILS_SECRET,
+# OIDC_CLIENT_SECRET, DATABASE_URL) are injected separately via the
+# outline-secrets / outline-db Secrets materialized by External Secrets.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: outline-config
+  namespace: outline
+data:
+  NODE_ENV: "production"
+  URL: "https://outline.shion1305.com"
+  PORT: "3000"
+  # TLS is terminated at Envoy Gateway, which forwards X-Forwarded-Proto. The
+  # gateway already enforces HTTPS, so disable Outline's own redirect to avoid
+  # any proxy-header redirect loop.
+  FORCE_HTTPS: "false"
+  DEFAULT_LANGUAGE: "en_US"
+  WEB_CONCURRENCY: "1"
+
+  # Postgres: shared cluster, in-cluster plaintext (pg_hba allows md5 over
+  # non-SSL). DATABASE_URL itself is templated into the outline-db Secret.
+  PGSSLMODE: "disable"
+
+  # Redis: in-namespace ephemeral instance (redis.yaml). Used for the
+  # websocket/collaboration pub-sub and the BullMQ job queue only.
+  REDIS_URL: "redis://outline-redis:6379"
+
+  # Attachments/images on the local Longhorn volume.
+  FILE_STORAGE: "local"
+  FILE_STORAGE_LOCAL_ROOT_DIR: "/var/lib/outline/data"
+  FILE_STORAGE_UPLOAD_MAX_SIZE: "262144000"
+
+  # OIDC against the Keycloak `user` realm (central passkey human-user pool).
+  # The client secret is delivered via the outline-secrets Secret.
+  OIDC_CLIENT_ID: "outline"
+  OIDC_AUTH_URI: "https://keycloak.shion1305.com/realms/user/protocol/openid-connect/auth"
+  OIDC_TOKEN_URI: "https://keycloak.shion1305.com/realms/user/protocol/openid-connect/token"
+  OIDC_USERINFO_URI: "https://keycloak.shion1305.com/realms/user/protocol/openid-connect/userinfo"
+  OIDC_LOGOUT_URI: "https://keycloak.shion1305.com/realms/user/protocol/openid-connect/logout"
+  OIDC_USERNAME_CLAIM: "preferred_username"
+  OIDC_DISPLAY_NAME: "Keycloak"
+  OIDC_SCOPES: "openid profile email"

--- a/outline/db-secret-store.yaml
+++ b/outline/db-secret-store.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso-db
+  namespace: outline
+---
+# Reads the postgres-operator-generated credentials Secret for the `outline`
+# user out of the operator's namespace (same Kubernetes-provider pattern as
+# langfuse/openwebui).
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: k8s-postgres
+  namespace: outline
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: postgres-operator-deployment
+      server:
+        url: "https://kubernetes.default.svc"
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: eso-db

--- a/outline/deployment.yaml
+++ b/outline/deployment.yaml
@@ -1,0 +1,100 @@
+# Outline knowledge base — single web replica.
+#
+# Storage: FILE_STORAGE=local on a Longhorn RWO PVC mounted at
+# /var/lib/outline/data (see pvc.yaml). Because the PVC is ReadWriteOnce the
+# Deployment uses the Recreate strategy — a rolling update would deadlock with
+# two pods contending for the same volume.
+#
+# Schema migrations are NOT run by `yarn start`; an initContainer runs
+# `yarn db:migrate` first. `--env=production-ssl-disabled` matches the in-cluster
+# plaintext Postgres connection (PGSSLMODE=disable, see envFrom/env below).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: outline
+  namespace: outline
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: outline
+  template:
+    metadata:
+      labels:
+        app: outline
+    spec:
+      securityContext:
+        # Outline's image runs as uid/gid 1001 ("nodejs"); chown the Longhorn
+        # volume to it via fsGroup so local file storage is writable.
+        fsGroup: 1001
+      initContainers:
+        - name: migrate
+          image: outlinewiki/outline:1.8.1
+          command: ["yarn", "db:migrate", "--env=production-ssl-disabled"]
+          envFrom:
+            - configMapRef:
+                name: outline-config
+            - secretRef:
+                name: outline-db
+            - secretRef:
+                name: outline-secrets
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+      containers:
+        - name: outline
+          image: outlinewiki/outline:1.8.1
+          ports:
+            - containerPort: 3000
+          envFrom:
+            - configMapRef:
+                name: outline-config
+            - secretRef:
+                name: outline-db
+            - secretRef:
+                name: outline-secrets
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/outline/data
+          readinessProbe:
+            httpGet:
+              path: /_health
+              port: 3000
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /_health
+              port: 3000
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: outline-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: outline
+  namespace: outline
+spec:
+  type: ClusterIP
+  selector:
+    app: outline
+  ports:
+    - port: 80
+      targetPort: 3000

--- a/outline/external-secret-db.yaml
+++ b/outline/external-secret-db.yaml
@@ -1,0 +1,33 @@
+# Materializes the outline-db Secret. Outline only accepts a single
+# DATABASE_URL connection string, so the username/password pulled from the
+# postgres-operator Secret are templated into the full URL here.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: outline-db
+  namespace: outline
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: k8s-postgres
+    kind: SecretStore
+  target:
+    name: outline-db
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+      data:
+        DATABASE_URL: "postgres://{{ .username }}:{{ .password }}@postgres-shared.postgres-operator-deployment.svc.cluster.local:5432/outline"
+  data:
+    - secretKey: username
+      remoteRef:
+        key: outline.postgres-shared.credentials.postgresql.acid.zalan.do
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: outline.postgres-shared.credentials.postgresql.acid.zalan.do
+        property: password

--- a/outline/external-secret.yaml
+++ b/outline/external-secret.yaml
@@ -1,0 +1,37 @@
+# Materializes the outline-secrets Secret from Vault (secret/shared/outline).
+# Populate the Vault path out-of-band before first sync — see outline/README.md:
+#   vault kv put secret/shared/outline \
+#     SECRET_KEY=<openssl rand -hex 32> \
+#     UTILS_SECRET=<openssl rand -hex 32> \
+#     OIDC_CLIENT_SECRET=<keycloak-generated outline client secret>
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: outline-secrets
+  namespace: outline
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  target:
+    name: outline-secrets
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+  data:
+    - secretKey: SECRET_KEY
+      remoteRef:
+        key: shared/outline
+        property: SECRET_KEY
+    - secretKey: UTILS_SECRET
+      remoteRef:
+        key: shared/outline
+        property: UTILS_SECRET
+    - secretKey: OIDC_CLIENT_SECRET
+      remoteRef:
+        key: shared/outline
+        property: OIDC_CLIENT_SECRET

--- a/outline/httproute-external.yaml
+++ b/outline/httproute-external.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: outline-external
+  namespace: outline
+spec:
+  parentRefs:
+    - name: external
+      namespace: envoy-gateway-system
+      sectionName: https
+  hostnames:
+    - outline.shion1305.com
+  rules:
+    - backendRefs:
+        - name: outline
+          port: 80

--- a/outline/kustomization.yaml
+++ b/outline/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - pvc.yaml
+  - redis.yaml
+  - deployment.yaml
+  - reference-grant.yaml
+  - httproute-external.yaml
+  - vault-secret-store.yaml
+  - external-secret.yaml
+  - db-secret-store.yaml
+  - external-secret-db.yaml

--- a/outline/namespace.yaml
+++ b/outline/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: outline
+  labels:
+    name: outline

--- a/outline/pvc.yaml
+++ b/outline/pvc.yaml
@@ -1,0 +1,15 @@
+# Local attachment/image storage for Outline (FILE_STORAGE=local).
+# ReadWriteOnce is sufficient for the single web replica; the Deployment uses
+# the Recreate strategy so the volume is never contended.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: outline-data
+  namespace: outline
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-hdd
+  resources:
+    requests:
+      storage: 20Gi

--- a/outline/redis.yaml
+++ b/outline/redis.yaml
@@ -1,0 +1,46 @@
+# Disposable Redis for Outline: backs the websocket/collaboration pub-sub and
+# the BullMQ job queue. No persistence — Postgres + the local volume hold the
+# source of truth, so a restart just drops in-flight queue state. Same-namespace
+# only (no NetworkPolicy needed; the generated default-deny allows same-ns
+# ingress).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: outline-redis
+  namespace: outline
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: outline-redis
+  template:
+    metadata:
+      labels:
+        app: outline-redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7.4-alpine
+          args: ["--save", "", "--appendonly", "no"]
+          ports:
+            - containerPort: 6379
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: outline-redis
+  namespace: outline
+spec:
+  type: ClusterIP
+  selector:
+    app: outline-redis
+  ports:
+    - port: 6379
+      targetPort: 6379

--- a/outline/reference-grant.yaml
+++ b/outline/reference-grant.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ReferenceGrant
+metadata:
+  name: allow-envoy-gateway
+  namespace: outline
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: envoy-gateway-system
+  to:
+    - group: ""
+      kind: Service

--- a/outline/vault-secret-store.yaml
+++ b/outline/vault-secret-store.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso
+  namespace: outline
+---
+# Vault-backed app secrets (SECRET_KEY, UTILS_SECRET, OIDC_CLIENT_SECRET).
+# Bound to the eso-outline Vault role; see vault/scripts/setup-eso-policies.sh.
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: vault
+  namespace: outline
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "secret"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "eso-outline"
+          serviceAccountRef:
+            name: "eso"

--- a/postgres-shared/networkpolicy.yaml
+++ b/postgres-shared/networkpolicy.yaml
@@ -27,6 +27,7 @@ spec:
                 - mlflow
                 - nc-press-chotatsu
                 - openwebui
+                - outline
                 - postgres-operator
                 - scalable-llm
       toPorts:

--- a/postgres-shared/postgres-cluster.yaml
+++ b/postgres-shared/postgres-cluster.yaml
@@ -18,6 +18,7 @@ spec:
     harbor: []
     litellm: [] # LiteLLM front for scalable-llm (KubeAI on Tenstorrent)
     fde_knowledge_engine: []
+    outline: []
   databases:
     openwebui: openwebui
     langfuse: langfuse
@@ -27,6 +28,7 @@ spec:
     harbor: harbor
     litellm: litellm
     fde_knowledge_engine: fde_knowledge_engine
+    outline: outline
   postgresql:
     version: "17"
   resources:

--- a/vault/scripts/setup-eso-policies.sh
+++ b/vault/scripts/setup-eso-policies.sh
@@ -40,6 +40,17 @@ path "secret/metadata/shared/openwebui" {
 EOF
 echo "✓ Created policy: eso-openwebui"
 
+# Policy for outline namespace
+vault policy write eso-outline - <<EOF
+path "secret/data/shared/outline" {
+  capabilities = ["read"]
+}
+path "secret/metadata/shared/outline" {
+  capabilities = ["read", "list"]
+}
+EOF
+echo "✓ Created policy: eso-outline"
+
 # Policy for keycloak namespace
 vault policy write eso-keycloak - <<EOF
 path "secret/data/shared/keycloak" {
@@ -253,6 +264,14 @@ vault write auth/kubernetes/role/eso-openwebui \
   policies=eso-openwebui \
   ttl=1h
 echo "✓ Created role: eso-openwebui"
+
+# Outline
+vault write auth/kubernetes/role/eso-outline \
+  bound_service_account_names=eso \
+  bound_service_account_namespaces=outline \
+  policies=eso-outline \
+  ttl=1h
+echo "✓ Created role: eso-outline"
 
 # Keycloak
 vault write auth/kubernetes/role/eso-keycloak \
@@ -474,6 +493,7 @@ echo ""
 echo "Per-namespace roles created:"
 echo "  eso-langfuse    → SA eso/langfuse        → secret/data/shared/langfuse"
 echo "  eso-openwebui   → SA eso/openwebui       → secret/data/shared/openwebui"
+echo "  eso-outline     → SA eso/outline         → secret/data/shared/outline"
 echo "  eso-keycloak    → SA eso/keycloak        → secret/data/shared/keycloak"
 echo "  eso-atc         → SA eso/atc             → atc/data/*"
 echo "  eso-lumos-bot   → SA eso/lumos-bot       → lumos-bot/data/*"


### PR DESCRIPTION
## Summary

Deploys self-hosted [Outline](https://docs.getoutline.com/s/hosting) at **https://outline.shion1305.com** in a new `outline` namespace, following the repo's single-source raw-manifest pattern (no maintained upstream Helm chart exists).

| Concern | Implementation |
| --- | --- |
| App | `outlinewiki/outline:1.8.1` Deployment — single replica, `Recreate` (RWO volume), schema migrations in an initContainer (`yarn db:migrate`), `/_health` probes |
| Database | dedicated `outline` user/db on the shared `postgres-shared` cluster; in-cluster plaintext (`PGSSLMODE=disable`) |
| DB creds | postgres-operator Secret → ESO (k8s provider) → `outline-db`, with `DATABASE_URL` templated |
| Redis | disposable in-namespace `outline-redis` (no persistence) for pub-sub + BullMQ queue |
| File storage | `FILE_STORAGE=local` on a 20Gi Longhorn **`longhorn-hdd`** RWO PVC |
| Auth | OIDC against the Keycloak `user` (passkey) realm; new `outline` relying-party client |
| App secrets | Vault `secret/shared/outline` → ESO → `outline-secrets` (`SECRET_KEY`, `UTILS_SECRET`, `OIDC_CLIENT_SECRET`) |
| Ingress | `HTTPRoute` on the `external` Gateway → `outline.shion1305.com` |

## Shared-resource changes

- `postgres-shared/postgres-cluster.yaml` — add `outline` user + db
- `postgres-shared/networkpolicy.yaml` — allow the `outline` namespace to reach Postgres
- `vault/scripts/setup-eso-policies.sh` — add `eso-outline` policy + role
- `keycloak-operator/user-realm.yaml` — add the `outline` OIDC client (placeholder secret per convention)

## One-time bootstrap (out-of-band, documented in `outline/README.md`)

1. `vault kv put secret/shared/outline SECRET_KEY=… UTILS_SECRET=… OIDC_CLIENT_SECRET=…`
2. Copy the Keycloak-generated `outline` client secret into Vault
3. Re-run `vault/scripts/setup-eso-policies.sh`

Until then the app stays `Progressing` (ESO can't materialize `outline-secrets`) — expected, not a failure.

## Validation

- `kustomize build outline` → 15 resources
- `kubeconform -strict -ignore-missing-schemas` → 0 invalid (6 CRDs skipped, no schema)
- `kustomize build postgres-shared` OK; ESO `DATABASE_URL` template survives render

## Notes / follow-ups

- Confirm in-cluster reach to `keycloak.shion1305.com` for the first OIDC login (server-side token/userinfo hairpins through the external gateway, the standard pattern here).
- Uses the shared `secret/shared/<svc>` Vault mount (langfuse/openwebui precedent) rather than a dedicated per-namespace mount.