### PR TITLE
chore(clearnet): expand data PVC 5Gi -> 20Gi

### DIFF
--- a/clearnet-website-monitoring/pvc.yaml
+++ b/clearnet-website-monitoring/pvc.yaml
@@ -13,4 +13,4 @@ spec:
   storageClassName: longhorn
   resources:
     requests:
-      storage: 5Gi
+      storage: 20Gi


### PR DESCRIPTION
The provider_monitor data PVC (`clearnet-website-monitoring-data`) was at 93% (4.5G/4.9G), dominated by ~45k full-page screenshots with no retention. Expanding 5Gi → 20Gi as a stopgap so probe rounds don't fail on a full volume.

- `longhorn` StorageClass has `allowVolumeExpansion: true`, so ArgoCD applies this online (no pod restart).
- Retention policy for screenshots/checks is tracked separately.