### PR TITLE
🐛 Dashboard: default template vars to All (panels were empty)

### DIFF
--- a/gh-leaked-tokens/grafana-dashboard.yaml
+++ b/gh-leaked-tokens/grafana-dashboard.yaml
@@ -19,39 +19,88 @@ spec:
   resyncPeriod: 5m
   json: |
     {
-      "annotations": { "list": [] },
+      "annotations": {
+        "list": []
+      },
       "editable": true,
       "graphTooltip": 1,
       "title": "Token Disablement",
       "uid": "gh-leaked-tokens-disablement",
-      "tags": ["gh-leaked-tokens"],
+      "tags": [
+        "gh-leaked-tokens"
+      ],
       "timezone": "",
       "schemaVersion": 39,
       "version": 1,
-      "time": { "from": "now-30d", "to": "now" },
+      "time": {
+        "from": "now-30d",
+        "to": "now"
+      },
       "refresh": "1m",
       "templating": {
         "list": [
           {
             "name": "provider",
             "type": "query",
-            "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "gh-leaked-tokens"
+            },
             "query": "label_values(gh_token_valid, provider)",
-            "includeAll": true, "multi": true, "refresh": 2
+            "includeAll": true,
+            "multi": true,
+            "refresh": 2,
+            "current": {
+              "selected": true,
+              "text": [
+                "All"
+              ],
+              "value": [
+                "$__all"
+              ]
+            }
           },
           {
             "name": "spec_id",
             "type": "query",
-            "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "gh-leaked-tokens"
+            },
             "query": "label_values(gh_token_valid, spec_id)",
-            "includeAll": true, "multi": true, "refresh": 2
+            "includeAll": true,
+            "multi": true,
+            "refresh": 2,
+            "current": {
+              "selected": true,
+              "text": [
+                "All"
+              ],
+              "value": [
+                "$__all"
+              ]
+            }
           },
           {
             "name": "impact_level",
             "type": "query",
-            "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "gh-leaked-tokens"
+            },
             "query": "label_values(gh_token_valid, impact_level)",
-            "includeAll": true, "multi": true, "refresh": 2
+            "includeAll": true,
+            "multi": true,
+            "refresh": 2,
+            "current": {
+              "selected": true,
+              "text": [
+                "All"
+              ],
+              "value": [
+                "$__all"
+              ]
+            }
           }
         ]
       },
@@ -60,108 +109,531 @@ spec:
           "id": 1,
           "title": "Live tokens (still valid)",
           "type": "stat",
