### PR TITLE
✨ gh-leaked-tokens: periodic recheck CronJob → Pushgateway → Prometheus

### DIFF
--- a/apps/gh-leaked-tokens-app.yaml
+++ b/apps/gh-leaked-tokens-app.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gh-leaked-tokens
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Shion1305/k8s-GitOps.git
+    targetRevision: HEAD
+    path: gh-leaked-tokens
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: gh-leaked-tokens
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/external-secrets/rbac-db-reader.yaml
+++ b/external-secrets/rbac-db-reader.yaml
@@ -182,3 +182,29 @@ subjects:
   - kind: ServiceAccount
     name: eso-db
     namespace: scalable-llm
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: eso-db-gh-leaked-tokens
+  namespace: postgres-operator-deployment
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - research_gh_leaks.postgres-shared.credentials.postgresql.acid.zalan.do
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: eso-db-gh-leaked-tokens
+  namespace: postgres-operator-deployment
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: eso-db-gh-leaked-tokens
+subjects:
+  - kind: ServiceAccount
+    name: eso-db
+    namespace: gh-leaked-tokens

--- a/gh-leaked-tokens/README.md
+++ b/gh-leaked-tokens/README.md
@@ -28,9 +28,20 @@ the job pushes are not overwritten by the scrape.
 | `namespace.yaml` | `gh-leaked-tokens` namespace |
 | `db-secret-store.yaml` | ESO SecretStore + `eso-db` SA to read the shared-Postgres user secret cross-namespace |
 | `db-external-secret.yaml` | Materializes `DB_URL` (user `research_gh_leaks`, db `research_gh_leaks`) for the in-cluster Postgres Service |
+| `vault-secret-store.yaml` | ESO SecretStore + `eso` SA to read this namespace's Vault KV mount (`gh-leaked-tokens/`) |
+| `healthcheck-external-secret.yaml` | Materializes `HEALTHCHECK_URL` (healthchecks.io ping URL) from Vault |
 | `pushgateway.yaml` | Pushgateway Deployment + PVC + Service |
 | `servicemonitor.yaml` | Tells kube-prometheus-stack to scrape the gateway (`release: kube-prometheus-stack`, `honorLabels: true`) |
 | `cronjob.yaml` | The 15-minute `recheck` job |
