### PR TITLE
fix(harbor): raise HTTPRoute timeout for registry blob transfers

### DIFF
--- a/harbor/httproute-external.yaml
+++ b/harbor/httproute-external.yaml
@@ -71,6 +71,15 @@ spec:
         - path:
             type: Exact
             value: /service/token
+      # Envoy Gateway's default route timeout is 15s, which is far too short for
+      # Docker Registry blob uploads: a multi-MB layer PATCH/PUT regularly runs
+      # tens of seconds (observed ~0.5 MB/s/stream over the home path), so crane
+      # pushes died with `504 upstream request timeout` at exactly 15000ms and
+      # the client then aborted the in-flight layer uploads. Raise it well above
+      # any realistic single blob transfer. Envoy's stream idle timeout still
+      # reaps genuinely dead connections, so a long request timeout is safe here.
+      timeouts:
+        request: "1800s"
       backendRefs:
         - name: harbor-core
           port: 80

--- a/harbor/httproute-internal.yaml
+++ b/harbor/httproute-internal.yaml
@@ -95,6 +95,10 @@ spec:
         - path:
             type: PathPrefix
             value: /chartrepo/
+      # Same reason as harbor-push-external: /v2/ here serves blob push AND pull;
+      # the default 15s route timeout is too short for large layer transfers.
+      timeouts:
+        request: "1800s"
       backendRefs:
         - name: harbor-core
           port: 80


### PR DESCRIPTION
## Symptom

`crane push` to Harbor (e.g. crypto-auto-trading `atc-dashboard`) fails:

```
unexpected status code 504 Gateway Timeout: upstream request timeout
```

Auth and the tiny manifest PUT succeed; the large blob uploads 504.

## Root cause

Envoy Gateway's **default route timeout is 15s**. Harbor's gateway access logs show requests dying at exactly `duration: 15000` with `response_flags: UT` / `response_code_details: response_timeout` — Envoy's route timeout firing on blob `POST/PATCH/PUT /v2/.../blobs/...`. A multi-MB layer transfer runs tens of seconds (observed ~0.5 MB/s/stream), so it blows past 15s. crane then aborts the in-flight layer uploads (`response_flags: DC`, downstream disconnect), failing the whole push.

This is **not** a Harbor capacity problem — harbor-core has no resource limits and isn't saturated; the registry PVC is RWO so adding replicas wouldn't raise throughput. It's purely the gateway request timeout.

## Fix

Set `timeouts.request: 1800s` on the two `/v2/`-bearing HTTPRoutes:

- `harbor-push-external` (`harbor.shion1305.com`) — push path.
- `harbor-core-internal` (`harbor.i.shion1305.com`) — `/v2/` here serves push **and** pull; large-layer pulls can be slow too.

Envoy's stream idle timeout still reaps genuinely dead connections, so a long request timeout is safe. Both the OCI and home gateways are covered (same HTTPRoutes, multiple `parentRefs`).

## Verified live

Applied to the cluster; `harbor-push-external` / `harbor-core-internal` now report `{"request":"1800s"}`. Re-running the crypto-auto-trading push should now complete.

## Follow-up (separate)

The ~0.5 MB/s per-stream throughput on the home path is slow — suspected WireGuard MTU between home nodes. Tracked separately; this PR only stops the premature 504.

## Validation

`kustomize build harbor/` OK; `kubeconform -strict -ignore-missing-schemas`: Invalid 0 / Errors 0.