### PR TITLE
Add Harbor push input

### DIFF
--- a/.github/actions/harbor-build-push/README.md
+++ b/.github/actions/harbor-build-push/README.md
@@ -56,6 +56,7 @@ jobs:
       - uses: Shion1305/k8s-GitOps/.github/actions/harbor-build-push@main
         with:
           image: harbor.shion1305.com/shion1305/<your-app>
+          push: "true"
 ```
 
 That's it. The action handles everything else.
@@ -79,6 +80,7 @@ That's it. The action handles everything else.
 | `context`    | `.`                     | Docker build context path (relative to repo root). |
 | `dockerfile` | `Dockerfile`            | Dockerfile path relative to `context`. |
 | `platforms`  | `linux/amd64,linux/arm64` | Comma-separated `buildx` target platforms. |
+| `push`       | `"true"`                 | Whether to publish the built image. Set to `"false"` for validation-only builds; no Harbor credentials are fetched in that case. For a workflow that handles PRs and pushes, use `${{ github.event_name != 'pull_request' }}`. |
 | `sign`       | `"true"`                | Whether to keyless-sign with cosign (Fulcio + Rekor). Defaulted ON because mixing signed and unsigned images is a supply-chain footgun. Pass the string `"false"` to disable. |
 | `tag`        | `${{ github.sha }}`     | Primary tag pushed. Defaults to the calling repo's commit SHA so every build is uniquely addressable. |
 | `extra-tags` | `""`                    | Comma-separated additional tags applied to the same digest (e.g. `latest,v1.2.3`). Empty by default — opt in explicitly if you want a moving `latest`. |
@@ -110,6 +112,7 @@ jobs:
         uses: Shion1305/k8s-GitOps/.github/actions/harbor-build-push@main
         with:
           image: harbor.shion1305.com/shion1305/myapp
+          push: "true"
 
   deploy:
     needs: build-push

--- a/.github/actions/harbor-build-push/action.yml
+++ b/.github/actions/harbor-build-push/action.yml
@@ -88,6 +88,13 @@ inputs:
       arm64 — matches the `harbor/demo` baseline.
     required: false
     default: linux/amd64,linux/arm64
+  push:
+    description: >-
+      Whether to push the built image to Harbor. Defaults to "true" for
+      backwards compatibility. Workflows that run for pull requests should
+      pass "false" for validation-only builds.
+    required: false
+    default: "true"
   sign:
     description: >-
       Whether to keyless-sign the pushed image with cosign. Off-by-default
@@ -153,7 +160,8 @@ runs:
     # JSON as if it were an image layer. So: signing only here; SBOM is
     # produced by Harbor's own Trivy via the GENERATE SBOM action on the
     # image artifact.
-    - uses: sigstore/cosign-installer@v4.1.2
+    - if: inputs.push == 'true'
+      uses: sigstore/cosign-installer@v4.1.2
       with:
         cosign-release: v2.4.1
 
@@ -161,14 +169,16 @@ runs:
     # $GITHUB_ENV (not the installer step's `env:`) so it persists for
     # the later push step — aqua-proxy re-reads it at every crane
     # invocation to dispatch to the pinned package version.
-    - name: Export AQUA_GLOBAL_CONFIG
+    - if: inputs.push == 'true'
+      name: Export AQUA_GLOBAL_CONFIG
       shell: bash
       run: echo "AQUA_GLOBAL_CONFIG=${{ github.action_path }}/aqua.yaml" >> "$GITHUB_ENV"
 
     # aqua_opts `-l -a`: `-a` triggers installAll which actually consumes
     # AQUA_GLOBAL_CONFIG; `-l` alone (the installer default) only links
     # aqua-proxy and skips package installs.
-    - uses: aquaproj/aqua-installer@v4.0.5
+    - if: inputs.push == 'true'
+      uses: aquaproj/aqua-installer@v4.0.5
       with:
         aqua_version: v2.59.1
         aqua_opts: -l -a
@@ -180,7 +190,8 @@ runs:
     # default audience (`https://github.com/<owner>`) which matches the
     # Vault role's `bound_audiences` — overriding `jwtGithubAudience` here
     # would cause a 400 at the Vault side.
-    - name: Fetch Harbor robot credentials from Vault
+    - if: inputs.push == 'true'
+      name: Fetch Harbor robot credentials from Vault
       uses: hashicorp/vault-action@v4
       with:
         url: https://vault.shion1305.com
@@ -196,7 +207,8 @@ runs:
     # (Vault returns 404 → action fails loud, but a renamed field would
     # bind an empty string to the env var and crane would 401 with a
     # generic message). Failing fast here surfaces the real cause.
-    - name: Verify robot credentials are non-empty
+    - if: inputs.push == 'true'
+      name: Verify robot credentials are non-empty
       shell: bash
       run: |
         set -euo pipefail
@@ -226,7 +238,8 @@ runs:
           --output type=oci,dest=/tmp/image.tar \
           "${CONTEXT}"
 
-    - name: Push and sign
+    - if: inputs.push == 'true'
+      name: Push and sign
       id: push
       shell: bash
       env:

--- a/.github/workflows/build-garm-runner-image.yaml
+++ b/.github/workflows/build-garm-runner-image.yaml
@@ -26,4 +26,5 @@ jobs:
         with:
           image: harbor.shion1305.com/shion1305/garm-runner
           context: ./github-actions-runner/runner-image
+          push: ${{ github.event_name != 'pull_request' }}
           extra-tags: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && '2.335.1-ubuntu24.04,latest' || '' }}

--- a/.github/workflows/demo-push-to-harbor.yaml
+++ b/.github/workflows/demo-push-to-harbor.yaml
@@ -51,13 +51,9 @@ jobs:
         with:
           image: harbor.shion1305.com/shion1305/demo
           context: ./harbor/demo
-          # Validate PR builds without publishing; push for main and manual
-          # runs.
-          push: ${{ github.event_name != 'pull_request' }}
           # The demo intentionally moves `latest` so a `docker pull
           # harbor.shion1305.com/shion1305/demo` always pulls the most recent
           # smoke-test image. Production callers should NOT pass extra-tags
           # unless they have a deliberate reason — the action defaults
           # extra-tags to empty for that reason.
-          extra-tags: >-
-            ${{ github.event_name != 'pull_request' && 'latest' || '' }}
+          extra-tags: latest

--- a/.github/workflows/demo-push-to-harbor.yaml
+++ b/.github/workflows/demo-push-to-harbor.yaml
@@ -51,9 +51,13 @@ jobs:
         with:
           image: harbor.shion1305.com/shion1305/demo
           context: ./harbor/demo
+          # Validate PR builds without publishing; push for main and manual
+          # runs.
+          push: ${{ github.event_name != 'pull_request' }}
           # The demo intentionally moves `latest` so a `docker pull
           # harbor.shion1305.com/shion1305/demo` always pulls the most recent
           # smoke-test image. Production callers should NOT pass extra-tags
           # unless they have a deliberate reason — the action defaults
           # extra-tags to empty for that reason.
-          extra-tags: latest
+          extra-tags: >-
+            ${{ github.event_name != 'pull_request' && 'latest' || '' }}


### PR DESCRIPTION
## Summary

- add a `push` input to the Harbor build composite action, defaulting to `true`
- skip Harbor credential retrieval and publishing setup when `push` is `false`
- set PR builds in the Harbor demo and GARM runner workflows to build without publishing

## Why

The composite action previously always pushed images, so pull-request runs could publish artifacts unintentionally.

## Validation

- `yamllint` on the changed action and workflows
- `actionlint .github/workflows/build-garm-runner-image.yaml`
- `git diff --check`
