### PR TITLE
clearnet app: add Prune=false (step 1 of migration to ylab)

### DIFF
--- a/apps/clearnet-website-monitoring-app.yaml
+++ b/apps/clearnet-website-monitoring-app.yaml
@@ -3,6 +3,13 @@ kind: Application
 metadata:
   name: clearnet-website-monitoring
   namespace: argocd
+  annotations:
+    # This Application is being migrated to be managed directly against its own
+    # repo (ylab-clearnet-research/deploy/k8s). Prune=false tells the root-app
+    # (app-of-apps) NOT to delete this Application when a follow-up PR removes its
+    # entry from apps/ — so the live App (and its resources) survive the removal
+    # and can be handed off to manual/ylab management instead of being pruned.
+    argocd.argoproj.io/sync-options: Prune=false
 spec:
   project: default
   source:


### PR DESCRIPTION
**Step 1 of 2** for migrating clearnet-website-monitoring to be managed directly against its own repo (ylab-clearnet-research/deploy/k8s).

## What this does
Adds `argocd.argoproj.io/sync-options: Prune=false` to the app-of-apps entry `apps/clearnet-website-monitoring-app.yaml`. Nothing else changes — repoURL/path stay as-is.

## Why (prune guard)
root-app has `prune: true`. The **next** PR removes this entry (and the `clearnet-website-monitoring/` directory) from k8s-GitOps. Without this annotation, root-app would then prune the live Application — cascade-deleting its 15 resources and stopping monitoring. `Prune=false` makes root-app keep the Application when its entry disappears, so it survives and can be handed off to direct/ylab management.

## Sequence
1. **Merge this PR.** Confirm root-app re-syncs (Application unchanged, now carries the annotation).
2. Then I open **PR-B**: delete `apps/clearnet-website-monitoring-app.yaml` + the `clearnet-website-monitoring/` directory. root-app leaves the live App alone (Prune=false); I then repoint the surviving App at ylab.

This is verified safe: `kubectl kustomize ylab/deploy/k8s` renders byte-identical to the current directory, so the eventual ylab cutover is a no-op.

Not self-merging — merge PR-A when ready and I'll verify + open PR-B.