### PR TITLE
clearnet dashboards: evidence links open in a new tab + header link

### DIFF
--- a/clearnet-website-monitoring/grafana-dashboard-pm-domain.yaml
+++ b/clearnet-website-monitoring/grafana-dashboard-pm-domain.yaml
@@ -16,6 +16,30 @@ spec:
       "tags": ["clearnet-website-monitoring"],
       "schemaVersion": 39,
       "editable": true,
+      "links": [
+        {
+          "asDropdown": false,
+          "icon": "external link",
+          "includeVars": false,
+          "keepTime": false,
+          "tags": [],
+          "targetBlank": true,
+          "title": "Evidence viewer",
+          "tooltip": "Screenshots & change records (opens in a new tab)",
+          "type": "link",
+          "url": "https://clearnet-evidence.i.shion1305.com/domain/$domain"
+        },
+        {
+          "asDropdown": false,
+          "icon": "external link",
+          "includeVars": false,
+          "keepTime": true,
+          "tags": ["clearnet-website-monitoring"],
+          "targetBlank": false,
+          "title": "Monitoring dashboards",
+          "type": "dashboards"
+        }
+      ],
       "graphTooltip": 0,
       "refresh": "1m",
       "time": {
@@ -227,8 +251,8 @@ spec:
           "title": "Evidence / Screenshots",
           "gridPos": { "h": 4, "w": 5, "x": 19, "y": 1 },
           "options": {
-            "mode": "markdown",
-            "content": "### Evidence\n\n[Open change records & screenshots for **$domain** →](https://clearnet-evidence.i.shion1305.com/domain/$domain)\n\nOpens the external evidence viewer (screenshots, diffs, change history)."
+            "mode": "html",
+            "content": "<div style=\"padding:8px 4px; font-size:14px; line-height:1.6\">\n<p>Open change records &amp; screenshots for <code>$domain</code>:</p>\n<p><a href=\"https://clearnet-evidence.i.shion1305.com/domain/$domain\" target=\"_blank\" rel=\"noopener\" style=\"font-weight:600\">→ Evidence viewer</a></p>\n<p style=\"opacity:0.7; font-size:12px\">Screenshots, diffs and change history are served by a separate viewer, not embedded here.</p>\n</div>"
           }
         },
         {

--- a/clearnet-website-monitoring/grafana-dashboard-pm-fleet.yaml
+++ b/clearnet-website-monitoring/grafana-dashboard-pm-fleet.yaml
@@ -36,6 +36,18 @@ spec:
           "asDropdown": false,
           "icon": "external link",
           "includeVars": false,
+          "keepTime": false,
+          "tags": [],
+          "targetBlank": true,
+          "title": "Evidence viewer",
+          "tooltip": "Screenshots & change records for all domains (opens in a new tab)",
+          "type": "link",
+          "url": "https://clearnet-evidence.i.shion1305.com/"
+        },
+        {
+          "asDropdown": false,
+          "icon": "external link",
+          "includeVars": false,
           "keepTime": true,
           "tags": [
             "clearnet-website-monitoring"

--- a/clearnet-website-monitoring/grafana-dashboard-pm-host.yaml
+++ b/clearnet-website-monitoring/grafana-dashboard-pm-host.yaml
@@ -28,7 +28,30 @@ spec:
       "fiscalYearStartMonth": 0,
       "graphTooltip": 1,
       "id": null,
-      "links": [],
+      "links": [
+        {
+          "asDropdown": false,
+          "icon": "external link",
+          "includeVars": false,
+          "keepTime": false,
+          "tags": [],
+          "targetBlank": true,
+          "title": "Evidence viewer",
+          "tooltip": "Screenshots & change records for this host (opens in a new tab)",
+          "type": "link",
+          "url": "https://clearnet-evidence.i.shion1305.com/domain/$domain?ip=$ip"
+        },
+        {
+          "asDropdown": false,
+          "icon": "external link",
+          "includeVars": false,
+          "keepTime": true,
+          "tags": ["clearnet-website-monitoring"],
+          "targetBlank": false,
+          "title": "Monitoring dashboards",
+          "type": "dashboards"
+        }
+      ],
       "liveNow": false,
       "panels": [
         {


### PR DESCRIPTION
Fixes the evidence/screenshot links opening in the same tab, and adds the viewer as a proper dashboard header link for easier access.

## Changes
- **Dashboard-level 'Evidence viewer' link** on all 3 dashboards (pm-fleet / pm-domain / pm-host): type link, targetBlank true, external-link icon. Domain-aware (/domain/$domain) on pm-domain, host-aware (/domain/$domain?ip=$ip) on pm-host, viewer root on pm-fleet.
- **pm-domain Evidence panel**: was a markdown link (opened in the same tab); now an HTML \<a target=_blank\> matching pm-host's existing pattern.

## Verified
Loaded into a local Grafana 13.1 and inspected the rendered DOM: both the header link and the text-panel link have target=_blank — Grafana's HTML sanitizer keeps target on \<a\>, so no need to disable sanitize. ArgoCD auto-syncs on merge.