### PR TITLE
envoy-gateway: add shion-ubuntu-2605 to the internal DaemonSet

### DIFF
--- a/envoy-gateway/envoyproxy.yaml
+++ b/envoy-gateway/envoyproxy.yaml
@@ -1,12 +1,13 @@
 # Data plane for the `envoy-default` GatewayClass.
 #
 # Runs as a DaemonSet (NOT a Deployment) on the OCI node instance-k8s-proxy AND
-# the amd64 home node shion-ubuntu-2505, binding 80/443/5432 via hostNetwork so
-# each node's own IP terminates the merged listeners:
+# the amd64 home nodes shion-ubuntu-2505 / shion-ubuntu-2605, binding 80/443/5432
+# via hostNetwork so each node's own IP terminates the merged listeners:
 #   - instance-k8s-proxy: 141.147.189.36 (public) + 10.130.5.21 (internal VIP)
-#   - shion-ubuntu-2505:  10.130.5.66 — so *.i.shion1305.com can terminate on a
-#     home node (point the *.i DNS record here) instead of hairpinning out to
-#     the OCI gateway and back over WireGuard.
+#   - shion-ubuntu-2505:  10.130.5.66  \  *.i.shion1305.com DNS round-robins across
+#   - shion-ubuntu-2605:  10.130.5.67  /  these two home nodes, so it terminates
+#     on a home node instead of hairpinning out to the OCI gateway and back over
+#     WireGuard.
 #
 # A DaemonSet is the correct primitive for a one-per-node hostNetwork proxy: its
 # rolling update replaces a node's pod in place (delete-then-create), so the new
@@ -51,6 +52,7 @@ spec:
                         values:
                           - instance-k8s-proxy
                           - shion-ubuntu-2505
+                          - shion-ubuntu-2605
           tolerations:
             - key: node-role.kubernetes.io/control-plane
               operator: Exists


### PR DESCRIPTION
Follow-up to #568. `*.i.shion1305.com` now DNS round-robins across `10.130.5.66` (shion-ubuntu-2505) and `10.130.5.67` (shion-ubuntu-2605), so both home nodes must run the envoy-default data plane. This adds `shion-ubuntu-2605` to the DaemonSet node affinity.

**Urgency:** `.67` is already in DNS but has no Envoy yet, so ~half of `*.i` resolutions currently fail until this syncs. Merge promptly, or temporarily drop DNS back to `.66` only.

**Cutover:** adding a node changes the DaemonSet pod template → a one-at-a-time rolling replace of all pods (incl. one more brief `:443` blip on the OCI pod). maxUnavailable:1 keeps it to one node at a time.

**HA caveat:** DNS round-robin is not health-aware — a dead node stays in rotation and clients fail over only after a TCP timeout. A health-checked floating VIP (keepalived/VRRP on the home LAN, or a WireGuard /32 advertised from the healthy node) is the robust HA follow-up.