### PR TITLE
atc: postgres-mcp --access-mode=restricted (Phase 0 hardening)

### DIFF
--- a/atc/mcp-connector.yaml
+++ b/atc/mcp-connector.yaml
@@ -17,9 +17,15 @@ spec:
         - name: postgres-mcp
           image: crystaldba/postgres-mcp:latest
           imagePullPolicy: Always
+          # SECURITY: restricted mode (read-only SQL with safety checks).
+          # This service injects the shared superuser DSN and is reachable from
+          # the openwebui namespace; unrestricted mode made it a write-capable,
+          # audit-free path into production data that also bypasses the research
+          # holdout law. Follow-up (tracked): a dedicated read-only DB role that
+          # excludes market-data tables, and a pinned image tag.
           args:
             - "--transport=sse"
-            - "--access-mode=unrestricted"
+            - "--access-mode=restricted"
           ports:
             - containerPort: 8000
               name: http


### PR DESCRIPTION
## What

Flips `postgres-mcp` from `--access-mode=unrestricted` to `--access-mode=restricted`.

## Why

Found during the 2026-07-07 infra review: the connector injects the **shared superuser** `ATC_DATABASE_URL` and is reachable from the `openwebui` namespace. Unrestricted mode therefore exposed a **write/DDL-capable, audit-free SQL path into production data** that also bypasses the research holdout law (`crypto-auto-trading` guardrails §4 — a prompt-injected chat agent could read reserved OOS ranges or mutate tables without any PR trail). Restricted mode limits the server to read-only SQL with built-in safety checks — the minimal, immediately-shippable fix.

## Follow-ups (deliberately NOT in this PR)

1. Dedicated Postgres role `atc_mcp_ro` (SELECT only on evaluation tables; **no GRANT on `market_stream_*` / `market_trade_events` / `multi_exchange_market_prices`** so holdout protection lives at the GRANT layer) + Vault/ESO plumbing for its DSN.
2. Pin the image (currently `crystaldba/postgres-mcp:latest` with `imagePullPolicy: Always`).
3. Longer term: replace with the planned read-only project-state MCP that shares the dashboard's typed query layer.

## Validation

`kustomize build atc` green. args-only change; Service/NetworkPolicy untouched.