### PR TITLE
vault: prevent quorum-loss lockout — node spread, file-based auto-unseal, raft snapshots

### DIFF
--- a/vault/README.md
+++ b/vault/README.md
@@ -17,8 +17,11 @@ Key configurations:
 - **Routing**: Envoy Gateway HTTPRoutes (see `httproute-*.yaml`); the chart-rendered Ingress is disabled
 - **Storage**: 10Gi persistent volumes for data and audit logs (longhorn-hdd-ha with 2 replicas)
 - **Resources**: 256Mi/250m requests, 512Mi/500m limits
-- **Auto-Unseal**: KV-based sidecar auto-unseal via active node
-- **Pod Anti-Affinity**: Pods prefer to spread across different nodes for better HA
+- **Auto-Unseal**: file-based sidecar auto-unseal — each pod reads the unseal
+  keys from a mounted Secret and unseals itself independently (see
+  [Resilience & Disaster Recovery](#resilience--disaster-recovery))
+- **Pod Anti-Affinity**: hard anti-affinity spreads the 3 pods across 3 distinct
+  nodes so a single-node event can never take down the raft quorum
 
 ## Access
 
@@ -66,13 +69,158 @@ vault kv put <svc>/credentials \
 ### Backup & Maintenance
 
 ```bash
-# Create Raft snapshot
+# Create Raft snapshot manually (automated hourly via the CronJob below)
 vault operator raft snapshot save backup-$(date +%Y%m%d).snap
 
 # Check cluster status
 vault operator raft list-peers
 vault status
 ```
+
+## Resilience & Disaster Recovery
+
+### How HA and auto-unseal work
+
+Vault runs as a **3-node Raft cluster**. Raft needs a **quorum of 2 of 3**
+voters to elect a leader (the *active* node); the other two are *standby*.
+
+Two independent mechanisms keep the cluster available:
+
+1. **Cross-node spread (hard anti-affinity).** The three pods are forced onto
+   three distinct nodes (`values.yaml` → `server.affinity.podAntiAffinity`,
+   `requiredDuringScheduling`). A single node event therefore seals/kills at
+   most **one** pod; the other two retain quorum and an active leader. Node
+   preference favours the strong amd64 hosts but every schedulable node is a
+   last-resort fallback, so a pod is never left `Pending`. Because
+   `longhorn-hdd-ha` uses `dataLocality: disabled`, a pod can attach its data
+   volume from any node.
+
+2. **File-based auto-unseal sidecar.** Each pod runs an `unseal-sidecar`
+   (`values.yaml` → `server.extraContainers`) that reads the unseal keys from a
+   **mounted Secret** (`vault-unseal-keys`) and unseals its *local* node. Because
+   the keys come from a Secret — not from the active node — **a pod can
+   self-unseal even when no node is active**. This is the key change from the
+   previous design, where the sidecar fetched keys from `vault-active` and thus
+   could not bootstrap when every node was sealed at once.
+
+**What now recovers automatically:**
+
+| Event | Outcome |
+|-------|---------|
+| One node reboots / one pod restarts | Other two hold quorum; the pod reschedules to a free node and auto-unseals. **No action.** |
+| All pods restart at once (e.g. all-nodes reboot), data intact | Each pod auto-unseals from its mounted Secret, they re-form quorum. **No action.** |
+| Quorum lost + Raft data loss/corruption on a majority | Manual recovery required — see [Lost-quorum recovery](#lost-quorum--corruption-recovery-peersjson). |
+
+### The unseal-keys Secret
+
+`vault-unseal-keys` (namespace `vault`) holds `key1`/`key2`/`key3` (3 of the 5
+Shamir shares = the unseal threshold). It is **created out-of-band and never
+committed** (this is a public repo). To (re)create it:
+
+```bash
+kubectl create secret generic vault-unseal-keys -n vault \
+  --from-literal=key1='<unseal-key-1>' \
+  --from-literal=key2='<unseal-key-2>' \
+  --from-literal=key3='<unseal-key-3>'
+```
+
+Security note: the keys live in etcd (base64). Ensure etcd encryption-at-rest is
+enabled, and restrict `get secret` in the `vault` namespace. This is the
+availability/security trade-off chosen over the previous self-referential
+design. A future hardening is KMS/transit auto-unseal (keys never leave the KMS).
+
+### Automated Raft snapshots
+
+`raft-snapshot-cronjob.yaml` runs `vault operator raft snapshot save` every 6h
+to a dedicated PVC (`vault-raft-snapshots`), keeping the 14 most recent. A recent
+snapshot turns a lost-quorum/corruption event into a `snapshot restore` instead
+of manual surgery.
+
+One-time setup (the CronJob's ServiceAccount needs a scoped Vault role). Run with
+an admin token:
+
+```bash
+export VAULT_ADDR=http://127.0.0.1:8200
+export VAULT_TOKEN=<admin-token>
+kubectl port-forward svc/vault-active 8200:8200 -n vault &
+bash vault/scripts/setup-snapshot-role.sh
+```
+
+Restore from a snapshot (into an already-initialised, unsealed, active cluster):
+
+```bash
+kubectl cp vault/<snapshot-pod>:/snapshots/vault-<ts>.snap ./restore.snap
+kubectl cp ./restore.snap vault/vault-0:/tmp/restore.snap
+kubectl exec -n vault vault-0 -c vault -- vault operator raft snapshot restore /tmp/restore.snap
+```
+
+### Lost-quorum / corruption recovery (peers.json)
+
+Use this only when a **majority of nodes have lost or corrupted Raft data** so no
+leader can be elected (symptoms: every node `Sealed`, one node `Initialized=true`
+but stuck `HA Mode: standby` after unseal, others `Initialized=false` /
+crash-looping with a bbolt `freepages` panic). This reduces the single surviving
+copy to a one-node cluster, then rejoins the rest fresh.
+
+1. **Identify the survivor** — the node with `Initialized=true` and the highest
+   `Raft Applied Index`. Back up its raw data first:
+
+   ```bash
+   kubectl exec -n vault vault-0 -c vault -- \
+     tar czf - -C /vault/data raft vault.db > vault-survivor-backup.tgz
+   ```
+
+2. **Write `peers.json`** (Raft protocol v3; cluster address is port `8201`)
+   into the survivor:
+
+   ```bash
+   kubectl exec -n vault vault-0 -c vault -- sh -c 'cat > /vault/data/raft/peers.json <<EOF
+   [{"id":"vault-0","address":"vault-0.vault-internal:8201","non_voter":false}]
+   EOF'
+   ```
+
+3. **Restart the survivor, then unseal it.** `peers.json` is consumed at
+   **unseal time** (Raft `SetupCluster` runs on unseal, not at process start):
+
+   ```bash
+   kubectl delete pod vault-0 -n vault
+   # wait for Running, then unseal (sidecar does this automatically, or:)
+   kubectl exec -n vault vault-0 -c vault -- vault operator unseal <key1>
+   kubectl exec -n vault vault-0 -c vault -- vault operator unseal <key2>
+   kubectl exec -n vault vault-0 -c vault -- vault operator unseal <key3>
+   ```
+
+   The logs show `initial configuration ... servers=[vault-0 Voter]` →
+   `entering leader state`, `peers.json` is auto-deleted, and `HA Mode: active`.
+   **Service is restored here** (all secrets available again).
+
+4. **Rejoin the other nodes fresh.** Their stale data blocks a clean join
+   (`cluster already has state`), so wipe it:
+
+   ```bash
+   # for a running-but-empty node:
+   kubectl exec -n vault vault-1 -c vault -- sh -c 'rm -rf /vault/data/raft /vault/data/vault.db'
+   kubectl delete pod vault-1 -n vault
+   # for a crash-looping node (container won't start): recreate its PVC
+   kubectl delete pvc data-vault-2 -n vault --wait=false
+   kubectl delete pod vault-2 -n vault
+   ```
+
+   Each rejoins via `retry_join`, receives a snapshot from the leader, and the
+   sidecar auto-unseals it. Confirm all three become `Voter`.
+
+5. **ESO recovery.** Stores/ExternalSecrets stuck `InvalidProviderConfig` from
+   the outage backoff recover after a reconcile nudge:
+
+   ```bash
+   kubectl annotate clustersecretstore <name> reconcile.eso/nudge="$(date +%s)" --overwrite
+   kubectl annotate externalsecret <name> -n <ns> force-sync="$(date +%s)" --overwrite
+   ```
+
+> PVCs are created from the StatefulSet's `volumeClaimTemplates` and are **not**
+> ArgoCD-tracked, so deleting a PVC/pod does not fight `selfHeal`. Do **not**
+> hand-edit the StatefulSet (affinity, sidecar) live — `selfHeal` reverts it;
+> change `values.yaml` and let ArgoCD sync.
 
 ## OIDC Authentication (Keycloak)
 

--- a/vault/kustomization.yaml
+++ b/vault/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - httproute-external.yaml
   - httproute-legacy-redirect.yaml
   - networkpolicy.yaml
+  - raft-snapshot-cronjob.yaml

--- a/vault/raft-snapshot-cronjob.yaml
+++ b/vault/raft-snapshot-cronjob.yaml
@@ -1,0 +1,93 @@
+---
+# Durable, off-raft copies of Vault state. A recent snapshot turns a lost-quorum
+# or storage-corruption event into `vault operator raft snapshot restore` instead
+# of manual peers.json surgery. See README.md ("Disaster Recovery").
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault-snapshot
+  namespace: vault
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vault-raft-snapshots
+  namespace: vault
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-hdd-ha
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: vault-raft-snapshot
+  namespace: vault
+spec:
+  schedule: "0 */6 * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 600
+      template:
+        spec:
+          serviceAccountName: vault-snapshot
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 100
+            runAsGroup: 1000
+            fsGroup: 1000
+          containers:
+            - name: snapshot
+              image: hashicorp/vault:2.0.3
+              env:
+                - name: VAULT_ADDR
+                  value: http://vault-active.vault.svc.cluster.local:8200
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  echo "Authenticating to Vault via Kubernetes auth (role=vault-snapshot)..."
+                  SA_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+                  AUTH_JSON=$(vault write -format=json auth/kubernetes/login \
+                    jwt="$SA_TOKEN" role="vault-snapshot")
+                  VAULT_TOKEN=$(printf '%s' "$AUTH_JSON" | sed -n 's/.*"client_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)
+                  if [ -z "$VAULT_TOKEN" ]; then
+                    echo "ERROR: failed to obtain Vault token" >&2
+                    exit 1
+                  fi
+                  export VAULT_TOKEN
+                  TS=$(date +%Y%m%d-%H%M%S)
+                  OUT="/snapshots/vault-${TS}.snap"
+                  echo "Saving raft snapshot to ${OUT}..."
+                  vault operator raft snapshot save "$OUT"
+                  # Retain the 14 most recent snapshots (~3.5 days at the 6h cadence).
+                  ls -1t /snapshots/vault-*.snap 2>/dev/null | tail -n +15 | while read -r old; do
+                    echo "Pruning old snapshot: $old"
+                    rm -f "$old"
+                  done
+                  echo "Done. Current snapshots:"
+                  ls -la /snapshots/
+              volumeMounts:
+                - name: snapshots
+                  mountPath: /snapshots
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 250m
+                  memory: 256Mi
+          volumes:
+            - name: snapshots
+              persistentVolumeClaim:
+                claimName: vault-raft-snapshots

--- a/vault/scripts/setup-snapshot-role.sh
+++ b/vault/scripts/setup-snapshot-role.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Create the Vault policy and Kubernetes-auth role used by the vault-raft-snapshot
+# CronJob (see ../raft-snapshot-cronjob.yaml). The CronJob's ServiceAccount
+# (vault-snapshot in namespace vault) logs in via the kubernetes auth method and
+# receives a token scoped to reading raft snapshots only.
+#
+# Prerequisites:
+#   - Vault is unsealed and Kubernetes auth is enabled
+#   - VAULT_ADDR and VAULT_TOKEN (admin) are set
+#
+# Usage:
+#   export VAULT_ADDR=http://127.0.0.1:8200
+#   export VAULT_TOKEN=<admin-token>
+#   kubectl port-forward svc/vault-active 8200:8200 -n vault &
+#   bash vault/scripts/setup-snapshot-role.sh
+
+set -euo pipefail
+
+echo "=== Creating vault-snapshot policy ==="
+vault policy write vault-snapshot - <<'EOF'
+# Read-only raft snapshots for the backup CronJob.
+path "sys/storage/raft/snapshot" {
+  capabilities = ["read"]
+}
+EOF
+echo "✓ Created policy: vault-snapshot"
+
+echo "=== Creating vault-snapshot Kubernetes auth role ==="
+vault write auth/kubernetes/role/vault-snapshot \
+  bound_service_account_names=vault-snapshot \
+  bound_service_account_namespaces=vault \
+  policies=vault-snapshot \
+  ttl=15m
+echo "✓ Created role: vault-snapshot"

--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -39,30 +39,64 @@ server:
   # routing to Envoy Gateway (matches harbor/zot/keycloak pattern).
   ingress:
     enabled: false
+  # 3-node raft cluster: a quorum (2 of 3) must survive any single-node event, so
+  # the three pods must land on three distinct nodes.
   affinity:
+    # Prefer the strong amd64 nodes, then the OCI arm64 nodes; all schedulable
+    # nodes stay eligible as a last resort so a pod is never left Pending. The
+    # longhorn-hdd-ha class has dataLocality=disabled, so a pod can attach its
+    # volume from any node.
     nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
               - key: kubernetes.io/hostname
                 operator: In
                 values:
                   - shion-ubuntu-2505
+                  - shion-ubuntu-2605
+        - weight: 50
+          preference:
+            matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values:
+                  - instance-2024-1
                   - instance-k8s-proxy
+    # Hard anti-affinity: never co-locate two vault pods on the same node.
     podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                app.kubernetes.io/name: vault
-                app.kubernetes.io/instance: vault
-                component: server
-            topologyKey: kubernetes.io/hostname
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: vault
+              app.kubernetes.io/instance: vault
+              component: server
+          topologyKey: kubernetes.io/hostname
+  # Tolerate the control-plane taint so instance-2024-1 can host a replica.
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
   serviceAccount:
     create: true
     name: "vault-unsealer"
+  # Extra volume holding the unseal keys, mounted read-only into the sidecar.
+  # The vault-unseal-keys Secret is created out-of-band and never committed
+  # (public repo).
+  volumes:
+    - name: unseal-keys
+      secret:
+        secretName: vault-unseal-keys
+        # 0440: files are owned root:1000 (pod fsGroup=1000); the sidecar runs as
+        # uid 100 / gid 1000 and reads the keys via the group bit.
+        defaultMode: 0440
   extraContainers:
+    # Auto-unseal sidecar. Reads the unseal keys from the mounted Secret and
+    # unseals the local node. Sourcing keys from a Secret rather than from the
+    # active node means a pod can self-unseal even when no node is active, so a
+    # full simultaneous restart (e.g. a node reboot) recovers without a human
+    # supplying keys.
     - name: unseal-sidecar
       image: hashicorp/vault:2.0.3
       securityContext:
@@ -73,9 +107,9 @@ server:
         - sh
         - -c
         - |
-          echo "Starting KV Auto-Unseal Sidecar..."
-          ACTIVE_ADDR="http://vault-active.vault.svc.cluster.local:8200"
+          echo "Starting file-based auto-unseal sidecar..."
           LOCAL_ADDR="http://127.0.0.1:8200"
+          KEYS_DIR="/vault/unseal-keys"
 
           while true; do
             sleep 10
@@ -86,33 +120,20 @@ server:
             fi
 
             if [ "$SEALED" = "true" ]; then
-              echo "Vault is sealed! Attempting auto-unseal via vault-active..."
-
-              SA_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-              AUTH_JSON=$(VAULT_ADDR="$ACTIVE_ADDR" vault write -format=json auth/kubernetes/login jwt="$SA_TOKEN" role="vault-unsealer" 2>/dev/null || true)
-              VAULT_TOKEN=$(printf '%s' "$AUTH_JSON" | sed -n 's/.*"client_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)
-              if [ -z "$VAULT_TOKEN" ]; then
-                echo "Failed to get Vault token. Active node might be down."
-                continue
-              fi
-
-              KEY1=$(VAULT_ADDR="$ACTIVE_ADDR" VAULT_TOKEN="$VAULT_TOKEN" vault kv get -field=key1 secret/unseal-keys 2>/dev/null || true)
-              KEY2=$(VAULT_ADDR="$ACTIVE_ADDR" VAULT_TOKEN="$VAULT_TOKEN" vault kv get -field=key2 secret/unseal-keys 2>/dev/null || true)
-              KEY3=$(VAULT_ADDR="$ACTIVE_ADDR" VAULT_TOKEN="$VAULT_TOKEN" vault kv get -field=key3 secret/unseal-keys 2>/dev/null || true)
-              if [ -z "$KEY1" ] || [ -z "$KEY2" ] || [ -z "$KEY3" ]; then
-                echo "Failed to read keys from KV."
-                continue
-              fi
-
-              echo "Submitting unseal keys..."
-              VAULT_ADDR="$LOCAL_ADDR" vault operator unseal "$KEY1" >/dev/null 2>&1 || true
-              VAULT_ADDR="$LOCAL_ADDR" vault operator unseal "$KEY2" >/dev/null 2>&1 || true
-              VAULT_ADDR="$LOCAL_ADDR" vault operator unseal "$KEY3" >/dev/null 2>&1 || true
-
-              echo "Unseal commands submitted."
+              echo "Vault is sealed! Unsealing from mounted keys..."
+              for f in "$KEYS_DIR"/key1 "$KEYS_DIR"/key2 "$KEYS_DIR"/key3; do
+                if [ -f "$f" ]; then
+                  VAULT_ADDR="$LOCAL_ADDR" vault operator unseal "$(cat "$f")" >/dev/null 2>&1 || true
+                fi
+              done
+              echo "Unseal keys submitted."
               sleep 5
             fi
           done
+      volumeMounts:
+        - name: unseal-keys
+          mountPath: /vault/unseal-keys
+          readOnly: true
   standalone:
     enabled: false
   ha:


### PR DESCRIPTION
## Background

On 2026-07-15 Vault went down in a way the usual "unseal all 3 nodes" runbook could **not** fix. Node `shion-ubuntu-2505` rebooted while **all three vault pods were co-located on it**, so the entire raft cluster died at once with unclean-shutdown damage:

- `vault-0`: intact, only sealed (sole complete copy)
- `vault-1`: raft data lost (empty barrier)
- `vault-2`: raft BoltDB freelist corruption (`freepages` panic), crash-looping

Quorum was lost → unsealing all 3 could never elect a leader. And the auto-unseal sidecar read the unseal keys **from the active node**, so with no active node it could not bootstrap. Recovery required manual `peers.json` single-node surgery.

This addresses the two root fragilities (co-location, self-referential unseal) plus makes future recovery trivial.

## Changes

**軸1 — Cross-node spread** (`values.yaml`)
- `podAntiAffinity` → `requiredDuringScheduling` (hard): the 3 pods must land on 3 distinct nodes, so a single-node event never kills quorum.
- `nodeAffinity`: 2-node allowlist → **preferred** weighting over all nodes (strong amd64 first, OCI arm64 next, everything else as last-resort) so a pod is never `Pending`.
- Control-plane toleration so `instance-2024-1` is eligible.
- `longhorn-hdd-ha` is `dataLocality=disabled`, so pods attach their volumes from any node — spread is not storage-constrained.

**軸2 — File-based auto-unseal** (`values.yaml`)
- The `unseal-sidecar` now reads keys from a **mounted Secret** (`vault-unseal-keys`) instead of from `vault-active`. A pod can self-unseal **even when no node is active**, so a full simultaneous restart recovers unattended.
- `defaultMode: 0440` — verified live that the uid100/gid1000 sidecar can read the keys under the pod's `fsGroup=1000`.

**軸3 — Automated raft snapshots** (`raft-snapshot-cronjob.yaml`)
- CronJob saves a snapshot every 6h to a dedicated PVC (keeps 14). Turns a lost-quorum event into a `snapshot restore`.

**Docs** (`README.md`): HA/auto-unseal architecture, what auto-recovers, and the full lost-quorum `peers.json` runbook.

## Required manual steps (out-of-band, not in git — public repo)

1. ✅ **Done live already**: the `vault-unseal-keys` Secret (`key1`/`key2`/`key3`) is created in the `vault` namespace. Merging is safe — the new sidecar will mount it.
2. ⚠️ **Run once before the CronJob's first run** (needs an admin token; `generate-root` is 403 on this cluster):
   ```
   bash vault/scripts/setup-snapshot-role.sh
   ```

## Rollout note

ArgoCD rolls the StatefulSet one pod at a time (vault-2 → vault-1 → vault-0); each restarted pod moves to a distinct node, attaches remotely, and auto-unseals from the Secret. Quorum (2/3) is held throughout — no downtime expected. Do **not** hand-edit the live STS (selfHeal reverts); this all lands via git.

## Validation

- `kustomize build vault/` → 7 resources OK; kubeconform valid.
- `helm template` (chart 0.34.0) with new values → 13 resources, all kubeconform-valid; confirmed hard anti-affinity, preferred nodeAffinity, toleration, unseal-keys volume (mode 288/0440), sidecar readOnly mount all rendered.
- Live-tested the 0440 + fsGroup=1000 permission model: sidecar uid/gid reads all 3 keys.