### PR TITLE
Improve proxpi concurrency and health checks

### DIFF
--- a/pypi-cache/deployment.yaml
+++ b/pypi-cache/deployment.yaml
@@ -60,7 +60,10 @@ spec:
             - --bind
             - 0.0.0.0:5000
             - --threads
-            - "4"
+            # proxpi's Gunicorn process has one worker by default.  Downloads
+            # are I/O-bound, so allow enough concurrent requests from several
+            # GARM runners that package transfers cannot starve /health.
+            - "16"
             - --no-control-socket
           env:
             # Persist the wheel cache on the PVC (default is an ephemeral /tmp dir).
@@ -91,12 +94,16 @@ spec:
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
           livenessProbe:
             httpGet:
               path: /health
               port: http
             initialDelaySeconds: 10
             periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
## Summary

- increase proxpi Gunicorn threads from 4 to 16
- allow transient request queueing before the readiness probe withdraws the only Service endpoint
- require sustained health failures before liveness restarts proxpi

## Root cause

Several concurrent GARM runner downloads saturated proxpi's four Gunicorn threads. The `/health` endpoint then timed out under the same burst, causing Kubernetes to remove or restart the single proxpi Pod. Clients observed intermittent connection failures and retries lasting minutes.

## Validation

- reproduced health timeouts and connection refusal with an eight-download load test from a GARM-labelled runner Pod
- observed matching readiness/liveness timeouts and proxpi restarts in the live cluster
- `kubectl kustomize pypi-cache | kubectl apply --dry-run=server -f -`
- `git diff --check`