### PR TITLE
nc-chotatsu: enforce GitHub login at the Envoy Gateway edge

### DIFF
--- a/keycloak-operator/kustomization.yaml
+++ b/keycloak-operator/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - user-realm.yaml
   - ynufes-tech-realm.yaml
   - harbor-realm.yaml
+  - nc-chotatsu-realm.yaml

--- a/keycloak-operator/nc-chotatsu-realm.yaml
+++ b/keycloak-operator/nc-chotatsu-realm.yaml
@@ -1,75 +1,24 @@
-# =============================================================================
-# Keycloak Realm Import: nc-chotatsu
-# =============================================================================
+# Keycloak realm gating https://nc-chotatsu.shion1305.com behind GitHub login,
+# enforced at the Envoy edge (nc-press-chotatsu/securitypolicy.yaml). GitHub is
+# OAuth2-only (no id_token), so Keycloak brokers it into OIDC for Envoy.
+# Mirrors the ynufes-tech (GitHub IdP) + zot (gateway OIDC) patterns. No
+# groups/mappers: the app reads no claim; Envoy enforces "authenticated" and
+# the first-broker-login flow (step 3) enforces "which users".
 #
-# This file is reconciled by the Keycloak Operator (KeycloakRealmImport CRD).
-# It declares the `nc-chotatsu` realm, whose sole purpose is to gate
-# https://nc-chotatsu.shion1305.com behind a GitHub login enforced at the
-# Envoy Gateway edge (nc-press-chotatsu/securitypolicy.yaml).
-#
-# Flow:
-#   Browser -> Envoy Gateway SecurityPolicy.oidc (Authorization Code flow
-#              against THIS realm, using the `nc-chotatsu` confidential client)
-#           -> Keycloak `github` Identity Provider (OAuth2) -> GitHub
-#   Envoy mints its own encrypted session cookie from the resulting id_token;
-#   the frontend upstream sees only authenticated requests. The app does not
-#   consume any claim, so this realm carries NO groups/roles/mappers -- Envoy
-#   enforces "authenticated" and the first-broker-login flow (manual step #3)
-#   enforces "which GitHub users are allowed".
-#
-# Why Keycloak at all: GitHub is pure OAuth2 (no OIDC discovery, no id_token),
-# so Envoy's SecurityPolicy.oidc cannot target GitHub directly. Keycloak
-# brokers GitHub into a real OIDC provider. This mirrors the ynufes-tech realm
-# (GitHub IdP) + the zot realm (Envoy-enforced gateway OIDC).
-#
-# Authentication policy:
-#   - Self-registration disabled.
-#   - GitHub OAuth IdP is the ONLY login path (local password form suppressed
-#     by binding the Browser flow to "Identity Provider Redirector").
-#   - Only pre-provisioned GitHub users may log in: the first-broker-login
-#     flow is configured to NOT auto-create accounts (manual step #3).
-#
-# -----------------------------------------------------------------------------
-# Manual post-import steps (one-time, after first successful sync):
-# -----------------------------------------------------------------------------
-# 1. Configure the `github` Identity Provider in the Keycloak admin UI:
-#      https://keycloak.shion1305.com -> realm `nc-chotatsu` -> Identity
-#      Providers -> github -> set "Client ID" and "Client Secret" from a
-#      GitHub OAuth App whose Authorization callback URL is:
-#        https://keycloak.shion1305.com/realms/nc-chotatsu/broker/github/endpoint
-#      (Register a new OAuth App, or reuse an existing one and add this
-#      callback URL.) The `PLACEHOLDER_REPLACE_AFTER_REALM_IMPORT` values below
-#      are the literal strings the operator imports; the admin overwrites them
-#      via the UI, and subsequent reconciles do NOT re-apply the placeholders.
-#
-# 2. Bind the Browser authentication flow to "Identity Provider Redirector"
-#    pinned to alias `github`, so users skip the password form and go straight
-#    to GitHub:
-#      Authentication -> Flows -> Browser -> add "Identity Provider Redirector"
-#      execution at the top, Required, config `Default Identity Provider =
-#      github`. Bind that copied flow as the realm's Browser flow.
-#    (Done via the UI: the v2alpha1 CRD's authenticationFlows shape is brittle.)
-#
-# 3. Restrict login to specific GitHub users. Copy the "first broker login"
-#    flow and set its "Create User If Unique" execution to DISABLED, then bind
-#    the copy as the realm's First Broker Login flow. With auto-provisioning
-#    off, an unknown GitHub identity cannot create an account and is denied;
-#    only users you pre-create are admitted.
-#      Users -> Add user (set the email matching the GitHub account, so
-#      "Handle Existing Account" links the GitHub identity by email at first
-#      login; trustEmail is set on the IdP below). Repeat per allowed user.
-#    WITHOUT this step ANY GitHub account could log in -- do not skip it.
-#
-# 4. Retrieve the auto-generated client secret for the `nc-chotatsu` client:
-#      Clients -> nc-chotatsu -> Credentials -> "Client secret"
-#    and persist it into Vault so ESO can sync the `nc-chotatsu-oidc-credentials`
-#    Secret in the `nc-press-chotatsu` namespace (see
-#    nc-press-chotatsu/oidc-external-secret.yaml):
+# Manual post-import steps (KeycloakRealmImport reconciles once; GitHub secrets
+# are UI-managed):
+# 1. github IdP: set Client ID/Secret from a GitHub OAuth App whose callback is
+#    https://keycloak.shion1305.com/realms/nc-chotatsu/broker/github/endpoint
+# 2. Bind the Browser flow to "Identity Provider Redirector" (default: github)
+#    so login skips the password form. (v2alpha1 CRD can't express flows.)
+# 3. Restrict to specific users: copy the "first broker login" flow, set
+#    "Create User If Unique" -> DISABLED, bind it. Pre-create allowed users
+#    (email matching their GitHub account; trustEmail links by email). WITHOUT
+#    this, ANY GitHub account can log in.
+# 4. Persist the generated `nc-chotatsu` client secret to Vault (mount/role
+#    already exist from the DB secret):
 #      vault kv put nc-press-chotatsu/oidc-credentials \
 #        client_id=nc-chotatsu client_secret=<value>