-          "gridPos": { "h": 5, "w": 5, "x": 0, "y": 0 },
-          "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" },
-          "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "green", "value": null } ] } }, "overrides": [] },
-          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "area" },
-          "targets": [ { "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" }, "expr": "sum(gh_token_valid{provider=~\"$provider\", spec_id=~\"$spec_id\", impact_level=~\"$impact_level\"} == 1)", "legendFormat": "live", "refId": "A" } ]
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 0,
+            "y": 0
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gh-leaked-tokens"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "gh-leaked-tokens"
+              },
+              "expr": "sum(gh_token_valid{provider=~\"$provider\", spec_id=~\"$spec_id\", impact_level=~\"$impact_level\"} == 1)",
+              "legendFormat": "live",
+              "refId": "A"
+            }
+          ]
         },
         {
           "id": 2,
-          "title": "Disabled (cumulative valid→invalid)",
+          "title": "Disabled (cumulative valid\u2192invalid)",
           "type": "stat",
-          "gridPos": { "h": 5, "w": 5, "x": 5, "y": 0 },
-          "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" },
-          "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "blue", "value": null }, { "color": "orange", "value": 1 } ] } }, "overrides": [] },
-          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "area" },
-          "targets": [ { "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" }, "expr": "sum(gh_token_disabled_transitions_total{provider=~\"$provider\", spec_id=~\"$spec_id\"})", "legendFormat": "disabled", "refId": "A" } ]
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 5,
+            "y": 0
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gh-leaked-tokens"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "gh-leaked-tokens"
+              },
+              "expr": "sum(gh_token_disabled_transitions_total{provider=~\"$provider\", spec_id=~\"$spec_id\"})",
+              "legendFormat": "disabled",
+              "refId": "A"
+            }
+          ]
         },
         {
           "id": 3,
           "title": "Newly disabled (24h)",
           "type": "stat",
-          "gridPos": { "h": 5, "w": 5, "x": 10, "y": 0 },
-          "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" },
-          "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] } }, "overrides": [] },
-          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "none" },
-          "targets": [ { "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" }, "expr": "sum(increase(gh_token_disabled_transitions_total{provider=~\"$provider\", spec_id=~\"$spec_id\"}[24h]))", "legendFormat": "disabled 24h", "refId": "A" } ]
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 10,
+            "y": 0
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gh-leaked-tokens"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "background",
+            "graphMode": "none"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "gh-leaked-tokens"
+              },
+              "expr": "sum(increase(gh_token_disabled_transitions_total{provider=~\"$provider\", spec_id=~\"$spec_id\"}[24h]))",
+              "legendFormat": "disabled 24h",
+              "refId": "A"
+            }
+          ]
         },
         {
           "id": 4,
           "title": "Disablement rate (% of ever-live)",
           "type": "gauge",
-          "gridPos": { "h": 5, "w": 4, "x": 15, "y": 0 },
-          "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" },
-          "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "red", "value": null }, { "color": "orange", "value": 0.5 }, { "color": "green", "value": 0.9 } ] } }, "overrides": [] },
-          "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
-          "targets": [ { "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" }, "expr": "sum(gh_token_disabled_transitions_total{provider=~\"$provider\", spec_id=~\"$spec_id\"}) / clamp_min(sum(gh_token_valid{provider=~\"$provider\", spec_id=~\"$spec_id\"}) + sum(gh_token_disabled_transitions_total{provider=~\"$provider\", spec_id=~\"$spec_id\"}), 1)", "legendFormat": "disabled share", "refId": "A" } ]
+          "gridPos": {
+            "h": 5,
+            "w": 4,
+            "x": 15,
+            "y": 0
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gh-leaked-tokens"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "min": 0,
+              "max": 1,
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "green",
+                    "value": 0.9
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "gh-leaked-tokens"
+              },
+              "expr": "sum(gh_token_disabled_transitions_total{provider=~\"$provider\", spec_id=~\"$spec_id\"}) / clamp_min(sum(gh_token_valid{provider=~\"$provider\", spec_id=~\"$spec_id\"}) + sum(gh_token_disabled_transitions_total{provider=~\"$provider\", spec_id=~\"$spec_id\"}), 1)",
+              "legendFormat": "disabled share",
+              "refId": "A"
+            }
+          ]
         },
         {
           "id": 5,
           "title": "Live write-capable tokens",
           "type": "stat",
-          "gridPos": { "h": 5, "w": 5, "x": 19, "y": 0 },
-          "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" },
-          "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] } }, "overrides": [] },
-          "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "none" },
-          "targets": [ { "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" }, "expr": "sum(gh_token_valid{provider=~\"$provider\", spec_id=~\"$spec_id\", has_write_scope=\"true\"} == 1)", "legendFormat": "write & live", "refId": "A" } ]
+          "gridPos": {
+            "h": 5,
+            "w": 5,
+            "x": 19,
+            "y": 0
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gh-leaked-tokens"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "background",
+            "graphMode": "none"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "gh-leaked-tokens"
+              },
+              "expr": "sum(gh_token_valid{provider=~\"$provider\", spec_id=~\"$spec_id\", has_write_scope=\"true\"} == 1)",
+              "legendFormat": "write & live",
+              "refId": "A"
+            }
+          ]
         },
         {
           "id": 6,
           "title": "Disablement events over time (hourly)",
           "type": "timeseries",
-          "gridPos": { "h": 8, "w": 16, "x": 0, "y": 5 },
-          "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" },
-          "fieldConfig": { "defaults": { "custom": { "drawStyle": "bars", "fillOpacity": 60, "lineWidth": 1 } }, "overrides": [] },
-          "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
-          "targets": [ { "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" }, "expr": "sum by (provider) (increase(gh_token_disabled_transitions_total{provider=~\"$provider\", spec_id=~\"$spec_id\"}[1h]))", "legendFormat": "{{provider}}", "refId": "A" } ]
+          "gridPos": {
+            "h": 8,
+            "w": 16,
+            "x": 0,
+            "y": 5
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gh-leaked-tokens"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "bars",
+                "fillOpacity": 60,
+                "lineWidth": 1
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "calcs": [
+                "sum"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "gh-leaked-tokens"
+              },
+              "expr": "sum by (provider) (increase(gh_token_disabled_transitions_total{provider=~\"$provider\", spec_id=~\"$spec_id\"}[1h]))",
+              "legendFormat": "{{provider}}",
+              "refId": "A"
+            }
+          ]
         },
         {
           "id": 7,
           "title": "Live tokens by impact level",
           "type": "piechart",
-          "gridPos": { "h": 8, "w": 8, "x": 16, "y": 5 },
-          "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" },
-          "fieldConfig": { "defaults": {}, "overrides": [] },
-          "options": { "legend": { "displayMode": "table", "placement": "right", "values": ["value"] }, "reduceOptions": { "calcs": ["lastNotNull"] } },
-          "targets": [ { "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" }, "expr": "sum by (impact_level) (gh_token_valid{provider=~\"$provider\", spec_id=~\"$spec_id\"} == 1)", "legendFormat": "{{impact_level}}", "refId": "A" } ]
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 5
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gh-leaked-tokens"
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "values": [
+                "value"
+              ]
+            },
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "gh-leaked-tokens"
+              },
+              "expr": "sum by (impact_level) (gh_token_valid{provider=~\"$provider\", spec_id=~\"$spec_id\"} == 1)",
+              "legendFormat": "{{impact_level}}",
+              "refId": "A"
+            }
+          ]
         },
         {
           "id": 8,
-          "title": "Per-token validity over time — each drop 1→0 is a disablement",
+          "title": "Per-token validity over time \u2014 each drop 1\u21920 is a disablement",
           "type": "timeseries",
-          "gridPos": { "h": 12, "w": 24, "x": 0, "y": 13 },
-          "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" },
+          "gridPos": {
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 13
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gh-leaked-tokens"
+          },
           "fieldConfig": {
             "defaults": {
-              "min": 0, "max": 1,
-              "custom": { "drawStyle": "line", "lineInterpolation": "stepAfter", "lineWidth": 2, "fillOpacity": 15, "pointSize": 7, "showPoints": "always", "spanNulls": true },
-              "mappings": [ { "type": "value", "options": { "0": { "text": "disabled", "color": "red" }, "1": { "text": "live", "color": "green" } } } ]
+              "min": 0,
+              "max": 1,
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "stepAfter",
+                "lineWidth": 2,
+                "fillOpacity": 15,
+                "pointSize": 7,
+                "showPoints": "always",
+                "spanNulls": true
+              },
+              "mappings": [
+                {
+                  "type": "value",
+                  "options": {
+                    "0": {
+                      "text": "disabled",
+                      "color": "red"
+                    },
+                    "1": {
+                      "text": "live",
+                      "color": "green"
+                    }
+                  }
+                }
+              ]
             },
             "overrides": []
           },
