### PR TITLE
Stabilize proxpi under concurrent CI downloads

### DIFF
--- a/pypi-cache/deployment.yaml
+++ b/pypi-cache/deployment.yaml
@@ -92,16 +92,21 @@ spec:
             - name: tmp
               mountPath: /tmp
           readinessProbe:
-            httpGet:
-              path: /health
+            # Do not send the only endpoint NotReady merely because all
+            # Gunicorn threads are busy serving large wheels. A TCP probe
+            # verifies that proxpi is accepting connections without competing
+            # with package downloads for an application worker.
+            tcpSocket:
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 6
           livenessProbe:
-            httpGet:
-              path: /health
+            # The HTTP /health handler uses the same single Gunicorn worker as
+            # downloads. Under a CI thundering herd it can time out even though
+            # proxpi is healthy, causing kubelet to kill the only cache Pod.
+            tcpSocket:
               port: http
             initialDelaySeconds: 10
             periodSeconds: 30
@@ -112,7 +117,7 @@ spec:
               cpu: 50m
               memory: 128Mi
             limits:
-              memory: 512Mi
+              memory: 1Gi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true


### PR DESCRIPTION
## Summary

- switch proxpi readiness and liveness probes from HTTP `/health` checks to TCP socket checks
- raise the proxpi memory limit from 512 MiB to 1 GiB

## Root cause

proxpi runs one Gunicorn worker with multiple threads because its in-memory cache management is not synchronized across processes. During concurrent CI dependency downloads, all application threads can be occupied serving large wheels. The HTTP `/health` endpoint uses the same worker and timed out under this load.

Kubernetes recorded hundreds of readiness failures and dozens of liveness failures. The liveness failure sent SIGTERM to the only proxpi Pod; its previous container then exited with code 137 after the termination grace period. CI clients consequently received TCP connection errors while the Pod restarted.

TCP probes verify that Gunicorn is still accepting connections without consuming an application thread. The increased memory limit also adds headroom during concurrent cold-cache downloads.

The urllib3 `Connection pool is full` warning is not treated as the failure cause: requests still proceed, but connections beyond the ten-entry keep-alive pool are closed instead of retained for reuse.

## Impact

The in-cluster PyPI cache should remain available during CI download bursts instead of removing its sole endpoint or restarting it because `/health` is queued behind package transfers.

## Validation

- `git diff --check`
- `./scripts/render-validate.sh` — all applications rendered and validated

After deployment, the existing eight-way pypi-cache benchmark should be rerun to confirm that connection failures and Pod restarts no longer occur.