-#    (The `nc-press-chotatsu` KV mount + `eso-nc-press-chotatsu` Vault role
-#    already exist for the DB secret; no new Vault policy is required.)
-# =============================================================================
 apiVersion: k8s.keycloak.org/v2alpha1
 kind: KeycloakRealmImport
 metadata:
@@ -85,29 +34,17 @@ spec:
     loginWithEmailAllowed: true
     rememberMe: false
 
-    # `external` = HTTPS required for any non-loopback request. Cluster-internal
-    # plaintext still satisfies this because Envoy terminates TLS and the
-    # Keycloak CR's xforwarded proxy config trusts X-Forwarded-Proto: https.
     sslRequired: external
 
-    # -------------------------------------------------------------------------
-    # Clients
-    # -------------------------------------------------------------------------
-    # nc-chotatsu: confidential client driven by Envoy Gateway's
-    # SecurityPolicy.oidc (nc-press-chotatsu/securitypolicy.yaml). Envoy runs
-    # the Authorization Code flow and mints its own session cookie; the
-    # frontend needs no claim, so no protocolMappers are declared. The default
-    # `openid`/`profile`/`email` client scopes Keycloak auto-seeds are enough.
-    #
-    # The redirect_uri Envoy uses is `https://<host>/oauth2/callback` (its
-    # default for the OAuth2 filter).
+    # Confidential client for Envoy's SecurityPolicy.oidc. No protocolMappers:
+    # the frontend reads no claim, and the auto-seeded openid/profile/email
+    # scopes suffice. Secret is Keycloak-generated on first import (placeholder
+    # not re-applied); do NOT commit the real value.
     clients:
       - clientId: nc-chotatsu
         protocol: openid-connect
         publicClient: false
         clientAuthenticatorType: client-secret
-        # Keycloak generates the real value on first import and never re-applies
-        # this placeholder. Do NOT commit the actual secret.
         secret: PLACEHOLDER_REPLACE_AFTER_REALM_IMPORT
         standardFlowEnabled: true
         directAccessGrantsEnabled: false
