### PR TITLE
envoy-gateway: run envoy-default as a DaemonSet on OCI + home node

### DIFF
--- a/envoy-gateway/envoyproxy.yaml
+++ b/envoy-gateway/envoyproxy.yaml
@@ -1,22 +1,30 @@
-# Data plane configuration for the Envoy Gateway controller.
-# Pins the Envoy proxy Pod to instance-k8s-proxy and binds 80/443 via hostNetwork
-# so that *.i.shion1305.com (10.130.5.21) and test-external.shion1305.com (141.147.189.36)
-# resolve directly to this node.
+# Data plane for the `envoy-default` GatewayClass.
 #
-# hostNetwork / dnsPolicy are not native EnvoyProxy CRD fields (removed in v1.0.0,
-# tracking issue: envoyproxy/gateway#1928). The official escape hatch is the
-# StrategicMerge patch on envoyDeployment. NET_BIND_SERVICE is required because
-# the data plane binds privileged ports (<1024).
+# Runs as a DaemonSet (NOT a Deployment) on the OCI node instance-k8s-proxy AND
+# the amd64 home node shion-ubuntu-2505, binding 80/443/5432 via hostNetwork so
+# each node's own IP terminates the merged listeners:
+#   - instance-k8s-proxy: 141.147.189.36 (public) + 10.130.5.21 (internal VIP)
+#   - shion-ubuntu-2505:  10.130.5.66 — so *.i.shion1305.com can terminate on a
+#     home node (point the *.i DNS record here) instead of hairpinning out to
+#     the OCI gateway and back over WireGuard.
 #
-# --base-id 1 is required because Cilium runs its own Envoy (cilium-envoy) on
-# the same node in the host network namespace. Both default to base-id=0 and
-# fight over the shared-memory domain socket (errno=98 EADDRINUSE on bind).
+# A DaemonSet is the correct primitive for a one-per-node hostNetwork proxy: its
+# rolling update replaces a node's pod in place (delete-then-create), so the new
+# pod never contends with the old for the privileged :443 bind. A Deployment
+# with maxSurge deadlocks here — the surge pod cannot bind :443 while the old
+# pod still holds it.
+#
+# hostNetwork / dnsPolicy are not native EnvoyProxy CRD fields (removed in
+# v1.0.0, tracking issue: envoyproxy/gateway#1928). The official escape hatch is
+# the StrategicMerge patch below. --base-id 1 is required because Cilium runs
+# its own Envoy (cilium-envoy) in the host network namespace on every node; both
+# default to base-id=0 and fight over the shared-memory domain socket
+# (errno=98 EADDRINUSE on bind).
 #
 # useListenerPortAsContainerPort: true makes Envoy bind the Gateway's listener
-# ports directly (80/443) instead of the default 10000-offset ports
-# (10080/10443). Required for hostNetwork because there is no Service in front
-# to remap ports. NET_BIND_SERVICE (set in the patch below) lets the unprivileged
-# envoy user bind ports <1024.
+# ports directly (80/443) instead of the default 10000-offset ports. Required
+# for hostNetwork because there is no Service in front to remap ports.
+# NET_BIND_SERVICE lets the envoy user bind ports <1024.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyProxy
 metadata:
@@ -31,11 +39,18 @@ spec:
     type: Kubernetes
     kubernetes:
       useListenerPortAsContainerPort: true
-      envoyDeployment:
-        replicas: 1
+      envoyDaemonSet:
         pod:
-          nodeSelector:
-            kubernetes.io/hostname: instance-k8s-proxy
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: kubernetes.io/hostname
+                        operator: In
+                        values:
+                          - instance-k8s-proxy
+                          - shion-ubuntu-2505
           tolerations:
             - key: node-role.kubernetes.io/control-plane
               operator: Exists


### PR DESCRIPTION
## What

Convert the `envoy-default` data plane from a single-replica **Deployment**
(pinned to `instance-k8s-proxy`) into a **DaemonSet** spanning
`instance-k8s-proxy` **and** the amd64 home node `shion-ubuntu-2505`
(`10.130.5.66`).

This is the first step of killing the `*.i.shion1305.com` hairpin: once a
home node also terminates the internal listeners, `*.i` DNS can point at
`10.130.5.66` so in-cluster traffic stays on the home network instead of
detouring `home → OCI (10.130.5.21) → home` over WireGuard.

**DNS is not touched in this PR** — pointing the `*.i` record at `.66` is a
separate manual follow-up (Cloudflare wildcard A record).

## Why a DaemonSet (and why now)

The existing single-replica Deployment has a **structural rollout deadlock**:
its update strategy is `maxSurge: 25%`, so on any template change the surge
pod is created *before* the old pod is removed — but under `hostNetwork` the
new pod cannot bind the privileged `:443` while the old pod still holds it.
This left a pod **Pending for 7 days** (`FailedScheduling … didn't have free
ports`).

A DaemonSet is the correct primitive for a one-per-node hostNetwork proxy: its
rolling update replaces a node's pod **in place** (delete-then-create), so the
new pod never contends with the old for `:443`. Switching also cleans up the
stuck rollout and is the natural on-ramp to a fully distributed internal
gateway later.

## Blast radius / cutover

`envoy-default` is a **merged** GatewayClass serving both the public
`*.shion1305.com` (`141.147.189.36`) and the internal `*.i.shion1305.com`
(`10.130.5.21`). When ArgoCD syncs this, Envoy Gateway replaces the Deployment
with a DaemonSet, so the **OCI pod is recreated once → a brief (~tens of
seconds) `:443` blip for all public apps**. This is accepted and should be
merged in a low-traffic window.

The `shion-ubuntu-2505` pod is brand new (nothing resolves to `.66` yet), so it
adds no traffic risk until the DNS flip.

## Validation

- `kubectl kustomize envoy-gateway` renders cleanly (14 resources).
- Server-side-apply dry-run as the ArgoCD field manager (`--server-side
  --field-manager=argocd-controller --force-conflicts --dry-run=server`)
  succeeds — confirming ArgoCD's `ServerSideApply=true` cleanly swaps the
  mutually-exclusive `envoyDeployment` → `envoyDaemonSet` field (plain
  client-side `kubectl apply` cannot, and is expected to fail).

## Post-merge checklist (manual)

1. Both DaemonSet pods `Ready`; `shion-ubuntu-2505` binds `:80/:443/:5432`
   (a port clash would only CrashLoop the `.66` pod — no prod impact, `.66`
   is unused until step 3).
2. `curl --resolve harbor.i.shion1305.com:443:10.130.5.66 …/v2/` for harbor /
   **zot (pull must not 401)** / longhorn terminates correctly via `.66`.
3. Flip Cloudflare wildcard A `*.i.shion1305.com`: `10.130.5.21 → 10.130.5.66`.
4. Confirm pod / `crictl pull` (kubelet) / a home device all reach `.66`, not
   `.21`.

## Rollback

- DaemonSet misbehaves → revert this commit (ArgoCD swaps back to the
  Deployment).
- `.66` serves wrong after the DNS flip → point Cloudflare `*.i` back to
  `.21` (its routes are unchanged, so it recovers immediately).

## Follow-ups (not in this PR)

- `*.i → .66` DNS flip (above).
- `.66`/`2505` is now the single internal terminator (SPOF). HA / full
  node-local termination is the DaemonSet-on-all-nodes design tracked
  separately.
