### PR TITLE
envoy-gateway: give the edge gateway a preempting PriorityClass

### DIFF
--- a/envoy-gateway/envoyproxy.yaml
+++ b/envoy-gateway/envoyproxy.yaml
@@ -42,6 +42,10 @@ spec:
       useListenerPortAsContainerPort: true
       envoyDaemonSet:
         pod:
+          # Must stay schedulable on the over-committed OCI node — preempts
+          # app-critical pods (e.g. argocd-controller) rather than losing its
+          # :443 bind. See priorityclass.yaml.
+          priorityClassName: envoy-gateway-critical
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:

--- a/envoy-gateway/kustomization.yaml
+++ b/envoy-gateway/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - priorityclass.yaml
   - envoyproxy.yaml
   - gatewayclass.yaml
   - certificates.yaml

--- a/envoy-gateway/priorityclass.yaml
+++ b/envoy-gateway/priorityclass.yaml
@@ -1,0 +1,19 @@
+# The edge gateway (envoy-default) fronts ALL public and internal traffic, so it
+# must stay schedulable even on the small, over-committed OCI node. This priority
+# sits ABOVE the app-critical tier (argocd-critical / postgres-operator-pod =
+# 1e6) so the gateway can preempt those to reclaim its slot, but BELOW the
+# storage/system tiers (longhorn-critical 1e9, system-* 2e9), which it must never
+# evict.
+#
+# Context: a rolling update once rescheduled the OCI gateway pod, which then
+# could not fit because argocd-application-controller (argocd-critical, ~1.5 CPU)
+# had claimed the node's CPU — taking down all public ingress. With priority 0
+# the gateway had no preemption victims.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: envoy-gateway-critical
+value: 2000000
+preemptionPolicy: PreemptLowerPriority
+globalDefault: false
+description: "Edge gateway data plane — must stay schedulable; preempts app-critical, never storage/system."


### PR DESCRIPTION
## Why (incident)
During the #569 DaemonSet rollout, the OCI gateway pod was rescheduled and could not fit on the 2-vCPU `instance-k8s-proxy` node — `argocd-application-controller` (`argocd-critical` = 1e6, ~1.5 CPU) held the node's CPU. At **priority 0 the gateway had no preemption victims**, so **all public ingress (`141.147.189.36`) went down** until the controller was manually evicted (and OCI cordoned) to free CPU.

## Fix
- New `PriorityClass envoy-gateway-critical` = **2,000,000**.
- Assigned to the `envoy-default` DaemonSet via `envoyDaemonSet.pod.priorityClassName`.

Tier placement: **above** app-critical (`argocd-critical` / `postgres-operator-pod` = 1e6) so the gateway can preempt them to reclaim its `:443` slot; **below** `longhorn-critical` (1e9) and `system-*` (2e9) so it never evicts storage or system components.

## Post-merge (manual)
1. ArgoCD sync → DaemonSet rolls all 3 pods (priorityClassName is a template change; one node at a time). OCI now has room (controller moved to 2605), so the roll is low-risk.
2. Verify pods carry `priority: 2000000`.
3. **Uncordon `instance-k8s-proxy`** — the cordon was the emergency mitigation; the PriorityClass replaces the need for it.

## Validation
- `kubectl kustomize envoy-gateway` → 15 resources incl. the PriorityClass.
- `kubectl apply --dry-run=server` on the PriorityClass succeeds.