### PR TITLE
Limit proxpi worker threads to upstream pool capacity

### DIFF
--- a/pypi-cache/deployment.yaml
+++ b/pypi-cache/deployment.yaml
@@ -64,9 +64,10 @@ spec:
             - 0.0.0.0:5000
             - --threads
             # proxpi's Gunicorn process has one worker by default.  Downloads
-            # are I/O-bound, so allow enough concurrent requests from several
-            # GARM runners that package transfers cannot starve /health.
-            - "16"
+            # are I/O-bound, but cap request concurrency at requests/urllib3's
+            # default per-host keep-alive pool size to avoid excessive upstream
+            # connection churn during cold-cache bursts.
+            - "10"
             - --no-control-socket
           env:
             # Cache dir on the node-local cache volume.


### PR DESCRIPTION
## Summary

- reduce proxpi's Gunicorn thread count from 16 to 10
- document why request concurrency is capped at the default Requests/urllib3 per-host keep-alive pool size

## Why

proxpi shares one Requests session for upstream package downloads. Requests retains at most ten reusable connections per host by default. With sixteen Gunicorn threads, cold-cache bursts repeatedly produced `Connection pool is full, discarding connection` warnings and unnecessary upstream connection churn.

Limiting Gunicorn to ten request threads aligns application-level concurrency more closely with that default pool capacity. This does not turn the pool into a hard concurrency limit, but reduces avoidable connection creation while retaining enough concurrency for the existing CI workload.

## Impact

Cold-cache bursts should create fewer disposable connections to `files.pythonhosted.org`. Peak proxpi request concurrency is reduced from sixteen to ten, so the existing eight-way benchmark should be used to watch for any throughput regression.

## Validation

- `git diff --check`
- `./scripts/render-validate.sh` — all applications rendered and validated