+
+## Monitoring the job itself
+
+The recheck CLI pings a [healthchecks.io](https://healthchecks.io) check once at
+the end of each run — the base URL on success, `…/fail` if the metrics push had
+errors. A run that never happens (CronJob broken, image won't pull) or crashes
+before finishing simply never pings, and healthchecks.io alerts on the overdue
+ping. The URL is injected as `$HEALTHCHECK_URL` from Vault (see setup below);
+when unset the ping is a no-op.
 
 ## Image
 
@@ -57,6 +68,15 @@ These are NOT in the repo and must exist before the app syncs cleanly:
    the `:5432` allow-list so the CronJob can reach Postgres. (Synced by the
    shared-postgres app — same repo, but a different ArgoCD Application, so it
    must be applied for the recheck job to connect.)
+4. **Vault healthcheck secret** — the `gh-leaked-tokens/` KV v2 mount, the
+   `eso-gh-leaked-tokens` policy/role, and the ping URL itself must exist:
+   ```sh
+   vault secrets enable -path=gh-leaked-tokens -version=2 kv   # once
+   bash vault/scripts/setup-eso-policies.sh                    # creates policy + role
+   vault kv put gh-leaked-tokens/healthcheck url=https://hc-ping.com/<your-check-uuid>
+   ```
+   Optional: skip all of this and the job still runs — `HEALTHCHECK_URL` is an
+   `optional` secret ref and the CLI no-ops on an empty URL (no ping, no error).
 
 ## Operating
 

--- a/gh-leaked-tokens/README.md
+++ b/gh-leaked-tokens/README.md
@@ -52,6 +52,11 @@ These are NOT in the repo and must exist before the app syncs cleanly:
 2. **Cross-namespace RBAC** — the `eso-db` SA's read access to that Secret is
    granted by `external-secrets/rbac-db-reader.yaml` (Role + RoleBinding
    `eso-db-gh-leaked-tokens`), synced by the external-secrets app.
+3. **DB network access** — `postgres-shared` denies ingress by default
+   (Cilium); `postgres-shared/networkpolicy.yaml` lists `gh-leaked-tokens` in
+   the `:5432` allow-list so the CronJob can reach Postgres. (Synced by the
+   shared-postgres app — same repo, but a different ArgoCD Application, so it
+   must be applied for the recheck job to connect.)
 
 ## Operating
 

--- a/gh-leaked-tokens/README.md
+++ b/gh-leaked-tokens/README.md
@@ -1,0 +1,68 @@
+# gh-leaked-tokens
+
+Periodic re-validation of already-discovered leaked API tokens, exported to
+Prometheus. This is the in-cluster deployment of the `recheck` command from
+[`gh-base64token-investigate`](https://github.com/Shion1305/gh-base64token-investigate).
+
+## What it does
+
+A CronJob runs `cli.py recheck` every 15 minutes. For each token already in the
+research DB it re-probes the provider's API, records any **valid → invalid**
+transition (the moment a leaked token gets disabled) to Postgres history, and
+**pushes** every result to a Pushgateway. kube-prometheus-stack scrapes the
+gateway, so the `gh_token_valid` gauge over successive runs becomes the
+token-disablement time-series the report audit trail depends on.
+
+## Why a Pushgateway
+
+`recheck` is a short-lived batch job — Prometheus can't scrape a pod that has
+already exited. The job pushes to an always-on Pushgateway (Deployment + PVC for
+persistence across restarts) and Prometheus scrapes that instead. The
+ServiceMonitor sets `honorLabels: true` so the per-token `job`/`instance` labels
+the job pushes are not overwritten by the scrape.
+
+## Components
+
+| File | Purpose |
+|------|---------|
+| `namespace.yaml` | `gh-leaked-tokens` namespace |
+| `db-secret-store.yaml` | ESO SecretStore + `eso-db` SA to read the shared-Postgres user secret cross-namespace |
+| `db-external-secret.yaml` | Materializes `DB_URL` (user `research_gh_leaks`, db `research_gh_leaks`) for the in-cluster Postgres Service |
+| `pushgateway.yaml` | Pushgateway Deployment + PVC + Service |
+| `servicemonitor.yaml` | Tells kube-prometheus-stack to scrape the gateway (`release: kube-prometheus-stack`, `honorLabels: true`) |
+| `cronjob.yaml` | The 15-minute `recheck` job |
+
+## Image
+
+Built and pushed by the
+[`build-push-harbor.yaml`](https://github.com/Shion1305/gh-base64token-investigate/blob/main/.github/workflows/build-push-harbor.yaml)
+workflow in the source repo to
+`harbor.shion1305.com/shion1305/gh-leaked-tokens` (pulled in-cluster as
+`harbor.i.shion1305.com/...`). The image entrypoint runs `alembic upgrade head`
+before the CLI, so schema migrations apply automatically on the next run.
+
+## One-time setup (out of band)
+
+These are NOT in the repo and must exist before the app syncs cleanly:
+
+1. **Postgres user/db** — `research_gh_leaks` user and database are already
+   declared in `postgres-shared/postgres-cluster.yaml`. The Zalando operator
+   generates the credentials Secret
+   `research_gh_leaks.postgres-shared.credentials.postgresql.acid.zalan.do`.
+2. **Cross-namespace RBAC** — the `eso-db` SA's read access to that Secret is
+   granted by `external-secrets/rbac-db-reader.yaml` (Role + RoleBinding
+   `eso-db-gh-leaked-tokens`), synced by the external-secrets app.
+
+## Operating
+
+```sh
+# Trigger an immediate run instead of waiting for the schedule:
+kubectl create job -n gh-leaked-tokens --from=cronjob/gh-leaked-tokens-recheck manual-$(date +%s)
+
+# Watch the latest run:
+kubectl logs -n gh-leaked-tokens -l job-name --tail=200 -f
+
+# Inspect what's currently on the gateway:
+kubectl port-forward -n gh-leaked-tokens svc/pushgateway 9091:9091
+# then open http://localhost:9091
+```

--- a/gh-leaked-tokens/cronjob.yaml
+++ b/gh-leaked-tokens/cronjob.yaml
@@ -14,9 +14,10 @@
 # watch set this job exists to observe. So no selection flag is passed below.
 #
 # Flags:
-#   --push-interval 5  background-flush partial results to the gateway every 5s,
-#                      so a long run is observable mid-flight, not only at the end.
 #   --workers 8        matches the CLI's RECHECK_WORKERS default (pure I/O wait).
+# Metrics are pushed once at the end of the (seconds-long) run — recheck has no
+# mid-run flusher, and the Pushgateway push replaces the whole per-spec group, so
+# a single final push carries the complete snapshot.
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -62,8 +63,6 @@ spec:
                 # every token valid at least once, incl. ones since disabled), so no
                 # selection flag is needed here.
                 - recheck
-                - --push-interval
-                - "5"
                 - --workers
                 - "8"
               env:

--- a/gh-leaked-tokens/cronjob.yaml
+++ b/gh-leaked-tokens/cronjob.yaml
@@ -1,0 +1,111 @@
+# Periodic re-validation of already-known leaked tokens, pushed to Prometheus.
+#
+# Runs `cli.py recheck` every 15 minutes. The image entrypoint applies Alembic
+# migrations first (schema is operator-owned, never created at runtime), then
+# execs the recheck command. recheck re-probes each currently-known token's
+# provider API, records valid→invalid transitions (the moment a leaked token is
+# disabled) to Postgres history, and PUSHES every result to the Pushgateway.
+# Prometheus scrapes the gateway → the gh_token_valid gauge over successive runs
+# becomes the disablement time-series.
+#
+# recheck defaults to --monitoring-only: it re-probes exactly the monitoring
+# targets — every token that has validated at least once (incl. ones since
+# disabled), skipping never-valid tokens — which is precisely the disablement-
+# watch set this job exists to observe. So no selection flag is passed below.
+#
+# Flags:
+#   --push-interval 5  background-flush partial results to the gateway every 5s,
+#                      so a long run is observable mid-flight, not only at the end.
+#   --workers 8        matches the CLI's RECHECK_WORKERS default (pure I/O wait).
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: gh-leaked-tokens-recheck
+  namespace: gh-leaked-tokens
+spec:
+  schedule: "*/15 * * * *"
+  timeZone: "UTC"
+  # Don't stack runs: a slow recheck must finish before the next fires, else two
+  # jobs probe the same tokens and double-push to the gateway. With a 15-minute
+  # period this is the load-shedding valve — a run that overruns its window is
+  # skipped, not queued.
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  # If the controller was down past a scheduled tick, don't fire a late catch-up
+  # run that would race the next on-time one. Kept within the 15-minute period.
+  startingDeadlineSeconds: 600
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      # Hard cap below the 15-minute schedule: a run that can't finish inside its
+      # own window is wedged, not slow — kill it so it releases the Forbid lock
+      # before the next tick instead of starving every subsequent run.
+      activeDeadlineSeconds: 600
+      template:
+        spec:
+          restartPolicy: Never
+          nodeSelector:
+            kubernetes.io/arch: amd64
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: recheck
+              image: harbor.i.shion1305.com/shion1305/gh-leaked-tokens:latest
+              imagePullPolicy: Always
+              args:
+                # recheck defaults to --monitoring-only (the disablement-watch set:
+                # every token valid at least once, incl. ones since disabled), so no
+                # selection flag is needed here.
+                - recheck
+                - --push-interval
+                - "5"
+                - --workers
+                - "8"
+              env:
+                - name: DB_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: gh-leaked-tokens-db
+                      key: DB_URL
+                # metrics.py reads these three. Pointing at the in-namespace
+                # Pushgateway Service; PROMETHEUS_JOB matches metrics.py's
+                # DEFAULT_JOB so the series name is stable across runs.
+                - name: PROMETHEUS_ENABLED
+                  value: "true"
+                - name: PROMETHEUS_PUSHGATEWAY_URL
+                  value: "http://pushgateway.gh-leaked-tokens.svc.cluster.local:9091"
+                - name: PROMETHEUS_JOB
+                  value: "gh_token_recheck"
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                  ephemeral-storage: 256Mi
+                limits:
+                  cpu: 1000m
+                  memory: 1Gi
+                  ephemeral-storage: 1Gi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              volumeMounts:
+                # uv writes bytecode caches under $HOME and /tmp at runtime;
+                # readOnlyRootFilesystem needs these writable.
+                - name: tmp
+                  mountPath: /tmp
+                - name: home
+                  mountPath: /home/appuser
+          volumes:
+            - name: tmp
+              emptyDir:
+                sizeLimit: 256Mi
+            - name: home
+              emptyDir:
+                sizeLimit: 256Mi

--- a/gh-leaked-tokens/cronjob.yaml
+++ b/gh-leaked-tokens/cronjob.yaml
@@ -80,6 +80,15 @@ spec:
                   value: "http://pushgateway.gh-leaked-tokens.svc.cluster.local:9091"
                 - name: PROMETHEUS_JOB
                   value: "gh_token_recheck"
+                # healthchecks.io dead-man's-switch URL (from Vault via ESO). Pinged
+                # once at the end of the run. optional:true so the job still runs if the
+                # secret isn't populated yet — the CLI no-ops when the URL is empty.
+                - name: HEALTHCHECK_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: gh-leaked-tokens-healthcheck
+                      key: HEALTHCHECK_URL
+                      optional: true
               resources:
                 requests:
                   cpu: 100m

--- a/gh-leaked-tokens/db-external-secret.yaml
+++ b/gh-leaked-tokens/db-external-secret.yaml
@@ -1,0 +1,39 @@
+# Materializes the shared-Postgres credentials into a Secret holding a ready-to-
+# use DB_URL — the exact env var cli.py / db.py / alembic all read (db.py:89,
+# migrations/env.py:36). The app normalizes the scheme to the psycopg driver
+# itself, so a plain postgresql:// URL is fine here.
+#
+# The connection targets the in-cluster Service DNS of the shared cluster
+# (postgres-shared.postgres-operator-deployment.svc.cluster.local), NOT the
+# external postgres-shared.i.shion1305.com host the local .env uses — so no TLS
+# round-trip / sslmode is needed for in-cluster traffic.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gh-leaked-tokens-db
+  namespace: gh-leaked-tokens
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: k8s-postgres
+    kind: SecretStore
+  target:
+    name: gh-leaked-tokens-db
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      engineVersion: v2
+      metadata:
+        labels:
+          managed-by: external-secrets
+      data:
+        DB_URL: "postgresql://{{ .username | urlquery }}:{{ .password | urlquery }}@postgres-shared.postgres-operator-deployment.svc.cluster.local:5432/research_gh_leaks"
+  data:
+    - secretKey: username
+      remoteRef:
+        key: research_gh_leaks.postgres-shared.credentials.postgresql.acid.zalan.do
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: research_gh_leaks.postgres-shared.credentials.postgresql.acid.zalan.do
+        property: password

--- a/gh-leaked-tokens/db-secret-store.yaml
+++ b/gh-leaked-tokens/db-secret-store.yaml
@@ -1,0 +1,32 @@
+# SecretStore that reads the Postgres-operator-generated user credentials out
+# of the postgres-operator-deployment namespace. The Zalando operator creates a
+# Secret `research_gh_leaks.postgres-shared.credentials.postgresql.acid.zalan.do`
+# (user + database both declared in postgres-shared/postgres-cluster.yaml), and
+# this store lets ESO in THIS namespace read it cross-namespace via a bound SA.
+#
+# Same shape as nc-press-chotatsu/db-secret-store.yaml — the established pattern
+# for any app that talks to the shared Postgres cluster.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso-db
+  namespace: gh-leaked-tokens
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: k8s-postgres
+  namespace: gh-leaked-tokens
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: postgres-operator-deployment
+      server:
+        url: "https://kubernetes.default.svc"
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: eso-db

--- a/gh-leaked-tokens/healthcheck-external-secret.yaml
+++ b/gh-leaked-tokens/healthcheck-external-secret.yaml
@@ -1,0 +1,31 @@
+# Materializes the healthchecks.io ping URL from Vault into a Secret the recheck
+# CronJob mounts as $HEALTHCHECK_URL. The URL is a capability secret (whoever
+# holds it can spoof the dead-man's-switch ping), so it's kept in Vault rather
+# than committed here.
+#
+# Vault data layout (KV v2 mount `gh-leaked-tokens/`):
+#   vault kv put gh-leaked-tokens/healthcheck url=https://hc-ping.com/<uuid>
+# Update the value in Vault and ESO re-syncs within refreshInterval.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gh-leaked-tokens-healthcheck
+  namespace: gh-leaked-tokens
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  target:
+    name: gh-leaked-tokens-healthcheck
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+  data:
+    - secretKey: HEALTHCHECK_URL
+      remoteRef:
+        key: healthcheck
+        property: url

--- a/gh-leaked-tokens/kustomization.yaml
+++ b/gh-leaked-tokens/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - db-secret-store.yaml
+  - db-external-secret.yaml
+  - pushgateway.yaml
+  - servicemonitor.yaml
+  - cronjob.yaml

--- a/gh-leaked-tokens/kustomization.yaml
+++ b/gh-leaked-tokens/kustomization.yaml
@@ -4,6 +4,8 @@ resources:
   - namespace.yaml
   - db-secret-store.yaml
   - db-external-secret.yaml
+  - vault-secret-store.yaml
+  - healthcheck-external-secret.yaml
   - pushgateway.yaml
   - servicemonitor.yaml
   - cronjob.yaml

--- a/gh-leaked-tokens/namespace.yaml
+++ b/gh-leaked-tokens/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gh-leaked-tokens

--- a/gh-leaked-tokens/pushgateway.yaml
+++ b/gh-leaked-tokens/pushgateway.yaml
@@ -1,0 +1,112 @@
+# Prometheus Pushgateway for the recheck CronJob.
+#
+# Why a Pushgateway at all: `recheck` is a short-lived BATCH job, not a
+# long-running scrape target. It computes each token's current validity and
+# PUSHES the result (metrics.py: push_recheck_batch → pushadd_to_gateway), then
+# exits. Prometheus can't scrape a pod that's already gone, so the job pushes to
+# this always-on gateway and kube-prometheus-stack scrapes the gateway instead.
+# The gh_token_valid gauge persisted here across successive runs IS the
+# token-disablement time-series the report audit trail depends on.
+#
+# --persistence.file + a PVC: the Pushgateway keeps pushed metrics in memory and
+# would lose the whole disablement history on every restart/redeploy. Persisting
+# to disk every 5m means a pod restart resumes from the last checkpoint instead
+# of dropping back to zero series.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pushgateway
+  namespace: gh-leaked-tokens
+  labels:
+    app: gh-leaked-tokens-pushgateway
+spec:
+  replicas: 1
+  # Recreate (not RollingUpdate): the single PVC is ReadWriteOnce, so a rolling
+  # update's second pod could not mount it. Recreate tears the old pod down
+  # first.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: gh-leaked-tokens-pushgateway
+  template:
+    metadata:
+      labels:
+        app: gh-leaked-tokens-pushgateway
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: pushgateway
+          image: prom/pushgateway:v1.11.1
+          args:
+            - --persistence.file=/data/pushgateway.store
+            - --persistence.interval=5m
+          ports:
+            - name: metrics
+              containerPort: 9091
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 15
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: pushgateway-data
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pushgateway-data
+  namespace: gh-leaked-tokens
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-ssd
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pushgateway
+  namespace: gh-leaked-tokens
+  labels:
+    app: gh-leaked-tokens-pushgateway
+spec:
+  type: ClusterIP
+  selector:
+    app: gh-leaked-tokens-pushgateway
+  ports:
+    - name: metrics
+      port: 9091
+      targetPort: metrics

--- a/gh-leaked-tokens/servicemonitor.yaml
+++ b/gh-leaked-tokens/servicemonitor.yaml
@@ -1,0 +1,33 @@
+# Tells kube-prometheus-stack to scrape the Pushgateway. The stack's
+# serviceMonitorSelector is empty (grafana/values.yaml:
+# serviceMonitorSelectorNilUsesHelmValues:false + serviceMonitorSelector:{}),
+# so it discovers all ServiceMonitors; the `release: kube-prometheus-stack`
+# label is the convention every other app in this repo uses for the same reason.
+#
+# honorLabels: true is REQUIRED for a Pushgateway. The recheck job pushes series
+# with its own `job="gh_token_recheck"` and per-spec/instance labels (see
+# metrics.py grouping keys). Without honorLabels, Prometheus would overwrite
+# those with the scrape target's job/instance and collapse every token's series
+# together. honorLabels keeps the pushed identity intact.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: gh-leaked-tokens-pushgateway
+  namespace: gh-leaked-tokens
+  labels:
+    app: gh-leaked-tokens-pushgateway
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app: gh-leaked-tokens-pushgateway
+  namespaceSelector:
+    matchNames:
+      - gh-leaked-tokens
+  endpoints:
+    - port: metrics
+      interval: 60s
+      scrapeTimeout: 30s
+      path: /metrics
+      scheme: http
+      honorLabels: true

--- a/gh-leaked-tokens/vault-secret-store.yaml
+++ b/gh-leaked-tokens/vault-secret-store.yaml
@@ -1,0 +1,33 @@
+# SA + SecretStore for reading this namespace's Vault secrets. The Vault role
+# `eso-gh-leaked-tokens` is bound to this SA + namespace (see
+# vault/scripts/setup-eso-policies.sh) and grants read on the
+# `gh-leaked-tokens/` KV v2 mount. Mirrors the per-namespace Vault pattern used
+# by nc-press-chotatsu / clearnet-website-monitoring.
+#
+# Note this is a SEPARATE SA from `eso-db` (db-secret-store.yaml): that one
+# authenticates to the in-cluster Kubernetes provider to read the
+# postgres-operator credential Secret cross-namespace; this one authenticates to
+# Vault. Different providers, different SAs, by design.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso
+  namespace: gh-leaked-tokens
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: vault
+  namespace: gh-leaked-tokens
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "gh-leaked-tokens"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "eso-gh-leaked-tokens"
+          serviceAccountRef:
+            name: "eso"

--- a/postgres-shared/networkpolicy.yaml
+++ b/postgres-shared/networkpolicy.yaml
@@ -21,6 +21,7 @@ spec:
               values:
                 - adminer
                 - fde-knowledge-engine
+                - gh-leaked-tokens
                 - harbor
                 - keycloak
                 - langfuse

--- a/vault/scripts/setup-eso-policies.sh
+++ b/vault/scripts/setup-eso-policies.sh
@@ -161,6 +161,20 @@ path "fde-knowledge-engine/metadata/*" {
 EOF
 echo "✓ Created policy: eso-fde-knowledge-engine"
 
+# Policy for gh-leaked-tokens namespace (separate KV v2 engine mounted at gh-leaked-tokens/).
+# Holds the healthchecks.io ping URL for the recheck CronJob (the URL is a
+# capability secret — anyone with it can spoof the dead-man's-switch — so it
+# lives in Vault, not the public k8s-GitOps repo).
+vault policy write eso-gh-leaked-tokens - <<EOF
+path "gh-leaked-tokens/data/*" {
+  capabilities = ["read"]
+}
+path "gh-leaked-tokens/metadata/*" {
+  capabilities = ["read", "list"]
+}
+EOF
+echo "✓ Created policy: eso-gh-leaked-tokens"
+
 # NOTE: An `eso-harbor-broker` role for the Keycloak namespace to read
 # `harbor/broker-credentials` is intentionally NOT created here. There is no
 # precedent yet for ESO-managed broker client secrets in the keycloak ns
@@ -342,6 +356,14 @@ vault write auth/kubernetes/role/eso-fde-knowledge-engine \
   ttl=1h
 echo "✓ Created role: eso-fde-knowledge-engine"
 
+# gh-leaked-tokens
+vault write auth/kubernetes/role/eso-gh-leaked-tokens \
+  bound_service_account_names=eso \
+  bound_service_account_namespaces=gh-leaked-tokens \
+  policies=eso-gh-leaked-tokens \
+  ttl=1h
+echo "✓ Created role: eso-gh-leaked-tokens"
+
 # github-app (cluster-scoped store; binds to the ESO operator SA, not a per-namespace SA)
 vault write auth/kubernetes/role/eso-github-app \
   bound_service_account_names=external-secrets \
@@ -485,6 +507,7 @@ echo "  eso-zot         → SA eso/zot             → zot/data/*"
 echo "  eso-harbor      → SA eso/harbor          → harbor/data/*"
 echo "  eso-nc-press-chotatsu → SA eso/nc-press-chotatsu → nc-press-chotatsu/data/*"
 echo "  eso-fde-knowledge-engine → SA eso/fde-knowledge-engine → fde-knowledge-engine/data/*"
+echo "  eso-gh-leaked-tokens → SA eso/gh-leaked-tokens → gh-leaked-tokens/data/*"
 echo "  eso-github-app  → SA external-secrets/external-secrets → github-app-shared/data/*"
 echo "  eso-cloudflare-grafana → SA eso/monitoring     → cloudflare-grafana/data/*"
 echo "  eso-cluster-puller → SA external-secrets/external-secrets → zot/data/cluster-puller"


### PR DESCRIPTION
## What

New ArgoCD app `gh-leaked-tokens` that runs the `recheck` command from [gh-base64token-investigate](https://github.com/Shion1305/gh-base64token-investigate) as a scheduled in-cluster job and exports leaked-token validity to Prometheus.

## Components (`gh-leaked-tokens/`)

| File | Purpose |
|------|---------|
| `namespace.yaml` | `gh-leaked-tokens` namespace |
| `db-secret-store.yaml` | ESO SecretStore + `eso-db` SA, reads the shared-Postgres user secret cross-namespace |
| `db-external-secret.yaml` | Materializes `DB_URL` (user/db `research_gh_leaks`, in-cluster Service DNS) |
| `pushgateway.yaml` | Pushgateway Deployment + PVC (persist across restarts) + Service |
| `servicemonitor.yaml` | kube-prometheus-stack scrape config (`release` label, `honorLabels: true`) |
| `cronjob.yaml` | `recheck` every 15 min |

Plus `apps/gh-leaked-tokens-app.yaml` (ArgoCD Application) and an `eso-db-gh-leaked-tokens` Role/RoleBinding in `external-secrets/rbac-db-reader.yaml`.

## Why a Pushgateway

`recheck` is a short-lived **batch** job — Prometheus can't scrape a pod that already exited. The job pushes to an always-on Pushgateway and Prometheus scrapes that; the value persists between runs so `gh_token_valid` becomes a continuous disablement time-series. `honorLabels: true` keeps the per-token `job`/`spec_id`/`instance` labels the job pushes from being overwritten by the scrape.

## Scheduling

15-minute schedule (a full run measured ~24s). `concurrencyPolicy: Forbid` + `activeDeadlineSeconds: 600` shed load if a run ever overruns its window. The CronJob passes no selection flag — it relies on recheck's new default `--monitoring-only` (every token valid at least once, including ones since disabled; never-valid tokens skipped).

## One-time setup (documented in the app README)
1. `research_gh_leaks` Postgres user/db — already in `postgres-shared/postgres-cluster.yaml`. ✅
2. The cross-namespace RBAC in this PR syncs via the external-secrets app.
3. First image build must land in Harbor (companion app PR).

## Companion
App logic + image: gh-base64token-investigate **#74**.

## Validation
`kubectl kustomize gh-leaked-tokens` and `kubectl kustomize external-secrets` both build clean.

## Network access
`postgres-shared` denies ingress by default (Cilium); this PR adds `gh-leaked-tokens` to the `:5432` allow-list in `postgres-shared/networkpolicy.yaml` so the CronJob can reach Postgres. That file is synced by the **shared-postgres** ArgoCD app (same repo, different Application).

---

## Added: healthchecks.io ping URL from Vault

The recheck CronJob now pings a healthchecks.io dead-man's switch at the end of each run (logic in the companion gh-base64token-investigate PR). This PR wires the URL in from Vault:

- `vault-secret-store.yaml` — per-namespace ESO SecretStore + `eso` SA for the `gh-leaked-tokens/` KV v2 mount.
- `healthcheck-external-secret.yaml` — materializes `HEALTHCHECK_URL` from `gh-leaked-tokens/healthcheck` (key `url`).
- `cronjob.yaml` — `HEALTHCHECK_URL` env via **optional** `secretKeyRef` (job still runs if the secret isn't populated; the CLI no-ops on an empty URL).
- `vault/scripts/setup-eso-policies.sh` — `eso-gh-leaked-tokens` policy + Kubernetes auth role.

One-time Vault setup (KV mount, policy/role, the URL value) documented in the app README.
