### PR TITLE
feat(envoy-gateway): home-resident gateway + split-horizon for Harbor

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -140,6 +140,60 @@ the WireGuard CIDR (the LAN-side L4 control). There is no
 SecurityPolicy / IP-allowlist on the internal Gateway today; defense in
 depth at L7 may be added later.
 
+## Home-resident gateway (in-cluster split-horizon)
+
+The canonical Envoy data plane is a single proxy pinned to `instance-k8s-proxy`
+(the OCI node) with `hostNetwork`, owning both `141.147.189.36` and
+`10.130.5.21`. That is correct for genuinely external traffic, but it means an
+**in-cluster** client on a home node that talks to a `*.shion1305.com` /
+`*.i.shion1305.com` host hairpins **home → OCI → home**: the request leaves to
+the OCI gateway and the gateway proxies straight back to a backend that usually
+runs on a home node. For large transfers (e.g. a GARM runner pushing a
+multi-arch image to Harbor) this wastes the home uplink / WireGuard mesh badly.
+
+The fix is a **second, home-resident Envoy fleet** plus **split-horizon DNS**:
+
+- `GatewayClass envoy-home` → `EnvoyProxy home` runs Envoy on the amd64 home
+  nodes (`shion-ubuntu-2505` / `shion-ubuntu-2605`), **not** hostNetwork,
+  reached via an in-cluster ClusterIP (`envoy-gateway/envoyproxy-home.yaml`).
+- `Gateway home` terminates `*.shion1305.com` and `*.i.shion1305.com` on `:443`
+  by SNI, reusing the **same wildcard certificates** as the OCI gateway
+  (`envoy-gateway/gateway-home.yaml`).
+- `Service home-ingress` is a stable-named ClusterIP in front of that fleet
+  (`envoy-gateway/service-home.yaml`); the EG-provisioned Service has a hashed
+  name, so this hand-authored one is what CoreDNS targets.
+- CoreDNS rewrites the opted-in hostnames to that Service
+  (`kube-system-manual-config/coredns-configmap.yaml`), so a pod's request
+  terminates on a home node and reaches the backend over the home network only.
+
+An app opts in by (a) adding the `home` Gateway to its HTTPRoute `parentRefs`
+and (b) adding a CoreDNS `rewrite` line for its hostname. Today only Harbor is
+wired (`harbor/httproute-external.yaml`, `harbor/httproute-internal.yaml`). The
+two opt-ins must stay in lockstep — a hostname rewritten to `home-ingress`
+without a matching route on the `home` Gateway returns 404.
+
+Scope and limits (current = "Phase 1"):
+
+- **Pods only.** The CoreDNS rewrite governs pod DNS. **kubelet image pulls use
+  the node resolver, not CoreDNS**, so in-cluster *pulls* still reach the OCI
+  gateway; redirecting those needs a per-node `/etc/hosts`/NodeHosts step (a
+  later phase). The immediate win is pod-originated traffic — notably runner
+  `crane push`.
+- **No same-host pinning yet.** `home-ingress` is a plain ClusterIP, so a pod
+  may terminate on either home node (one cheap home-LAN hop) rather than its
+  own. A later phase can switch the fleet to a DaemonSet and add
+  `internalTrafficPolicy: Local` to pin termination to the client's node.
+- **External clients are unchanged.** Public DNS still points at
+  `141.147.189.36` / `10.130.5.21`; only in-cluster resolution is overridden.
+
+`kube-system-manual-config/coredns-configmap.yaml` is **not** managed by ArgoCD
+— apply it by hand and roll CoreDNS:
+
+```bash
+kubectl apply -f kube-system-manual-config/coredns-configmap.yaml
+kubectl rollout restart -n kube-system deployment/coredns
+```
+
 ## Migration status
 
 | Phase | Status | Notes |