@@ -117,13 +54,8 @@ spec:
         webOrigins:
           - https://nc-chotatsu.shion1305.com
 
-    # -------------------------------------------------------------------------
-    # Identity Providers
-    # -------------------------------------------------------------------------
-    # GitHub OAuth IdP. The admin overwrites clientId / clientSecret in the
-    # Keycloak UI post-import (manual step 1). The GitHub OAuth App's callback
-    # URL must point at:
-    #   https://keycloak.shion1305.com/realms/nc-chotatsu/broker/github/endpoint
+    # GitHub OAuth IdP. clientId/clientSecret set via the admin UI post-import
+    # (step 1); not re-applied on reconcile, so do NOT commit real creds.
     identityProviders:
       - alias: github
         providerId: github
@@ -133,9 +65,6 @@ spec:
         trustEmail: true
         firstBrokerLoginFlowAlias: "first broker login"
         config:
-          # Placeholders replaced via the admin UI after initial import; the
-          # realm import does NOT re-apply them on subsequent reconciles, so it
-          # is safe to let Keycloak own the values. Do NOT commit real creds.
           clientId: PLACEHOLDER_REPLACE_AFTER_REALM_IMPORT
           clientSecret: PLACEHOLDER_REPLACE_AFTER_REALM_IMPORT
           defaultScope: "user:email"

