### PR TITLE
feat(atc): expose atc-dashboard internally

### DIFF
--- a/atc/atc-dashboard-deployment.yaml
+++ b/atc/atc-dashboard-deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: atc-dashboard
+  namespace: atc
+  labels:
+    app: atc-dashboard
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: atc-dashboard
+  template:
+    metadata:
+      labels:
+        app: atc-dashboard
+      annotations:
+        reloader.stakater.com/auto: "true"
+    spec:
+      containers:
+        - name: atc-dashboard
+          image: harbor.i.shion1305.com/shion1305/atc-dashboard:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            - name: ATC_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: atc-database-secret
+                  key: ATC_DATABASE_URL
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "10m"
+            limits:
+              memory: "1024Mi"
+              cpu: "2000m"

--- a/atc/atc-dashboard-httproute.yaml
+++ b/atc/atc-dashboard-httproute.yaml
@@ -1,0 +1,18 @@
+# Internal Gateway only serves *.i.shion1305.com, so the dashboard is exposed
+# on the internal listener as an authenticated internal app.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: atc-dashboard-internal
+  namespace: atc
+spec:
+  parentRefs:
+    - name: internal
+      namespace: envoy-gateway-system
+      sectionName: https
+  hostnames:
+    - atc-dashboard.i.shion1305.com
+  rules:
+    - backendRefs:
+        - name: atc-dashboard
+          port: 80

--- a/atc/atc-dashboard-service.yaml
+++ b/atc/atc-dashboard-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: atc-dashboard
+  namespace: atc
+spec:
+  type: ClusterIP
+  selector:
+    app: atc-dashboard
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000

--- a/atc/kustomization.yaml
+++ b/atc/kustomization.yaml
@@ -12,11 +12,14 @@ resources:
   - grafana-deployment.yaml
   - grafana-service.yaml
   - grafana-httproute.yaml
+  - atc-dashboard-service.yaml
+  - atc-dashboard-httproute.yaml
   - prometheus.yaml
   - prometheus-httproute.yaml
   - vault-secret-store.yaml
   - external-secret.yaml
   - deployment-gmocoin-exec-alert.yaml
+  - atc-dashboard-deployment.yaml
   - seaweedfs-external-secret.yaml
   - etl-s3-external-secret.yaml
   - cronjob-orderbook-s3-export.yaml


### PR DESCRIPTION
Expose atc-dashboard on atc-dashboard.i.shion1305.com behind the internal Envoy Gateway.

Changes:
- add Deployment for harbor.i.shion1305.com/shion1305/atc-dashboard:latest
- inject ATC_DATABASE_URL from atc-database-secret
- add ClusterIP Service on port 80 -> 3000
- add internal HTTPRoute for atc-dashboard.i.shion1305.com

Validation:
- kustomize build atc