### PR TITLE
fix(envoy-gateway): allow cross-ns ingress to the home gateway fleet

### DIFF
--- a/envoy-gateway/kustomization.yaml
+++ b/envoy-gateway/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - envoyproxy-home.yaml
   - gateway-home.yaml
   - service-home.yaml
+  - networkpolicy-home.yaml

--- a/envoy-gateway/networkpolicy-home.yaml
+++ b/envoy-gateway/networkpolicy-home.yaml
@@ -1,0 +1,36 @@
+# Allow in-cluster clients to reach the home Envoy fleet across namespaces.
+#
+# The Kyverno-generated `cross-ns-isolation` NetworkPolicy default-denies
+# ingress into envoy-gateway-system from every OTHER namespace (it permits only
+# same-namespace ingress). The home fleet, unlike the OCI `envoy-default` proxy,
+# is NOT hostNetwork — it is reached over a ClusterIP (home-ingress) by client
+# pods that live in other namespaces, e.g. GARM runner pods in
+# `github-actions-runner-pods` running `crane push harbor.shion1305.com`. Those
+# cross-namespace connections are dropped by the default-deny, surfacing to the
+# client as `dial tcp <home-ingress>:443: i/o timeout`.
+#
+# (The OCI gateway never needed this: hostNetwork means it is reached via the
+# node IP, which the cluster-wide allow-from-infra policy already permits.)
+#
+# Allow ingress to the home proxy pods on the HTTPS listener container port
+# (10443; home-ingress maps 443 -> 10443) from any namespace, matching the
+# gateway's role as a cluster-wide in-cluster ingress. This unions with the
+# default-deny — Cilium evaluates standard + Cilium policies as a union of
+# allows.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-home-gateway-ingress
+  namespace: envoy-gateway-system
+spec:
+  podSelector:
+    matchLabels:
+      gateway.envoyproxy.io/owning-gatewayclass: envoy-home
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 10443


### PR DESCRIPTION
## Symptom

After #470, self-hosted (in-cluster) runners in PR #471 failed to push to Harbor:

```
2026/06/19 06:19:46 retrying dial tcp 10.96.158.48:443: i/o timeout
Error: Get "https://harbor.shion1305.com/v2/": dial tcp 10.96.158.48:443: i/o timeout
```

DNS was already correct (`harbor.shion1305.com → 10.96.158.48`, the `home-ingress` ClusterIP). github-hosted runners passed (they use public DNS → OCI gateway).

## Root cause

`home-ingress` and its endpoints were healthy, but the **Kyverno-generated `cross-ns-isolation` NetworkPolicy** in `envoy-gateway-system` default-denies ingress except from the **same namespace**:

```yaml
spec:
  podSelector: {}
  policyTypes: [Ingress]
  ingress:
    - from: [{ podSelector: {} }]   # same-ns only
```

The GARM runner pod lives in `github-actions-runner-pods`, so its connection to the home fleet (in `envoy-gateway-system`) was **dropped** → `i/o timeout`. The OCI gateway never hit this because it is `hostNetwork` (reached via the node IP, already allowed by `allow-from-infra`); the home fleet is plain pod-networked behind a ClusterIP. This is exactly the "reached from another namespace → add an app-specific allow" case in `CLAUDE.md`.

## Fix

A `NetworkPolicy` allowing ingress to the home proxy pods (`gateway.envoyproxy.io/owning-gatewayclass=envoy-home`) on the HTTPS listener container port **10443** (`home-ingress` maps 443→10443) from any namespace. Unions with the default-deny (Cilium evaluates allows as a union).

## Verified live

From the `github-actions-runner-pods` namespace, **already applied to the cluster**:

```
harbor.shion1305.com → 10.96.158.48
curl https://harbor.shion1305.com/v2/  → http_code=401  connect=0.039s
```

401 is Harbor's expected unauthenticated `/v2/` response — the full path DNS → NetworkPolicy → home Envoy → TLS → harbor-core works. Re-running #471's self-hosted jobs should now pass.

## Validation

`kustomize build envoy-gateway/` OK; `kubeconform -strict -ignore-missing-schemas`: Invalid 0 / Errors 0.