### PR TITLE
feat(pypi-cache): in-cluster PyPI pull-through cache (proxpi)

### DIFF
--- a/apps/pypi-cache-app.yaml
+++ b/apps/pypi-cache-app.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: pypi-cache
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Shion1305/k8s-GitOps.git
+    targetRevision: HEAD
+    path: pypi-cache
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: pypi-cache
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/pypi-cache/README.md
+++ b/pypi-cache/README.md
@@ -1,0 +1,67 @@
+# pypi-cache — in-cluster PyPI pull-through cache (proxpi)
+
+A lightweight [proxpi](https://github.com/EpicWink/proxpi) deployment that caches
+PyPI wheels in-cluster so CI (and any in-cluster `pip`/`uv`) fetches each wheel
+from the WAN **once**, then serves every subsequent pull from the home LAN.
+
+## Why this exists
+
+The ATC CI jobs spend ~150s/job in `uv sync` downloading ~200 MB of wheels
+(pyarrow, scipy, polars, numpy, marimo, …) from PyPI over the WAN. The wheel
+*content* is identical every run, but nothing in-cluster caches it. This is the
+"move the artifact source in-cluster" half of the CI-cache work (the other half —
+a warm CPython hostedtoolcache + aqua/uv baked into the runner image — lives in
+the `crypto-auto-trading` repo).
+
+## Why proxpi and not a plain reverse-proxy
+
+PyPI's simple API returns **absolute** wheel URLs on `files.pythonhosted.org`, so
+a naive nginx proxy of the index host serves the index but lets the client fetch
+wheels straight from PyPI — uncached. proxpi rewrites those file URLs to route
+through itself (`/index/<pkg>/<file>`) and caches the bytes; that rewrite is the
+whole point. devpi does the same but has no official image and needs index/user
+init — proxpi is a single gunicorn process purpose-built for exactly this.
+
+## Consumer contract (do not break without updating consumers)
+
+- **Service:** `proxpi.pypi-cache.svc.cluster.local:5000`
+- **Index endpoint:** `/index/` (PEP 503 simple API)
+
+The `crypto-auto-trading` CI runner image (`Dockerfile.ci-runner`) bakes these
+env vars so `uv sync` uses the cache transparently — **zero per-repo workflow
+edits**:
+
+```dockerfile
+ENV UV_DEFAULT_INDEX=http://proxpi.pypi-cache.svc.cluster.local:5000/index/ \
+    UV_INSECURE_HOST=proxpi.pypi-cache.svc.cluster.local:5000
+```
+
+`UV_INSECURE_HOST` is required because proxpi speaks plain HTTP in-cluster; uv
+refuses an `http://` index otherwise. This is an in-cluster-only plaintext hop
+within one trust domain (Cilium-policed pod network), not internet-facing, so TLS
+is not warranted here.
+
+**Lockfile integrity is preserved:** proxpi returns byte-identical upstream
+wheels, so the hashes pinned in `uv.lock` still verify. The cache changes *where*
+a wheel comes from, never *what* it is.
+
+## Operational notes
+
+- **Single replica + RWO PVC** (`longhorn-hdd`, 20Gi). Never scale to >1 replica
+  against the same volume; `strategy: Recreate` ensures the old pod detaches
+  before the new one attaches. The cache is a warm-up optimisation — losing the
+  PVC just means the next pulls repopulate it from PyPI.
+- **Eviction:** `PROXPI_CACHE_SIZE=16Gi` (LRU) sits below the 20Gi PVC so proxpi
+  evicts before longhorn fills.
+- **Index freshness:** `PROXPI_INDEX_TTL=1800s` — new releases appear within 30
+  min; the wheel *files* are immutable and cached indefinitely (until LRU-evicted).
+- **Image:** `epicwink/proxpi` pinned by digest (Docker Hub is its only channel).
+  A Harbor `docker.io` proxy-cache project could front it later; the digest pin
+  already makes the pull reproducible.
+
+## Validation
+
+Verified end-to-end locally (proxpi + a real `pip`/`uv` install): the index and
+every wheel are served through proxpi (`GET /index/<pkg>/<file>` 200), and wheels
+persist to the cache dir (`files-pythonhosted-org/packages/.../<pkg>.whl`). A
+second install of the same package is served entirely from the cache.

--- a/pypi-cache/deployment.yaml
+++ b/pypi-cache/deployment.yaml
@@ -1,0 +1,109 @@
+# proxpi -- a lightweight pull-through PyPI proxy that caches wheels in-cluster.
+#
+# WHY (and why not a plain nginx proxy): PyPI's simple API returns ABSOLUTE wheel
+# URLs on files.pythonhosted.org, so a naive reverse-proxy of just the index host
+# would serve the index but let the client fetch wheels straight from PyPI --
+# uncached. proxpi rewrites those file URLs to route through itself
+# (/index/<pkg>/<file>) and caches the bytes, which is exactly what makes the
+# cache effective. devpi does the same but has no official image and needs
+# index/user init; proxpi is a single Flask/gunicorn process purpose-built for
+# this, so it's the minimal fit.
+#
+# WHO USES IT: this repo's CI runner image (crypto-auto-trading-ci) bakes
+# UV_DEFAULT_INDEX=http://proxpi.pypi-cache.svc.cluster.local:5000/index/ , so
+# `uv sync` resolves + downloads wheels through here with ZERO per-repo workflow
+# edits. Lockfile integrity is preserved: proxpi returns byte-identical upstream
+# wheels, so the hashes pinned in uv.lock still match. First fetch of a wheel goes
+# to PyPI (WAN) and is cached to the PVC; every subsequent pull -- across pods and
+# across CI jobs -- is served from the LAN.
+#
+# This is a NEW, self-contained component. It does NOT touch the shared
+# github-actions-runner config; runner pods reach it as an ordinary in-cluster
+# Service (their namespace has no egress default-deny blocking it).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: proxpi
+  namespace: pypi-cache
+  labels:
+    app.kubernetes.io/name: proxpi
+spec:
+  replicas: 1
+  # RWO PVC with a single writer: never run two proxpi pods against the same
+  # volume. Recreate (not RollingUpdate) so the old pod releases the PVC before
+  # the new one attaches, avoiding a multi-attach stall on longhorn.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: proxpi
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: proxpi
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: proxpi
+          # Pinned by digest (epicwink/proxpi:latest at time of writing). Docker
+          # Hub is the only distribution channel for this image; a Harbor
+          # docker.io proxy-cache project could front it later, but the digest
+          # pin already makes the pull reproducible.
+          image: epicwink/proxpi@sha256:7f8dce8778b7d4634c1e35d6f8d99f366e83dc60721ffc8f45893d19afcc5a90
+          imagePullPolicy: IfNotPresent
+          args:
+            - --bind
+            - 0.0.0.0:5000
+            - --threads
+            - "4"
+            - --no-control-socket
+          env:
+            # Persist the wheel cache on the PVC (default is an ephemeral /tmp dir).
+            - name: PROXPI_CACHE_DIR
+              value: /var/cache/proxpi
+            # LRU ceiling in bytes; keep below the 20Gi PVC so proxpi evicts
+            # before longhorn fills. 16 GiB.
+            - name: PROXPI_CACHE_SIZE
+              value: "17179869184"
+            # Re-check the simple index this often (seconds). 30 min balances
+            # picking up new releases against hammering PyPI for the index.
+            - name: PROXPI_INDEX_TTL
+              value: "1800"
+          ports:
+            - name: http
+              containerPort: 5000
+          volumeMounts:
+            - name: cache
+              mountPath: /var/cache/proxpi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: cache
+          persistentVolumeClaim:
+            claimName: proxpi-cache

--- a/pypi-cache/kustomization.yaml
+++ b/pypi-cache/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml

--- a/pypi-cache/namespace.yaml
+++ b/pypi-cache/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pypi-cache
+  labels:
+    name: pypi-cache

--- a/pypi-cache/pvc.yaml
+++ b/pypi-cache/pvc.yaml
@@ -1,0 +1,24 @@
+# Persistent wheel cache for proxpi. proxpi caches downloaded files under
+# PROXPI_CACHE_DIR (an LRU bounded by PROXPI_CACHE_SIZE); without a PVC that
+# cache lives in the container's /tmp and is lost on every restart, so each cold
+# start would re-fetch every wheel from PyPI over the WAN -- defeating the point.
+# A single RWO volume is correct: proxpi runs as one replica (a shared cache with
+# one writer; scaling out would need RWX + coordination we don't want here).
+#
+# longhorn-hdd: the workload is bandwidth-bound bulk wheel storage, not latency-
+# sensitive, so HDD-class replicated storage is the right cost/durability point
+# (matches mlflow-artifacts). 20Gi comfortably holds the ATC dependency closure
+# (pyarrow/scipy/polars/numpy/marimo/... ~a few hundred MB per Python/platform)
+# with headroom; proxpi's LRU evicts against PROXPI_CACHE_SIZE below this.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: proxpi-cache
+  namespace: pypi-cache
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-hdd
+  resources:
+    requests:
+      storage: 20Gi

--- a/pypi-cache/service.yaml
+++ b/pypi-cache/service.yaml
@@ -1,0 +1,20 @@
+# Stable in-cluster endpoint for proxpi. The CI runner image bakes
+# UV_DEFAULT_INDEX=http://proxpi.pypi-cache.svc.cluster.local:5000/index/ , so
+# this Service name/port is part of the contract -- do not rename without
+# updating Dockerfile.ci-runner in crypto-auto-trading.
+apiVersion: v1
+kind: Service
+metadata:
+  name: proxpi
+  namespace: pypi-cache
+  labels:
+    app.kubernetes.io/name: proxpi
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: proxpi
+  ports:
+    - name: http
+      port: 5000
+      targetPort: http
+      protocol: TCP


### PR DESCRIPTION
## What & why

Adds a lightweight **proxpi** deployment that caches PyPI wheels in-cluster, so CI (and any in-cluster `pip`/`uv`) fetches each wheel from the WAN **once**, then serves every subsequent pull from the home LAN.

This is the "move the artifact source in-cluster" half of the ATC CI-cache work. The ATC CI jobs spend ~150s/job in `uv sync` downloading ~200 MB of wheels (pyarrow, scipy, polars, numpy, marimo, …) from PyPI over the WAN; the content is identical every run but nothing in-cluster caches it. (The other half — a warm CPython hostedtoolcache + aqua/uv baked into the runner image — is [crypto-auto-trading#511](https://github.com/Shion1305/crypto-auto-trading/pull/511).)

## Why proxpi, not a plain reverse-proxy

PyPI's simple API returns **absolute** wheel URLs on `files.pythonhosted.org`, so a naive nginx proxy of the index host would serve the index but let clients fetch wheels straight from PyPI — uncached. proxpi rewrites those file URLs to route through itself (`/index/<pkg>/<file>`) and caches the bytes; that rewrite is the whole point. devpi does the same but has no official image and needs index/user init — proxpi is a single gunicorn process purpose-built for exactly this.

## What's here

- New self-contained component: `pypi-cache/{namespace,pvc,deployment,service}.yaml` + `kustomization.yaml` + README, and `apps/pypi-cache-app.yaml` (single-source ArgoCD app, `path: pypi-cache`).
- **Single replica** against an RWO `longhorn-hdd` 20Gi PVC (`Recreate` strategy so the old pod detaches first). Image **pinned by digest**, `runAsNonRoot` + `readOnlyRootFilesystem`, `/health` readiness/liveness probes. `PROXPI_CACHE_DIR` → the PVC; `PROXPI_CACHE_SIZE=16Gi` LRU below the PVC.

## Consumer contract

- **Service:** `proxpi.pypi-cache.svc.cluster.local:5000`, index at `/index/`.
- The crypto-auto-trading runner image bakes `UV_DEFAULT_INDEX` + `UV_INSECURE_HOST` at this address, so `uv sync` uses the cache **transparently — zero per-repo workflow edits**. `UV_INSECURE_HOST` is needed because proxpi speaks plain HTTP in-cluster (an in-cluster-only hop within one Cilium-policed trust domain; not internet-facing).
- **Lockfile integrity preserved:** proxpi returns byte-identical upstream wheels, so the hashes pinned in `uv.lock` still verify — the cache changes *where* a wheel comes from, never *what* it is.

## Isolation / blast radius

Touches **no shared config**. Runner pods reach it as an ordinary in-cluster Service (their namespace has no egress default-deny). It's a new, standalone ArgoCD app.

## Validation

- **End-to-end locally:** ran a real `pip`/`uv` install with the index pointed at proxpi — the index and every wheel are served through proxpi (`GET /index/<pkg>/<file>` 200), and wheels persist to the cache dir (`files-pythonhosted-org/packages/.../<pkg>.whl`). A repeat install is served from cache.
- **kubeconform:** 4/4 resources valid.

## Sequencing (after merge)

1. `kubectl apply -f apps/pypi-cache-app.yaml` → ArgoCD deploys proxpi.
2. **Then** build + swap the crypto-auto-trading runner image (crypto-auto-trading#511) whose uv points here. Order matters: `uv sync` resolves only against this index, so proxpi must be up before a runner using that image runs.