--- a/envoy-gateway/envoyproxy-home.yaml
+++ b/envoy-gateway/envoyproxy-home.yaml
@@ -1,0 +1,70 @@
+# Data plane for the `envoy-home` GatewayClass: a second Envoy fleet that lives
+# on the amd64 home nodes (shion-ubuntu-2505 / shion-ubuntu-2605) so that
+# in-cluster traffic to *.shion1305.com / *.i.shion1305.com can be terminated
+# INSIDE the home network instead of detouring through the OCI gateway
+# (instance-k8s-proxy) and back over WireGuard.
+#
+# Differences from the `instance-k8s-proxy` EnvoyProxy (envoyproxy.yaml):
+#   - NOT hostNetwork. This fleet is reached via an in-cluster ClusterIP
+#     (see service-home.yaml), not by owning a node's :443. So there is no
+#     privileged-port bind, no `--base-id` dance against cilium-envoy (which
+#     only collides in the shared host netns), and no root securityContext.
+#     The proxy binds the default offset container port 10443 for the :443
+#     listener; service-home.yaml maps 443 -> 10443.
+#   - Pinned to the two amd64 home nodes. Harbor itself is amd64-only
+#     (harbor/values.yaml), so harbor-core always lands on one of these; co-
+#     locating the ingress keeps the whole path on the home LAN/WireGuard mesh.
+#   - replicas: 2 with soft anti-affinity => one proxy per home node for HA.
+#     (Phase 2 will switch this to a DaemonSet so a Service with
+#     internalTrafficPolicy: Local can pin termination to the client's own node;
+#     not needed yet — plain ClusterIP load-balancing already removes the OCI
+#     round-trip.)
+#
+# mergeGateways: true matches the existing fleet's labeling
+# (gateway.envoyproxy.io/owning-gatewayclass=envoy-home), which service-home.yaml
+# selects on. Only the `home` Gateway uses this class, so the merge is a no-op
+# beyond the label scheme.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: home
+  namespace: envoy-gateway-system
+spec:
+  mergeGateways: true
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        replicas: 2
+        pod:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: kubernetes.io/hostname
+                        operator: In
+                        values:
+                          - shion-ubuntu-2505
+                          - shion-ubuntu-2605
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    topologyKey: kubernetes.io/hostname
+                    labelSelector:
+                      matchLabels:
+                        gateway.envoyproxy.io/owning-gatewayclass: envoy-home
+        container:
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+      envoyService:
+        # In-cluster only; CoreDNS rewrites the target hostnames to the stable
+        # ClusterIP Service in service-home.yaml. This EG-managed Service exists
+        # but is not referenced by name (its name carries a hash suffix).
+        type: ClusterIP

--- a/envoy-gateway/gateway-home.yaml
+++ b/envoy-gateway/gateway-home.yaml
@@ -1,0 +1,47 @@
+# Home Gateway: terminates the apex and internal wildcard hostnames on the home
+# nodes for in-cluster clients. Two HTTPS listeners share :443 and are
+# distinguished by SNI:
+#
+#   https           *.shion1305.com    cert wildcard-shion1305-com-tls
+#   https-internal  *.i.shion1305.com  cert wildcard-i-shion1305-com-tls
+#
+# Both certs already live in this namespace (envoy-gateway/certificates.yaml),
+# so the same wildcard certificates the OCI gateway serves are reused verbatim —
+# clients see an identical, valid certificate regardless of which gateway they
+# land on.
+#
+# Routes are attached per-app (NOT a wildcard catch-all): an HTTPRoute opts in
+# by adding this Gateway to its parentRefs. Today only Harbor does
+# (harbor/httproute-external.yaml + httproute-internal.yaml). A hostname whose
+# route is NOT attached here would 404, which is exactly why the CoreDNS
+# split-horizon override is also per-name — the two grow together.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: home
+  namespace: envoy-gateway-system
+spec:
+  gatewayClassName: envoy-home
+  listeners:
+    - name: https
+      port: 443
+      protocol: HTTPS
+      hostname: "*.shion1305.com"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: wildcard-shion1305-com-tls
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https-internal
+      port: 443
+      protocol: HTTPS
+      hostname: "*.i.shion1305.com"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: wildcard-i-shion1305-com-tls
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/envoy-gateway/gatewayclass-home.yaml
+++ b/envoy-gateway/gatewayclass-home.yaml
@@ -1,0 +1,21 @@
+# Home-resident GatewayClass. Separate from `envoy-default` because it needs a
+# DIFFERENT data plane: `envoy-default`'s EnvoyProxy (instance-k8s-proxy) is
+# pinned to the OCI node with hostNetwork to own the public 141.147.189.36 and
+# the internal 10.130.5.21 VIPs. This class points at the `home` EnvoyProxy,
+# whose proxies run on the amd64 home nodes behind an in-cluster ClusterIP — so
+# in-cluster clients (e.g. GARM runner pods pushing to Harbor) terminate on a
+# home node instead of hairpinning out to the OCI gateway and back.
+#
+# See `gateway-home.yaml` for the listeners and `docs/networking.md` for the
+# split-horizon design.
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: envoy-home
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: home
+    namespace: envoy-gateway-system

