### PR TITLE
🐛 Fix gh-leaked-tokens Postgres datasource user placeholder

### DIFF
--- a/gh-leaked-tokens/grafana-datasource-postgres.yaml
+++ b/gh-leaked-tokens/grafana-datasource-postgres.yaml
@@ -24,7 +24,7 @@ spec:
     type: postgres
     access: proxy
     url: postgres-shared.postgres-operator-deployment.svc.cluster.local:5432
-    user: ${user}
+    user: ${username}
     database: research_gh_leaks
     isDefault: false
     editable: true


### PR DESCRIPTION
## Problem
The Postgres datasource rendered `"user": "${user}"` literally (Grafana then failed to auth). Password resolved fine.

## Cause
grafana-operator v5 `valuesFrom` replaces the placeholder `${<KEY>}` where `<KEY>` is the **referenced secret key name** — not `${targetPath}`. Confirmed against the operator's own `datasource_variables` example (`${PROMETHEUS_TOKEN}` for key `PROMETHEUS_TOKEN`).

- password: targetPath `secureJsonData.password`, key `password`, placeholder `${password}` ✅ matched
- user: targetPath `user`, key **`username`**, placeholder `${user}` ❌ mismatch → left literal

## Fix
`user: ${user}` → `user: ${username}` (matches the secret key `username`).