--- a/keycloak-operator/nc-chotatsu-realm.yaml
+++ b/keycloak-operator/nc-chotatsu-realm.yaml
@@ -1,0 +1,142 @@
+# =============================================================================
+# Keycloak Realm Import: nc-chotatsu
+# =============================================================================
+#
+# This file is reconciled by the Keycloak Operator (KeycloakRealmImport CRD).
+# It declares the `nc-chotatsu` realm, whose sole purpose is to gate
+# https://nc-chotatsu.shion1305.com behind a GitHub login enforced at the
+# Envoy Gateway edge (nc-press-chotatsu/securitypolicy.yaml).
+#
+# Flow:
+#   Browser -> Envoy Gateway SecurityPolicy.oidc (Authorization Code flow
+#              against THIS realm, using the `nc-chotatsu` confidential client)
+#           -> Keycloak `github` Identity Provider (OAuth2) -> GitHub
+#   Envoy mints its own encrypted session cookie from the resulting id_token;
+#   the frontend upstream sees only authenticated requests. The app does not
+#   consume any claim, so this realm carries NO groups/roles/mappers -- Envoy
+#   enforces "authenticated" and the first-broker-login flow (manual step #3)
+#   enforces "which GitHub users are allowed".
+#
+# Why Keycloak at all: GitHub is pure OAuth2 (no OIDC discovery, no id_token),
+# so Envoy's SecurityPolicy.oidc cannot target GitHub directly. Keycloak
+# brokers GitHub into a real OIDC provider. This mirrors the ynufes-tech realm
+# (GitHub IdP) + the zot realm (Envoy-enforced gateway OIDC).
+#
+# Authentication policy:
+#   - Self-registration disabled.
+#   - GitHub OAuth IdP is the ONLY login path (local password form suppressed
+#     by binding the Browser flow to "Identity Provider Redirector").
+#   - Only pre-provisioned GitHub users may log in: the first-broker-login
+#     flow is configured to NOT auto-create accounts (manual step #3).
+#
+# -----------------------------------------------------------------------------
+# Manual post-import steps (one-time, after first successful sync):
+# -----------------------------------------------------------------------------
+# 1. Configure the `github` Identity Provider in the Keycloak admin UI:
+#      https://keycloak.shion1305.com -> realm `nc-chotatsu` -> Identity
+#      Providers -> github -> set "Client ID" and "Client Secret" from a
+#      GitHub OAuth App whose Authorization callback URL is:
+#        https://keycloak.shion1305.com/realms/nc-chotatsu/broker/github/endpoint
+#      (Register a new OAuth App, or reuse an existing one and add this
+#      callback URL.) The `PLACEHOLDER_REPLACE_AFTER_REALM_IMPORT` values below
+#      are the literal strings the operator imports; the admin overwrites them
+#      via the UI, and subsequent reconciles do NOT re-apply the placeholders.
+#
+# 2. Bind the Browser authentication flow to "Identity Provider Redirector"
+#    pinned to alias `github`, so users skip the password form and go straight
+#    to GitHub:
+#      Authentication -> Flows -> Browser -> add "Identity Provider Redirector"
+#      execution at the top, Required, config `Default Identity Provider =
+#      github`. Bind that copied flow as the realm's Browser flow.
+#    (Done via the UI: the v2alpha1 CRD's authenticationFlows shape is brittle.)
+#
+# 3. Restrict login to specific GitHub users. Copy the "first broker login"
+#    flow and set its "Create User If Unique" execution to DISABLED, then bind
+#    the copy as the realm's First Broker Login flow. With auto-provisioning
+#    off, an unknown GitHub identity cannot create an account and is denied;
+#    only users you pre-create are admitted.
+#      Users -> Add user (set the email matching the GitHub account, so
+#      "Handle Existing Account" links the GitHub identity by email at first
+#      login; trustEmail is set on the IdP below). Repeat per allowed user.
+#    WITHOUT this step ANY GitHub account could log in -- do not skip it.
+#
+# 4. Retrieve the auto-generated client secret for the `nc-chotatsu` client:
+#      Clients -> nc-chotatsu -> Credentials -> "Client secret"
+#    and persist it into Vault so ESO can sync the `nc-chotatsu-oidc-credentials`
+#    Secret in the `nc-press-chotatsu` namespace (see
+#    nc-press-chotatsu/oidc-external-secret.yaml):
+#      vault kv put nc-press-chotatsu/oidc-credentials \
+#        client_id=nc-chotatsu client_secret=<value>
+#    (The `nc-press-chotatsu` KV mount + `eso-nc-press-chotatsu` Vault role
+#    already exist for the DB secret; no new Vault policy is required.)
+# =============================================================================
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: KeycloakRealmImport
+metadata:
+  name: nc-chotatsu
+  namespace: keycloak
+spec:
+  keycloakCRName: keycloak
+  realm:
+    realm: nc-chotatsu
+    enabled: true
+    registrationAllowed: false
+    resetPasswordAllowed: false
+    loginWithEmailAllowed: true
+    rememberMe: false
+
+    # `external` = HTTPS required for any non-loopback request. Cluster-internal
+    # plaintext still satisfies this because Envoy terminates TLS and the
+    # Keycloak CR's xforwarded proxy config trusts X-Forwarded-Proto: https.
+    sslRequired: external
+
+    # -------------------------------------------------------------------------
+    # Clients
+    # -------------------------------------------------------------------------
+    # nc-chotatsu: confidential client driven by Envoy Gateway's
+    # SecurityPolicy.oidc (nc-press-chotatsu/securitypolicy.yaml). Envoy runs
+    # the Authorization Code flow and mints its own session cookie; the
+    # frontend needs no claim, so no protocolMappers are declared. The default
+    # `openid`/`profile`/`email` client scopes Keycloak auto-seeds are enough.
+    #
+    # The redirect_uri Envoy uses is `https://<host>/oauth2/callback` (its
+    # default for the OAuth2 filter).
+    clients:
+      - clientId: nc-chotatsu
+        protocol: openid-connect
+        publicClient: false
+        clientAuthenticatorType: client-secret
+        # Keycloak generates the real value on first import and never re-applies
+        # this placeholder. Do NOT commit the actual secret.
+        secret: PLACEHOLDER_REPLACE_AFTER_REALM_IMPORT
+        standardFlowEnabled: true
+        directAccessGrantsEnabled: false
+        serviceAccountsEnabled: false
+        redirectUris:
+          - https://nc-chotatsu.shion1305.com/oauth2/callback
+        webOrigins:
+          - https://nc-chotatsu.shion1305.com
+
+    # -------------------------------------------------------------------------
+    # Identity Providers
+    # -------------------------------------------------------------------------
+    # GitHub OAuth IdP. The admin overwrites clientId / clientSecret in the
+    # Keycloak UI post-import (manual step 1). The GitHub OAuth App's callback
+    # URL must point at:
+    #   https://keycloak.shion1305.com/realms/nc-chotatsu/broker/github/endpoint
+    identityProviders:
+      - alias: github
+        providerId: github
+        enabled: true
+        storeToken: false
+        addReadTokenRoleOnCreate: false
+        trustEmail: true
+        firstBrokerLoginFlowAlias: "first broker login"
+        config:
+          # Placeholders replaced via the admin UI after initial import; the
+          # realm import does NOT re-apply them on subsequent reconciles, so it
+          # is safe to let Keycloak own the values. Do NOT commit real creds.
+          clientId: PLACEHOLDER_REPLACE_AFTER_REALM_IMPORT
+          clientSecret: PLACEHOLDER_REPLACE_AFTER_REALM_IMPORT
+          defaultScope: "user:email"
+          syncMode: IMPORT