-          "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["lastNotNull"] }, "tooltip": { "mode": "multi", "sort": "desc" } },
-          "targets": [ { "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" }, "expr": "gh_token_valid{provider=~\"$provider\", spec_id=~\"$spec_id\", impact_level=~\"$impact_level\"}", "legendFormat": "{{provider}}/{{spec_id}} {{token}} [{{impact_level}}]", "refId": "A" } ]
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "gh-leaked-tokens"
+              },
+              "expr": "gh_token_valid{provider=~\"$provider\", spec_id=~\"$spec_id\", impact_level=~\"$impact_level\"}",
+              "legendFormat": "{{provider}}/{{spec_id}} {{token}} [{{impact_level}}]",
+              "refId": "A"
+            }
+          ]
         },
         {
           "id": 9,
           "title": "Time since each token's last re-check (staleness)",
           "type": "timeseries",
-          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 25 },
-          "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" },
-          "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 5 } }, "overrides": [] },
-          "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } },
-          "targets": [ { "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" }, "expr": "time() - gh_token_recheck_timestamp_seconds{provider=~\"$provider\", spec_id=~\"$spec_id\"}", "legendFormat": "{{provider}}/{{spec_id}} {{token}}", "refId": "A" } ]
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 25
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gh-leaked-tokens"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 5
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "gh-leaked-tokens"
+              },
+              "expr": "time() - gh_token_recheck_timestamp_seconds{provider=~\"$provider\", spec_id=~\"$spec_id\"}",
+              "legendFormat": "{{provider}}/{{spec_id}} {{token}}",
+              "refId": "A"
+            }
+          ]
         },
         {
           "id": 10,
           "title": "Recheck run duration & last run",
           "type": "timeseries",
-          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 25 },
-          "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" },
-          "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 } }, "overrides": [] },
-          "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
-          "targets": [ { "datasource": { "type": "prometheus", "uid": "gh-leaked-tokens" }, "expr": "gh_token_recheck_duration_seconds{kind=\"run\"}", "legendFormat": "{{provider}}/{{spec}} duration", "refId": "A" } ]
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 25
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gh-leaked-tokens"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "gh-leaked-tokens"
+              },
+              "expr": "gh_token_recheck_duration_seconds{kind=\"run\"}",
+              "legendFormat": "{{provider}}/{{spec}} duration",
+              "refId": "A"
+            }
+          ]
         }
       ],
       "__inputs": [],


### PR DESCRIPTION
## Symptom
The Token Disablement dashboard showed **no data**, even though the dedicated long-term Prometheus holds 273 `gh_token_valid` series and Grafana can query it fine (verified end-to-end against the live cluster).

## Root cause
The `provider` / `spec_id` / `impact_level` template variables had `includeAll: true` but **no `current` selection**. On first load they default to an **empty string**, so panel queries become `gh_token_valid{provider=~"", ...}` — and an empty regex matches nothing for series that *have* the label. Every panel renders blank.

Confirmed on the live Prometheus:
- `sum(gh_token_valid{provider=~".*"} == 1)` → `273`
- `sum(gh_token_valid{provider=~""} == 1)` → `[]`  ← what the un-selected var produced

## Fix
Set each var's `current` to `$__all` (includeAll was already true) so they default to **All**. Semantic diff is exactly those three additions (the large line count is JSON re-indentation only).

## Verification
`kubectl kustomize gh-leaked-tokens` builds; normalized-JSON diff shows only the three `current` blocks added.

> Note: the underlying recheck data is still from the pre-#76 image (labels `token`/`provider`/`spec_id` only, no `impact_level`/`token_hash`/etc.), so the impact panels will populate once the new image is rolled out. The empty regex matches label-less series too, so existing panels work now.