### PR TITLE
Right-size memory requests: prometheus 4Gi→3Gi, buildkitd 4Gi→2Gi

### DIFF
--- a/buildkit/deployment.yaml
+++ b/buildkit/deployment.yaml
@@ -64,7 +64,7 @@ spec:
           resources:
             requests:
               cpu: 1000m
-              memory: 4Gi
+              memory: 2Gi
             limits:
               memory: 8Gi
           volumeMounts:

--- a/grafana/values.yaml
+++ b/grafana/values.yaml
@@ -51,7 +51,7 @@ prometheus:
         memory: 8Gi
       requests:
         cpu: 1000m
-        memory: 4Gi
+        memory: 3Gi
 # Grafana is managed by grafana-operator; disable the bundled chart instance
 # but still render the chart's bundled dashboard ConfigMaps so the operator
 # can adopt them via GrafanaDashboard CRs (see grafana/dashboards.yaml).


### PR DESCRIPTION
## What

Reduce two over-provisioned memory **requests** (limits unchanged, so burst headroom is preserved):

| Workload | mem req | live usage | change |
|---|---|---|---|
| `prometheus-kube-prometheus-stack-prometheus-0` (`grafana/values.yaml`) | 4Gi → **3Gi** | ~2.1Gi RSS | −1Gi reservation |
| `buildkitd` (`buildkit/deployment.yaml`) | 4Gi → **2Gi** | ~760Mi RSS idle | −2Gi reservation |

Both keep their **8Gi limit**, so Prometheus can still burst for ingestion/query spikes and buildkitd can still burst to 8Gi during heavy multi-arch builds.

## Why

Live `kubectl top` shows both sitting far below their requested floor. The request is a hard scheduling reservation; trimming it frees ~3Gi of schedulable memory across the amd64 build node / grafana node without touching burst ceilings.

## Notes

- Grafana Prometheus is rendered by the Helm chart via `grafana/values.yaml`; ArgoCD self-heal will roll the STS.
- buildkitd uses a `Recreate` strategy, so applying this restarts the single builder (cache is `emptyDir`, so the first post-restart build is a cold cache — expected).