--- a/nc-press-chotatsu/kustomization.yaml
+++ b/nc-press-chotatsu/kustomization.yaml
@@ -7,8 +7,10 @@ resources:
   - db-external-secret.yaml
   - vault-secret-store.yaml
   - external-secret.yaml
+  - oidc-external-secret.yaml
   - frontend-deployment.yaml
   - frontend-service.yaml
   - reference-grant.yaml
   - httproute-external.yaml
+  - securitypolicy.yaml
   - crawler-cronjob.yaml

--- a/nc-press-chotatsu/oidc-external-secret.yaml
+++ b/nc-press-chotatsu/oidc-external-secret.yaml
@@ -1,15 +1,6 @@
-# Envoy Gateway's SecurityPolicy.oidc reads two keys from a Kubernetes Secret:
-#
-#   - `client-id`     (referenced via `oidc.clientIDRef`)
-#   - `client-secret` (referenced via `oidc.clientSecret`)
-#
-# Both come from the Keycloak `nc-chotatsu` confidential client in the
-# `nc-chotatsu` realm (see keycloak-operator/nc-chotatsu-realm.yaml). The
-# literal client-id `nc-chotatsu` MUST match the Keycloak client name.
-#
-# Reuses the existing `vault` SecretStore in this namespace (KV mount
-# `nc-press-chotatsu`, role `eso-nc-press-chotatsu`; see vault-secret-store.yaml).
-# Populate the source after the realm import (see realm manual step #4):
+# Projects the Keycloak `nc-chotatsu` client creds into the client-id/
+# client-secret keys Envoy's SecurityPolicy.oidc reads. Reuses this namespace's
+# `vault` SecretStore; populate the source after realm import (realm step 4):
 #   vault kv put nc-press-chotatsu/oidc-credentials \
 #     client_id=nc-chotatsu client_secret=<value>
 apiVersion: external-secrets.io/v1

--- a/nc-press-chotatsu/oidc-external-secret.yaml
+++ b/nc-press-chotatsu/oidc-external-secret.yaml
@@ -1,0 +1,41 @@
+# Envoy Gateway's SecurityPolicy.oidc reads two keys from a Kubernetes Secret:
+#
+#   - `client-id`     (referenced via `oidc.clientIDRef`)
+#   - `client-secret` (referenced via `oidc.clientSecret`)
+#
+# Both come from the Keycloak `nc-chotatsu` confidential client in the
+# `nc-chotatsu` realm (see keycloak-operator/nc-chotatsu-realm.yaml). The
+# literal client-id `nc-chotatsu` MUST match the Keycloak client name.
+#
+# Reuses the existing `vault` SecretStore in this namespace (KV mount
+# `nc-press-chotatsu`, role `eso-nc-press-chotatsu`; see vault-secret-store.yaml).
+# Populate the source after the realm import (see realm manual step #4):
+#   vault kv put nc-press-chotatsu/oidc-credentials \
+#     client_id=nc-chotatsu client_secret=<value>
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: nc-chotatsu-oidc-credentials
+  namespace: nc-press-chotatsu
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  target:
+    name: nc-chotatsu-oidc-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          managed-by: external-secrets
+  data:
+    - secretKey: client-id
+      remoteRef:
+        key: oidc-credentials
+        property: client_id
+    - secretKey: client-secret
+      remoteRef:
+        key: oidc-credentials
+        property: client_secret

