### PR TITLE
feat(postgres-shared): add research_gh_leaks database

### DIFF
--- a/postgres-shared/postgres-cluster.yaml
+++ b/postgres-shared/postgres-cluster.yaml
@@ -18,6 +18,7 @@ spec:
     harbor: []
     litellm: [] # LiteLLM front for scalable-llm (KubeAI on Tenstorrent)
     fde_knowledge_engine: []
+    research_gh_leaks: []
   databases:
     openwebui: openwebui
     langfuse: langfuse
@@ -27,6 +28,7 @@ spec:
     harbor: harbor
     litellm: litellm
     fde_knowledge_engine: fde_knowledge_engine
+    research_gh_leaks: research_gh_leaks
   postgresql:
     version: "17"
   resources:


### PR DESCRIPTION
## What

Add a new database and owning role `research_gh_leaks` to the `postgres-shared` Zalando cluster.

## Why

A new app/workload (`research-gh-leaks`) needs a dedicated database on the shared cluster.

## Notes

- Follows the existing underscore-delimited naming convention (`nc_press_chotatsu`, `fde_knowledge_engine`) so SQL and connection strings don't need quoting.
- After merge, ArgoCD syncs and the Zalando operator provisions the role + DB; credentials land as a Secret (`research-gh-leaks.postgres-shared.credentials...`) in the `postgres-operator-deployment` namespace.
- Consuming the credentials from an app namespace still requires an ESO Kubernetes-provider copy — out of scope for this PR.