### PR TITLE
feat(atc): grow postgres volume to 1200Gi

### DIFF
--- a/atc/postgres-cluster.yaml
+++ b/atc/postgres-cluster.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   teamId: "default"
   volume:
-    size: 1000Gi
+    size: 1200Gi
     storageClass: longhorn-ssd
   numberOfInstances: 1
   users:


### PR DESCRIPTION
## What

Increase the `atc` PostgreSQL cluster volume from `1000Gi` to `1200Gi` (1.2 TB).

## Details

- File: [atc/postgres-cluster.yaml](atc/postgres-cluster.yaml)
- StorageClass `longhorn-ssd` (Longhorn supports online volume expansion).
- Zalando postgres-operator propagates the new `spec.volume.size` to the PVC; the underlying Longhorn volume expands in place. Volume **growth only** — shrinking is not supported.

## Notes

- The pod stays pinned to `shion-ubuntu-2505` via nodeAffinity (unchanged).
- After sync, verify the PVC/Longhorn volume reached `1200Gi`:
  ```
  kubectl get pvc -n postgres-operator-deployment -l cluster-name=atc
  ```