### PR TITLE
Allow GARM runners to use proxpi

### DIFF
--- a/pypi-cache/kustomization.yaml
+++ b/pypi-cache/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - pvc.yaml
   - deployment.yaml
   - service.yaml
+  - networkpolicy.yaml

--- a/pypi-cache/networkpolicy.yaml
+++ b/pypi-cache/networkpolicy.yaml
@@ -1,0 +1,24 @@
+# The namespace-wide cross-ns-isolation policy denies this ingress by default.
+# Permit only ephemeral GARM runner Pods to use the in-cluster PyPI cache.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-garm-runners-to-proxpi
+  namespace: pypi-cache
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: proxpi
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: github-actions-runner-pods
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/managed-by: garm
+      ports:
+        - protocol: TCP
+          port: 5000


### PR DESCRIPTION
## Summary

- add a narrowly scoped ingress NetworkPolicy for GARM runner Pods
- include the policy in the pypi-cache Kustomization

## Root cause

The Kyverno-generated namespace-wide `cross-ns-isolation` policy permits ingress only from Pods in the same namespace. GARM runner Pods run in `github-actions-runner-pods`, so their requests to the proxpi ClusterIP timed out.

## Impact

Self-hosted GitHub Actions runners can reach `proxpi.pypi-cache.svc.cluster.local:5000`; all other namespaces and ports remain blocked.

## Validation

- `kubectl kustomize pypi-cache | kubectl apply --dry-run=server -f -`
- `git diff --check`
- temporary live-policy test from a real GARM runner Pod: `GET /index/marimo/` returned HTTP 200; the temporary policy was deleted after verification.