### PR TITLE
✨ Dashboard: add per-token status table

### DIFF
--- a/gh-leaked-tokens/grafana-dashboard.yaml
+++ b/gh-leaked-tokens/grafana-dashboard.yaml
@@ -634,6 +634,229 @@ spec:
               "refId": "A"
             }
           ]
+        },
+        {
+          "id": 16,
+          "title": "Token status (per-token table)",
+          "type": "table",
+          "gridPos": {
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 33
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gh-leaked-tokens"
+          },
+          "description": "One row per leaked token: current validity, last re-check, and its labels. Filter/sort by any column.",
+          "targets": [
+            {
+              "refId": "valid",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "gh-leaked-tokens"
+              },
+              "expr": "gh_token_valid{provider=~\"$provider\", spec_id=~\"$spec_id\", impact_level=~\"$impact_level\"}",
+              "format": "table",
+              "instant": true,
+              "legendFormat": ""
+            },
+            {
+              "refId": "lastcheck",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "gh-leaked-tokens"
+              },
+              "expr": "gh_token_recheck_timestamp_seconds{provider=~\"$provider\", spec_id=~\"$spec_id\"}",
+              "format": "table",
+              "instant": true,
+              "legendFormat": ""
+            }
+          ],
+          "transformations": [
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "token",
+                "mode": "outer"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "Time 1": true,
+                  "Time 2": true,
+                  "__name__": true,
+                  "__name__ 1": true,
+                  "__name__ 2": true,
+                  "job": true,
+                  "job 1": true,
+                  "job 2": true,
+                  "instance": true,
+                  "instance 1": true,
+                  "instance 2": true,
+                  "namespace": true,
+                  "namespace 1": true,
+                  "namespace 2": true,
+                  "pod": true,
+                  "pod 1": true,
+                  "pod 2": true,
+                  "service": true,
+                  "service 1": true,
+                  "service 2": true,
+                  "endpoint": true,
+                  "endpoint 1": true,
+                  "endpoint 2": true,
+                  "container": true,
+                  "container 1": true,
+                  "container 2": true,
+                  "provider 2": true,
+                  "spec_id 2": true
+                },
+                "renameByName": {
+                  "provider 1": "provider",
+                  "spec_id 1": "spec_id",
+                  "Value #valid": "status",
+                  "Value #lastcheck": "last_check"
+                },
+                "indexByName": {
+                  "token": 0,
+                  "provider 1": 1,
+                  "spec_id 1": 2,
+                  "token_hash": 3,
+                  "leak_level": 4,
+                  "impact_level": 5,
+                  "has_write_scope": 6,
+                  "has_admin_scope": 7,
+                  "Value #valid": 8,
+                  "Value #lastcheck": 9
+                }
+              }
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "filterable": true
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "status"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "1": {
+                            "text": "\ud83d\udfe2 live",
+                            "color": "green",
+                            "index": 0
+                          },
+                          "0": {
+                            "text": "\ud83d\udd34 disabled",
+                            "color": "red",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 110
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "last_check"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "dateTimeFromNow"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "has_write_scope"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "true": {
+                            "text": "\u270d\ufe0f",
+                            "color": "orange",
+                            "index": 0
+                          },
+                          "false": {
+                            "text": "\u00b7",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
+                  }
+                ]
+              }
+            ]
+          },
+          "options": {
+            "showHeader": true,
+            "cellHeight": "sm",
+            "sortBy": [
+              {
+                "displayName": "status",
+                "desc": false
+              }
+            ],
+            "footer": {
+              "show": true,
+              "reducer": [
+                "count"
+              ],
+              "fields": [
+                "token"
+              ]
+            }
+          }
         }
       ],
       "__inputs": [],

--- a/gh-leaked-tokens/grafana-dashboard.yaml
+++ b/gh-leaked-tokens/grafana-dashboard.yaml
@@ -668,7 +668,7 @@ spec:
                 "type": "prometheus",
                 "uid": "gh-leaked-tokens"
               },