--- a/nc-press-chotatsu/securitypolicy.yaml
+++ b/nc-press-chotatsu/securitypolicy.yaml
@@ -1,0 +1,42 @@
+# Envoy Gateway-managed OIDC for nc-chotatsu.shion1305.com.
+#
+# Attaches to the nc-press-chotatsu-external HTTPRoute so every request to the
+# frontend must first complete an Authorization Code flow against the
+# `nc-chotatsu` Keycloak realm (keycloak-operator/nc-chotatsu-realm.yaml),
+# which itself brokers login to GitHub. Envoy validates the id_token, mints an
+# encrypted session cookie, and only then forwards the request upstream.
+#
+# The whole origin is one Next.js frontend (no Docker Registry v2 / machine
+# clients), so unlike zot this needs no path split and no denyRedirect: a
+# missing/expired cookie 302s the top-level navigation to Keycloak, which is
+# exactly the desired behaviour.
+#
+# `redirectURL` must be this exact string -- Envoy validates the OIDC
+# redirect_uri against it and will not substitute the request :authority.
+# `/oauth2/callback` is Envoy's default OAuth2 callback path and is also
+# listed as a redirectUri on the Keycloak client.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: nc-chotatsu-oidc
+  namespace: nc-press-chotatsu
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: nc-press-chotatsu-external
+  oidc:
+    provider:
+      issuer: https://keycloak.shion1305.com/realms/nc-chotatsu
+    clientIDRef:
+      name: nc-chotatsu-oidc-credentials
+    clientSecret:
+      name: nc-chotatsu-oidc-credentials
+    redirectURL: https://nc-chotatsu.shion1305.com/oauth2/callback
+    logoutPath: /logout
+    # `openid` is auto-added by Envoy; the frontend needs no other claim.
+    scopes:
+      - email
+      - profile
+    cookieConfig:
+      sameSite: Lax

--- a/nc-press-chotatsu/securitypolicy.yaml
+++ b/nc-press-chotatsu/securitypolicy.yaml
@@ -1,20 +1,10 @@
-# Envoy Gateway-managed OIDC for nc-chotatsu.shion1305.com.
+# Gateway-enforced OIDC for nc-chotatsu.shion1305.com: every request completes
+# an Authorization Code flow against the `nc-chotatsu` Keycloak realm (which
+# brokers GitHub login) before reaching the frontend.
 #
-# Attaches to the nc-press-chotatsu-external HTTPRoute so every request to the
-# frontend must first complete an Authorization Code flow against the
-# `nc-chotatsu` Keycloak realm (keycloak-operator/nc-chotatsu-realm.yaml),
-# which itself brokers login to GitHub. Envoy validates the id_token, mints an
-# encrypted session cookie, and only then forwards the request upstream.
-#
-# The whole origin is one Next.js frontend (no Docker Registry v2 / machine
-# clients), so unlike zot this needs no path split and no denyRedirect: a
-# missing/expired cookie 302s the top-level navigation to Keycloak, which is
-# exactly the desired behaviour.
-#
-# `redirectURL` must be this exact string -- Envoy validates the OIDC
-# redirect_uri against it and will not substitute the request :authority.
-# `/oauth2/callback` is Envoy's default OAuth2 callback path and is also
-# listed as a redirectUri on the Keycloak client.
+# `/oauth2/callback` and `/logout` are handled by Envoy, not proxied upstream,
+# so the auth-unaware frontend needs no changes. `redirectURL` must match the
+# Keycloak client redirectUri exactly.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:


### PR DESCRIPTION
## What

Gate `https://nc-chotatsu.shion1305.com` behind a **GitHub login enforced at the Envoy Gateway edge**. The `nc-press-chotatsu` frontend is currently published with no auth; this puts a mandatory login in front of it **without touching the app** — the frontend stays auth-unaware.