--- a/envoy-gateway/kustomization.yaml
+++ b/envoy-gateway/kustomization.yaml
@@ -7,3 +7,9 @@ resources:
   - gateway-internal.yaml
   - gateway-external.yaml
   - client-traffic-policy.yaml
+  # Home-resident data plane (split-horizon for in-cluster *.shion1305.com /
+  # *.i.shion1305.com — see docs/networking.md).
+  - gatewayclass-home.yaml
+  - envoyproxy-home.yaml
+  - gateway-home.yaml
+  - service-home.yaml

--- a/envoy-gateway/service-home.yaml
+++ b/envoy-gateway/service-home.yaml
@@ -1,0 +1,33 @@
+# Stable in-cluster entrypoint for the home Envoy fleet.
+#
+# Envoy Gateway provisions its own Service for the `home` proxies, but its name
+# carries a content hash (e.g. envoy-envoy-home-XXXXXXXX), which is awkward to
+# pin from CoreDNS. This hand-authored Service gives a deterministic name that
+# the CoreDNS split-horizon rewrite targets:
+#
+#   harbor.shion1305.com    -> home-ingress.envoy-gateway-system.svc.cluster.local
+#   harbor.i.shion1305.com  -> home-ingress.envoy-gateway-system.svc.cluster.local
+#
+# (see kube-system-manual-config/coredns-configmap.yaml).
+#
+# The selector matches the home proxy pods (mergeGateways labels them by owning
+# GatewayClass). targetPort 10443 is Envoy Gateway's default container port for
+# a :443 listener when the proxy is NOT hostNetwork and does not set
+# useListenerPortAsContainerPort (the privileged port is offset by +10000). If a
+# future EG upgrade changes that offset, only this targetPort needs updating.
+apiVersion: v1
+kind: Service
+metadata:
+  name: home-ingress
+  namespace: envoy-gateway-system
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/managed-by: envoy-gateway
+    app.kubernetes.io/component: proxy
+    gateway.envoyproxy.io/owning-gatewayclass: envoy-home
+  ports:
+    - name: https
+      port: 443
+      targetPort: 10443
+      protocol: TCP

--- a/harbor/httproute-external.yaml
+++ b/harbor/httproute-external.yaml
@@ -54,6 +54,13 @@ spec:
     - name: external
       namespace: envoy-gateway-system
       sectionName: https
+    # Also served by the home gateway so in-cluster pushers (GARM runner pods)
+    # resolved to home-ingress via CoreDNS split-horizon terminate on a home
+    # node instead of hairpinning through the OCI external gateway. Same
+    # hostname, same wildcard cert, same harbor-core backend.
+    - name: home
+      namespace: envoy-gateway-system
+      sectionName: https
   hostnames:
     - harbor.shion1305.com
   rules:

--- a/harbor/httproute-internal.yaml
+++ b/harbor/httproute-internal.yaml
@@ -47,6 +47,11 @@ spec:
     - name: internal
       namespace: envoy-gateway-system
       sectionName: https
+    # Home gateway: in-cluster clients resolved to home-ingress terminate on a
+    # home node rather than detouring through 10.130.5.21 on the OCI node.
+    - name: home
+      namespace: envoy-gateway-system
+      sectionName: https-internal
   hostnames:
     - harbor.i.shion1305.com
   rules:
@@ -68,6 +73,9 @@ spec:
     - name: internal
       namespace: envoy-gateway-system
       sectionName: https
+    - name: home
+      namespace: envoy-gateway-system
+      sectionName: https-internal
   hostnames:
     - harbor.i.shion1305.com
   rules:

--- a/kube-system-manual-config/coredns-configmap.yaml
+++ b/kube-system-manual-config/coredns-configmap.yaml
@@ -7,6 +7,22 @@ data:
            lameduck 5s
         }
         ready
