### PR TITLE
atc app: add Prune=false (step 1 of migration to crypto-auto-trading)

### DIFF
--- a/apps/atc-app.yaml
+++ b/apps/atc-app.yaml
@@ -3,6 +3,13 @@ kind: Application
 metadata:
   name: atc
   namespace: argocd
+  annotations:
+    # This Application is being migrated to be managed directly against its own
+    # repo (crypto-auto-trading/infra/k8s). Prune=false tells the root-app
+    # (app-of-apps) NOT to delete this Application when a follow-up PR removes its
+    # entry from apps/ — so the live App (and its resources) survive the removal
+    # and can be handed off to crypto-auto-trading management instead of being pruned.
+    argocd.argoproj.io/sync-options: Prune=false
 spec:
   project: default
   source:


### PR DESCRIPTION
**Step 1 of 2** (k8s-GitOps side) for migrating `atc` to be managed directly against its own repo (`crypto-auto-trading/infra/k8s`). Same pattern as the clearnet → ylab migration (#504 / #505).

Pairs with `crypto-auto-trading#490`, which adds `infra/k8s/` (byte-identical copy of `atc/`) + a self-referencing ArgoCD app. Merge that one first.

## What this does
Adds `argocd.argoproj.io/sync-options: Prune=false` to the app-of-apps entry `apps/atc-app.yaml`. Nothing else changes — `repoURL`/`path` stay as-is, cluster state unchanged.

## Why (prune guard)
root-app has `prune: true`. The **next** PR removes this entry (and the `atc/` directory) from k8s-GitOps. Without this annotation, root-app would then prune the live `atc` Application — cascade-deleting its resources (postgres cluster, seaweedfs, ws-stream, dashboard, grafana, prometheus, …) and taking the stack down. `Prune=false` makes root-app keep the Application when its entry disappears, so it survives and can be repointed at crypto-auto-trading.

## Sequence
1. **Merge this PR.** Confirm root-app re-syncs (Application unchanged, now carries the annotation).
2. Then **PR-C**: delete `apps/atc-app.yaml` + the `atc/` directory. root-app leaves the live App alone (Prune=false); I then repoint the surviving App at `crypto-auto-trading` (`repoURL` + `path: infra/k8s`) and verify Synced/Healthy with **no pod recreation** (kustomize render is byte-identical → no-op).

Not self-merging — merge when ready and I'll verify + open PR-C.