## Why Keycloak (not GitHub directly)

Envoy Gateway's `SecurityPolicy.oidc` is an **OIDC** filter — it needs the token endpoint to return an `id_token`. GitHub is pure **OAuth2**: no OIDC discovery, no `id_token`, so Envoy cannot target GitHub directly. A dedicated `nc-chotatsu` Keycloak realm brokers GitHub into a real OIDC provider.

This reuses two patterns already proven in the cluster:

| Half of the flow | Existing precedent |
|---|---|
| Gateway-side OIDC enforcement | `zot/securitypolicy.yaml` (Envoy `SecurityPolicy.oidc` → Keycloak) |
| GitHub OAuth broker | `keycloak-operator/ynufes-tech-realm.yaml` (`github` Identity Provider) |

```
Browser → Envoy Gateway (SecurityPolicy.oidc)
        → Keycloak realm nc-chotatsu (issues id_token)
        → GitHub IdP (OAuth2) → GitHub
```

## The frontend needs no callback route

A natural question: *"the frontend has no auth, so `/oauth2/callback` doesn't exist."* That's fine — **`/oauth2/callback` and `/logout` are handled by Envoy, not proxied upstream.** Envoy intercepts the callback, exchanges the auth code for tokens, mints its own encrypted session cookie, then 302s to the originally-requested page. The request never reaches the frontend, so the app requires zero changes (same as zot's UI, which also has no callback handler). The only constraint is that these two paths not collide with real frontend routes — they don't.

Note the three distinct "callback"-shaped URLs, none of which the frontend implements:
- GitHub OAuth App callback → `keycloak.shion1305.com/realms/nc-chotatsu/broker/github/endpoint` (handled by **Keycloak**)
- Envoy `redirectURL` → `nc-chotatsu.shion1305.com/oauth2/callback` (handled by **Envoy**, not proxied)
- Keycloak client `redirectUri` (same URL) → just a validation allowlist entry in **Keycloak**

## Changes

- **`keycloak-operator/nc-chotatsu-realm.yaml`** — dedicated realm mirroring `ynufes-tech`: GitHub IdP + one confidential client. No groups/roles/mappers (the app consumes no claim; Envoy enforces "authenticated").
- **`nc-press-chotatsu/oidc-external-secret.yaml`** — Vault → Secret via the existing `vault` SecretStore in the namespace, producing the `client-id`/`client-secret` keys Envoy reads.
- **`nc-press-chotatsu/securitypolicy.yaml`** — `SecurityPolicy.oidc` attached to the existing `nc-press-chotatsu-external` HTTPRoute.
- kustomization updates in both dirs.

No NetworkPolicy / ReferenceGrant changes needed (the Gateway is already in the cluster-wide infra allow list).

## Authorization scope

**Specific GitHub users only.** Self-registration is disabled and the first-broker-login flow is configured to not auto-create accounts, so only pre-provisioned users are admitted.

## ⚠️ Manual post-merge steps (cannot be GitOps-managed)

`KeycloakRealmImport` reconciles only on first import, and GitHub OAuth secrets are UI-managed. Full steps are in the realm file header; summary:

1. Create a **GitHub OAuth App** with callback `https://keycloak.shion1305.com/realms/nc-chotatsu/broker/github/endpoint`; set its client-id/secret on the `github` IdP in the Keycloak UI.
2. Bind the Browser flow to **Identity Provider Redirector** (default `github`) to skip the password form.
3. **Enforce specific-users-only:** copy the *first broker login* flow, set **"Create User If Unique" → DISABLED**, bind it. Pre-create allowed users (email matching their GitHub account; `trustEmail` links them). **Skipping this lets any GitHub account in.**
4. Write the Keycloak-generated client secret to Vault: `vault kv put nc-press-chotatsu/oidc-credentials client_id=nc-chotatsu client_secret=<value>`.

## Validation

- `kustomize build` passes for both `nc-press-chotatsu/` and `keycloak-operator/`.
- render-validate: new CRDs (`SecurityPolicy`, `KeycloakRealmImport`) are skipped via `-ignore-missing-schemas` (existing behaviour).