+        # Split-horizon for Harbor: keep in-cluster traffic on the home nodes.
+        # Public DNS resolves these to the OCI gateway (141.147.189.36 /
+        # 10.130.5.21); for pods we instead rewrite them to the in-cluster
+        # home-ingress Service, which fronts the home Envoy fleet (see
+        # envoy-gateway/service-home.yaml + docs/networking.md). The kubernetes
+        # plugin below resolves the rewritten cluster.local name; the answer's
+        # name is restored to the original by the rewrite plugin.
+        #
+        # Per-name (NOT a *.shion1305.com wildcard): the home gateway only has
+        # routes for the Harbor hostnames, so redirecting any other name here
+        # would 404. Add a line as each app's HTTPRoute is attached to the home
+        # gateway. NOTE: this only affects pods (CoreDNS); kubelet image pulls
+        # use the node resolver and are unaffected (a future per-node /etc/hosts
+        # phase covers those).
+        rewrite name harbor.shion1305.com home-ingress.envoy-gateway-system.svc.cluster.local
+        rewrite name harbor.i.shion1305.com home-ingress.envoy-gateway-system.svc.cluster.local
         kubernetes cluster.local in-addr.arpa ip6.arpa {
            pods insecure
            fallthrough in-addr.arpa ip6.arpa


### PR DESCRIPTION
## Why

In-cluster clients on the home nodes that talk to `harbor.shion1305.com` / `harbor.i.shion1305.com` currently **hairpin home → OCI → home**. The single Envoy data plane is pinned to `instance-k8s-proxy` (OCI, `hostNetwork`, owns `141.147.189.36` / `10.130.5.21`), but `harbor-core` is amd64-only and runs on a home node. So a GARM runner doing `crane push` ships every blob out over the home uplink and back over WireGuard for no reason.

## What

A second, **home-resident** Envoy fleet + **split-horizon DNS** so in-cluster traffic terminates on a home node and reaches the backend over the home network only.

- `GatewayClass envoy-home` → `EnvoyProxy home`: Envoy on the amd64 home nodes (`shion-ubuntu-2505` / `shion-ubuntu-2605`), **non-hostNetwork**, ClusterIP. Off the host netns ⇒ no `--base-id` dance vs cilium-envoy, no root securityContext; binds the default offset port `10443`.
- `Gateway home`: terminates `*.shion1305.com` and `*.i.shion1305.com` on `:443` by SNI, reusing the existing wildcard certs.
- `Service home-ingress`: stable-named ClusterIP in front of the fleet (EG's own Service name carries a hash), targeted by CoreDNS.
- harbor HTTPRoutes: add the `home` Gateway as an extra `parentRef` — same single route, served by both gateways.
- CoreDNS: per-name `rewrite` of the two Harbor hostnames → `home-ingress`. Public DNS unchanged.

## Scope / limits (Phase 1)

- **Pods only.** kubelet image *pulls* use the node resolver, not CoreDNS → pulls are a later per-node `/etc/hosts` phase. Immediate win is pod-originated traffic (runner `crane push`).
- **No same-host pinning.** Plain ClusterIP ⇒ termination lands on either home node (one home-LAN hop). Later: DaemonSet + `internalTrafficPolicy: Local`.
- **External clients unchanged.**

## Apply (after merge)

ArgoCD syncs `envoy-gateway` / `harbor`. CoreDNS is **not** ArgoCD-managed — apply by hand:

\`\`\`bash
kubectl apply -f kube-system-manual-config/coredns-configmap.yaml
kubectl rollout restart -n kube-system deployment/coredns
\`\`\`

Verify from an in-cluster pod:

\`\`\`bash
kubectl run dns-test --rm -it --image=busybox --restart=Never -- nslookup harbor.shion1305.com
# expect the home-ingress ClusterIP (10.96/12), not 141.147.189.36
\`\`\`

## Validation

- \`kustomize build envoy-gateway/\` and \`harbor/\` OK
- \`kubeconform -strict -ignore-missing-schemas\`: Invalid 0 / Errors 0 (CRDs skipped, as in CI)
- CoreDNS Corefile parses

Design recorded in `docs/networking.md`.