### PR TITLE
grafana: give Prometheus a 90m startup budget for WAL replay

### DIFF
--- a/grafana/values.yaml
+++ b/grafana/values.yaml
@@ -8,6 +8,13 @@ global:
 prometheus:
   enabled: true
   prometheusSpec:
+    # Give the startup probe enough runway for a full WAL replay. On this
+    # HDD-backed longhorn volume replay can take far longer than the operator's
+    # default 15m budget (esp. under I/O contention), and a mid-replay probe
+    # kill restarts the replay from scratch — a loop that never lets the head
+    # compact, so the WAL only grows and each attempt gets slower. 90m breaks
+    # that spiral; a healthy start still passes in seconds.
+    maximumStartupDurationSeconds: 5400
     # Retention settings
     retention: 999d # High value to allow size to be the primary retention factor
     retentionSize: 340GB # About ~85% of total capacity for safety margin


### PR DESCRIPTION
## What

Add `maximumStartupDurationSeconds: 5400` to the primary Prometheus (`grafana` ns).

## Why — incident

The primary Prometheus (`prometheus-kube-prometheus-stack-prometheus-0`) was CrashLoopBackOff, logging:

```
level=ERROR msg="Fatal error" err="opening storage failed: lock DB directory: resource temporarily unavailable"
```

That lock error was a **symptom, not the cause**:

1. On this HDD-backed `longhorn-hdd` volume a full WAL replay (**5607 segments**) took far longer than the operator's **default 15m startup-probe budget** (failureThreshold 60 × period 15s). It was especially slow while the **Harbor GC was saturating the same node's (`shion-ubuntu-2605`) Longhorn I/O** (~17–33s/segment).
2. The startup probe SIGKILLed Prometheus mid-replay → each restart replays from scratch → the head never compacts → the WAL only grows → every attempt gets slower. A death spiral.
3. `resource temporarily unavailable` = a freshly-killed instance still holding the TSDB directory flock when the next one started.

It later **self-recovered** at 00:59 UTC once the Harbor GC finished and I/O contention eased (the same 5607-segment replay then completed in ~70s). `maximumStartupDurationSeconds=5400` (90m) makes that recovery deterministic instead of luck — a replay can always finish once, after which the head compacts and subsequent starts are fast. A healthy start still passes in seconds, so there is no downside.

## Related out-of-band change (not in this PR)

The Prometheus PVC was expanded **200Gi → 400Gi** live. `storageSpec` has declared `400Gi` since Feb (commit 05521d4), but the operator does not resize existing PVCs (StatefulSet `volumeClaimTemplate` is immutable), so it was stuck at 200Gi and `retentionSize: 340GB` could never cap usage before the disk filled. Longhorn online-expanded the PVC (replica on `shion-ubuntu-2505`, ample free space).

## Test

- `maximumStartupDurationSeconds` is a valid `PrometheusSpec` field (operator v0.92.1); render-validate covers the Application.