### PR TITLE
Fix proxpi temporary directory

### DIFF
--- a/pypi-cache/deployment.yaml
+++ b/pypi-cache/deployment.yaml
@@ -80,6 +80,11 @@ spec:
           volumeMounts:
             - name: cache
               mountPath: /var/cache/proxpi
+            # Gunicorn creates a per-worker temporary file at startup.  The
+            # container filesystem is intentionally read-only, so provide a
+            # writable ephemeral /tmp without weakening that hardening.
+            - name: tmp
+              mountPath: /tmp
           readinessProbe:
             httpGet:
               path: /health
@@ -107,3 +112,5 @@ spec:
         - name: cache
           persistentVolumeClaim:
             claimName: proxpi-cache
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
## Summary

- mount an ephemeral writable `/tmp` for the proxpi container
- preserve the read-only root filesystem and persistent wheel-cache volume

## Root cause

Gunicorn creates a worker temporary file during startup. With `readOnlyRootFilesystem: true` and no writable temporary directory, proxpi exited with `FileNotFoundError: No usable temporary directory found`.

## Validation

- `kubectl apply --dry-run=server` for the rendered resource YAMLs
- `git diff --check`
- reproduced the pre-fix CrashLoop log signal twice