### PR TITLE
clearnet: switch to targets.yaml + wire Browserbase for flagged domains

### DIFF
--- a/clearnet-website-monitoring/deployment.yaml
+++ b/clearnet-website-monitoring/deployment.yaml
@@ -36,6 +36,23 @@ spec:
             # single Pod can comfortably finish a round.
             - name: PROVIDER_MONITOR_INTERVAL
               value: "3600"
+            # Browserbase-flagged targets (browserbase-crawl: true in
+            # targets.yaml) crawl on this slower cadence (4h) because Browserbase
+            # sessions are a limited paid resource.
+            - name: PROVIDER_MONITOR_BROWSERBASE_INTERVAL
+              value: "14400"
+            # Browserbase credentials (materialized from Vault by ESO). Optional
+            # to the exporter — domains without browserbase-crawl never touch it.
+            - name: BROWSERBASE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: clearnet-website-monitoring-browserbase
+                  key: BROWSERBASE_API_KEY
+            - name: BROWSERBASE_PROJECT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: clearnet-website-monitoring-browserbase
+                  key: BROWSERBASE_PROJECT_ID
           volumeMounts:
             - name: domains
               mountPath: /data

--- a/clearnet-website-monitoring/external-secret-browserbase.yaml
+++ b/clearnet-website-monitoring/external-secret-browserbase.yaml
@@ -1,0 +1,36 @@
+# Materializes Browserbase credentials from Vault into a Kubernetes Secret that
+# the exporter consumes as env vars. Browserbase is used to capture domains
+# flagged `browserbase-crawl: true` in targets.yaml (clears WAF/captcha
+# challenges before screenshotting the upstream page).
+#
+# Vault data layout (KV v2 mount `clearnet-website-monitoring/`):
+#   vault kv put clearnet-website-monitoring/browserbase \
+#     BROWSERBASE_API_KEY='bb_live_xxxxx' \
+#     BROWSERBASE_PROJECT_ID='xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: clearnet-website-monitoring-browserbase
+  namespace: clearnet-website-monitoring
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  target:
+    name: clearnet-website-monitoring-browserbase
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+  data:
+    - secretKey: BROWSERBASE_API_KEY
+      remoteRef:
+        key: browserbase
+        property: BROWSERBASE_API_KEY
+    - secretKey: BROWSERBASE_PROJECT_ID
+      remoteRef:
+        key: browserbase
+        property: BROWSERBASE_PROJECT_ID

--- a/clearnet-website-monitoring/external-secret.yaml
+++ b/clearnet-website-monitoring/external-secret.yaml
@@ -1,9 +1,15 @@
-# Materializes the domains list from Vault into a Kubernetes Secret that
-# the exporter mounts at /data/domains.txt.
+# Materializes the monitored-target list from Vault into a Kubernetes Secret
+# that the exporter mounts at /data/targets.yaml.
 #
 # Vault data layout (KV v2 mount `clearnet-website-monitoring/`):
 #   vault kv put clearnet-website-monitoring/domains \
-#     domains.txt=@/path/to/local/domains.txt
+#     targets.yaml=@/path/to/local/targets.yaml
+#
+# targets.yaml schema (see ylab-clearnet-research config.read_targets):
+#   targets:
+#     - domain: example.com
+#     - domain: authorizecvv.in
+#       browserbase-crawl: true      # route this domain through Browserbase
 #
 # Update the value in Vault and ESO re-syncs within `refreshInterval`.
 apiVersion: external-secrets.io/v1
@@ -25,7 +31,7 @@ spec:
         labels:
           managed-by: external-secrets
   data:
-    - secretKey: domains.txt
+    - secretKey: targets.yaml
       remoteRef:
         key: domains
-        property: domains.txt
+        property: targets.yaml

--- a/clearnet-website-monitoring/kustomization.yaml
+++ b/clearnet-website-monitoring/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - pvc.yaml
   - vault-secret-store.yaml
   - external-secret.yaml
+  - external-secret-browserbase.yaml
   - deployment.yaml
   - service.yaml
   - servicemonitor.yaml


### PR DESCRIPTION
Wires the Browserbase-capable exporter (ylab-clearnet-research#20, merged) into production.

## Changes
- **ExternalSecret** now materializes `targets.yaml` (Vault `domains/targets.yaml`) instead of `domains.txt`, matching the new exporter that reads a YAML target list where each entry may set `browserbase-crawl: true`.
- **New `external-secret-browserbase.yaml`**: `BROWSERBASE_API_KEY` / `BROWSERBASE_PROJECT_ID` from Vault (`clearnet-website-monitoring/browserbase`).
- **deployment**: inject the Browserbase creds as env + `PROVIDER_MONITOR_BROWSERBASE_INTERVAL=14400` (4h) so flagged domains (WAF/captcha targets like authorizecvv.in, rm1.to, freshtools.net/.to) capture the upstream on a cost-controlled cadence.

## Sequencing
⚠️ Merge only AFTER the exporter image (provider-monitor:latest reading /data/targets.yaml) has finished building from ylab-clearnet-research#20 — otherwise the running pod (old image) looks for the old /data/domains.txt. ArgoCD auto-syncs on merge.

## Vault prerequisites (done by operator)
- `clearnet-website-monitoring/domains` now has a `targets.yaml` key
- `clearnet-website-monitoring/browserbase` has `BROWSERBASE_API_KEY` + `BROWSERBASE_PROJECT_ID`