### PR TITLE
atc: nightly market_stream S3 export CronJob + parity gate

### DIFF
--- a/atc/cronjob-orderbook-s3-export.yaml
+++ b/atc/cronjob-orderbook-s3-export.yaml
@@ -1,0 +1,86 @@
+# Nightly replenishment of the market_stream_* S3 parquet archive (data-infra
+# plan B2, made continuous). Exports a trailing 3-business-day window —
+# idempotent (skip-existing keys), so gaps self-heal on later nights — then
+# runs the orderbook parity gate over the same window; a not_exported /
+# count_mismatch day exits non-zero and marks the Job failed (visible in Argo).
+#
+# The orderbook capture is the platform's irreplaceable asset (no vendor sells
+# GMO L2 history); before this CronJob its only durable copy stopped at the
+# last manual export. One-time catch-up of the historical gap: run the same
+# container command with ATC_EXPORT_START/ATC_EXPORT_END set explicitly
+# (kubectl create job --from=cronjob/orderbook-s3-export atc-ob-backfill, then
+# edit the env overrides), or run the CLI from an operator box.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: orderbook-s3-export
+  namespace: atc
+  labels:
+    app: orderbook-s3-export
+spec:
+  # 07:30 JST — the previous JST business date closed at 06:00 JST.
+  schedule: "30 7 * * *"
+  timeZone: "Asia/Tokyo"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 3600
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 21600
+      template:
+        metadata:
+          labels:
+            app: orderbook-s3-export
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: export
+              image: ghcr.io/shion1305/crypto-auto-trading/ws-stream:main
+              imagePullPolicy: Always
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+                  END="${ATC_EXPORT_END:-$(TZ=Asia/Tokyo date -d '1 day ago' +%F)}"
+                  START="${ATC_EXPORT_START:-$(TZ=Asia/Tokyo date -d '3 days ago' +%F)}"
+                  for SYMBOL in ${ATC_EXPORT_SYMBOLS:-ETH_JPY}; do
+                    echo "== export ${SYMBOL} ${START}..${END} (market_stream_* -> S3 parquet, skip-existing)"
+                    uv run atc etl stream-to-s3 --symbol "${SYMBOL}" \
+                      --start "${START}" --end "${END}" --tables all --concurrency 2
+                    echo "== orderbook parity gate ${SYMBOL} ${START}..${END}"
+                    uv run atc research orderbook-s3-parity --symbol "${SYMBOL}" \
+                      --start "${START}" --end "${END}"
+                  done
+              env:
+                - name: ATC_DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: atc-database-secret
+                      key: ATC_DATABASE_URL
+                - name: HISTORICAL_SOURCE_S3_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: atc-etl-s3-credentials
+                      key: HISTORICAL_SOURCE_S3_ACCESS_KEY
+                - name: HISTORICAL_SOURCE_S3_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: atc-etl-s3-credentials
+                      key: HISTORICAL_SOURCE_S3_SECRET_KEY
+                # In-cluster S3 endpoint (avoids the external gateway round trip).
+                - name: HISTORICAL_SOURCE_S3_ENDPOINT
+                  value: "http://seaweedfs-historical-source.atc.svc.cluster.local:8333"
+                # Space-separated symbol list; extend when more captured symbols
+                # should be archived.
+                - name: ATC_EXPORT_SYMBOLS
+                  value: "ETH_JPY"
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "2Gi"
+                  cpu: "1000m"

--- a/atc/etl-s3-external-secret.yaml
+++ b/atc/etl-s3-external-secret.yaml
@@ -1,0 +1,25 @@
+# Plain env-style S3 credentials for ATC ETL jobs (the seaweedfs secret only
+# renders s3.config.json, which CronJob containers cannot consume as env vars).
+# Same Vault source as seaweedfs-external-secret.yaml.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: atc-etl-s3-credentials
+  namespace: atc
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  target:
+    name: atc-etl-s3-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: HISTORICAL_SOURCE_S3_ACCESS_KEY
+      remoteRef:
+        key: seaweedfs-historical-source
+        property: S3_ACCESS_KEY
+    - secretKey: HISTORICAL_SOURCE_S3_SECRET_KEY
+      remoteRef:
+        key: seaweedfs-historical-source
+        property: S3_SECRET_KEY

--- a/atc/kustomization.yaml
+++ b/atc/kustomization.yaml
@@ -18,6 +18,8 @@ resources:
   - external-secret.yaml
   - deployment-gmocoin-exec-alert.yaml
   - seaweedfs-external-secret.yaml
+  - etl-s3-external-secret.yaml
+  - cronjob-orderbook-s3-export.yaml
   - seaweedfs-statefulset.yaml
   - seaweedfs-service.yaml
   - seaweedfs-httproute.yaml


### PR DESCRIPTION
## What

Adds a nightly CronJob that replenishes the SeaweedFS S3 parquet archive from the `market_stream_*` Postgres tables, plus a plain env-style S3 credentials ExternalSecret it consumes.

## Why

The GMO L2 orderbook capture (~550GB, growing ~4GB/day) is the platform's irreplaceable asset — **no vendor sells GMO order-book history** (verified 2026-07-07 against Tardis/Kaiko/CoinAPI listings). Its S3 export was last validated 2026-04-19; everything since lives as a single copy in Postgres (single instance, no backups — see `crypto-auto-trading` `docs/research/data-infra-plan-2026-07.md` B2, flagged "Now (durability)"). Owner decision 2026-07-07: make the export continuous in-cluster (no offsite copy).

## How

- `atc/cronjob-orderbook-s3-export.yaml` — 07:30 JST daily (the previous JST business date closes at 06:00 JST): exports a **trailing 3-business-day window** with `atc etl stream-to-s3` (idempotent, skip-existing ⇒ gaps self-heal), then runs the read-only `atc research orderbook-s3-parity` gate over the same window — `not_exported`/`count_mismatch` exits non-zero ⇒ Job failed, visible in ArgoCD. Uses the existing `ws-stream:main` image (has the `atc` CLI) and the in-cluster S3 endpoint. Symbols via `ATC_EXPORT_SYMBOLS` (default `ETH_JPY`; extend when more captured symbols should be archived).
- `atc/etl-s3-external-secret.yaml` — same Vault entry as the seaweedfs secret, rendered as plain `HISTORICAL_SOURCE_S3_ACCESS_KEY/_SECRET_KEY` keys (the seaweedfs secret only renders `s3.config.json`, unusable as container env).

## Validation

`kustomize build atc` green. NetworkPolicy already allows the whole `atc` namespace to reach Postgres 5432; S3 stays in-namespace.

## Follow-ups (not this PR)

- One-time catch-up of the 2026-04-20..now gap: run the same command with `ATC_EXPORT_START/END` overrides (manifest header documents it).
- Enumerate all captured symbols in `market_stream_*` and extend `ATC_EXPORT_SYMBOLS`.