-              "expr": "time() - gh_token_recheck_timestamp_seconds{provider=~\"$provider\", spec_id=~\"$spec_id\"}",
+              "expr": "time() - max by (token) (gh_token_recheck_timestamp_seconds{provider=~\"$provider\", spec_id=~\"$spec_id\"})",
               "format": "table",
               "instant": true,
               "legendFormat": ""
@@ -686,46 +686,25 @@ spec:
               "id": "organize",
               "options": {
                 "excludeByName": {
-                  "Time": true,
                   "Time 1": true,
                   "Time 2": true,
                   "__name__": true,
-                  "__name__ 1": true,
-                  "__name__ 2": true,
                   "job": true,
-                  "job 1": true,
-                  "job 2": true,
                   "instance": true,
-                  "instance 1": true,
-                  "instance 2": true,
                   "namespace": true,
-                  "namespace 1": true,
-                  "namespace 2": true,
                   "pod": true,
-                  "pod 1": true,
-                  "pod 2": true,
                   "service": true,
-                  "service 1": true,
-                  "service 2": true,
                   "endpoint": true,
-                  "endpoint 1": true,
-                  "endpoint 2": true,
-                  "container": true,
-                  "container 1": true,
-                  "container 2": true,
-                  "provider 2": true,
-                  "spec_id 2": true
+                  "container": true
                 },
                 "renameByName": {
-                  "provider 1": "provider",
-                  "spec_id 1": "spec_id",
                   "Value #valid": "status",
                   "Value #lastcheck": "last_check_ago"
                 },
                 "indexByName": {
                   "token": 0,
-                  "provider 1": 1,
-                  "spec_id 1": 2,
+                  "provider": 1,
+                  "spec_id": 2,
                   "token_hash": 3,
                   "leak_level": 4,
                   "impact_level": 5,

--- a/gh-leaked-tokens/grafana-dashboard.yaml
+++ b/gh-leaked-tokens/grafana-dashboard.yaml
@@ -668,7 +668,7 @@ spec:
                 "type": "prometheus",
                 "uid": "gh-leaked-tokens"
               },
-              "expr": "gh_token_recheck_timestamp_seconds{provider=~\"$provider\", spec_id=~\"$spec_id\"}",
+              "expr": "time() - gh_token_recheck_timestamp_seconds{provider=~\"$provider\", spec_id=~\"$spec_id\"}",
               "format": "table",
               "instant": true,
               "legendFormat": ""
@@ -720,7 +720,7 @@ spec:
                   "provider 1": "provider",
                   "spec_id 1": "spec_id",
                   "Value #valid": "status",
-                  "Value #lastcheck": "last_check"
+                  "Value #lastcheck": "last_check_ago"
                 },
                 "indexByName": {
                   "token": 0,
@@ -786,12 +786,12 @@ spec:
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "last_check"
+                  "options": "last_check_ago"
                 },
                 "properties": [
                   {
                     "id": "unit",
-                    "value": "dateTimeFromNow"
+                    "value": "s"
                   },
                   {
                     "id": "custom.width",


### PR DESCRIPTION
Adds a **table panel** to the Token Disablement dashboard for checking each token's status at a glance.

## What it shows
One row per leaked token:
- **status** — 🟢 live / 🔴 disabled (value-mapped from `gh_token_valid`, color-coded)
- **last_check** — relative time of the last re-check (`gh_token_recheck_timestamp_seconds`)
- **labels** — provider, spec_id, token, token_hash, leak_level, impact_level, has_write_scope (✍️), has_admin_scope

## How
Two instant queries (`gh_token_valid` + `gh_token_recheck_timestamp_seconds`) joined by `token`, then an `organize` transform drops the scrape-target noise columns (job/pod/namespace/…) and renames the value columns. Columns are filterable + sortable; default sort is by status so disabled tokens surface first, with a row count in the footer. Pinned to datasource `uid: gh-leaked-tokens`.

The local docker-compose copy gets the same panel in the app repo (datasource `prometheus`).

Validated: `kubectl kustomize gh-leaked-tokens` builds; dashboard JSON parses with the new table panel.