### PR TITLE
Pin Harbor workloads and raise priority

### DIFF
--- a/docs/priority-classes.md
+++ b/docs/priority-classes.md
@@ -1,0 +1,61 @@
+# Kubernetes Pod Priority Design
+
+## Purpose
+
+Pod priority is the cluster's last-resort admission control when a node cannot
+fit every requested Pod. It determines scheduler ordering and which lower
+priority Pods may be preempted; it does not reserve CPU or memory, guarantee
+availability, or prevent kubelet eviction under memory pressure. Requests,
+limits, replica placement, disruption budgets, and node capacity remain the
+primary availability controls.
+
+Every workload remains at Kubernetes' default priority (`0`) unless losing it
+would block cluster management, traffic ingress, storage, or the image supply
+chain. `globalDefault` is always `false`: a new workload must opt in explicitly
+after its failure mode is understood.
+
+## Tiers
+
+| Priority | Class | Intended workloads | Preemption rule |
+| --- | --- | --- | --- |
+| `2000001000` | Kubernetes `system-node-critical` | Node-local Kubernetes and required node-health agents | Never assign to ordinary application workloads. |
+| `2000000000` | Kubernetes `system-cluster-critical` | Cluster-wide Kubernetes control-plane add-ons | Never assign to ordinary application workloads. |
+| `1000000000` | `longhorn-critical` | Storage control/data plane | Must stay above ingress and applications. |
+| `2000000` | `envoy-gateway-critical` | Edge Gateway data plane | May preempt app-critical Pods; must not preempt storage or system Pods. |
+| `1000000` | `argocd-critical`, `harbor-critical`, `postgres-operator-pod` | GitOps control plane and essential shared application services | May preempt default-priority workloads, but not other Pods in this tier. |
+| `100000` | `github-readme-stats-app` | Existing repository-specific service tier | May preempt default-priority workloads, but not app-critical Pods. |
+| `0` | no class | Normal applications, batch work, and optional services | May be preempted by any tier above. |
+
+Classes at the same numeric value are deliberately peers. Kubernetes only
+preempts lower values, so `harbor-critical` cannot displace Argo CD or another
+app-critical workload. This keeps image distribution important without letting
+it outrank the cluster components that reconcile or expose it.
+
+## Harbor
+
+Harbor is assigned `harbor-critical` (`1000000`) for its chart-rendered core,
+portal, registry, jobservice, nginx, exporter, Redis, and Trivy Pods, as well
+as the post-sync OIDC configuration Job. Registry availability is required for
+image pulls and deployments, so Harbor must be schedulable ahead of
+default-priority workloads. It remains below Envoy Gateway, storage, and
+Kubernetes system work because those layers are prerequisites for reaching or
+running Harbor.
+
+All Harbor workloads are additionally pinned to `shion-ubuntu-2505`. Priority
+only decides contention on that node; it cannot move a Pod elsewhere when the
+node selector has made it ineligible.
+
+## Operating rules
+
+1. Prefer the existing tier whose failure impact matches the workload. Create a
+   new class only when a distinct preemption relationship is necessary.
+2. Do not use `system-*` classes for application workloads.
+3. Specify `priorityClassName` in the Helm values or Pod template, and commit
+   the corresponding `PriorityClass` manifest in the owning application.
+4. Give every elevated workload realistic resource requests. A high priority
+   Pod without requests can still cause resource pressure and kubelet eviction.
+5. When adding or changing a class, update this document, identify its
+   preemption victims, and test that the owning renderer emits the class name.
+6. During an incident, inspect `kubectl get events` for `Preempted` and
+   scheduling failures. Raise capacity or reduce requests before escalating
+   more workloads into a higher tier.

--- a/harbor/configure-oidc-job.yaml
+++ b/harbor/configure-oidc-job.yaml
@@ -75,6 +75,9 @@ spec:
       serviceAccountName: harbor-configure-oidc
       automountServiceAccountToken: false
       restartPolicy: OnFailure
+      priorityClassName: harbor-critical
+      nodeSelector:
+        kubernetes.io/hostname: shion-ubuntu-2505
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532

--- a/harbor/kustomization.yaml
+++ b/harbor/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - priorityclass.yaml
   - secret-store.yaml
   - external-secret.yaml
   - db-secret-store.yaml

--- a/harbor/priorityclass.yaml
+++ b/harbor/priorityclass.yaml
@@ -1,0 +1,8 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: harbor-critical
+value: 1000000
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: "Harbor registry control and data-plane workloads. Matches the app-critical tier so image distribution remains schedulable under node pressure."

--- a/harbor/values.yaml
+++ b/harbor/values.yaml
@@ -117,8 +117,10 @@ database:
 redis:
   type: internal
   internal:
+    priorityClassName: harbor-critical
     nodeSelector:
       kubernetes.io/arch: amd64
+      kubernetes.io/hostname: shion-ubuntu-2505
 
 # -----------------------------------------------------------------------------
 # Harbor admin password — sourced from Vault via ESO
@@ -152,8 +154,10 @@ internalTLS:
 # (HTTPRoutes target harbor-core/harbor-portal Services directly). Pin it to
 # amd64 because goharbor/nginx-photon is also amd64-only.
 nginx:
+  priorityClassName: harbor-critical
   nodeSelector:
     kubernetes.io/arch: amd64
+    kubernetes.io/hostname: shion-ubuntu-2505
 
 # -----------------------------------------------------------------------------
 # core / portal / registry / jobservice / trivy / exporter
@@ -174,7 +178,8 @@ nginx:
 # built-in `admin` user and PUTs the full payload. The Job is idempotent and
 # re-runs on every ArgoCD sync.
 #
-# nodeSelector on every component pins Harbor to amd64 nodes. Upstream
+# nodeSelector on every component pins Harbor to shion-ubuntu-2505 (an amd64
+# node). Upstream
 # (goharbor/harbor) only publishes linux/amd64 images on Docker Hub — see
 # https://github.com/goharbor/harbor/issues/22491 (target/2.15.0, still open).
 # Without this, pods scheduled to arm64 nodes CrashLoopBackOff with
@@ -182,13 +187,17 @@ nginx:
 core:
   replicas: 1
   existingSecret: harbor-core-secret
+  priorityClassName: harbor-critical
   nodeSelector:
     kubernetes.io/arch: amd64
+    kubernetes.io/hostname: shion-ubuntu-2505
 
 portal:
   replicas: 1
+  priorityClassName: harbor-critical
   nodeSelector:
     kubernetes.io/arch: amd64
+    kubernetes.io/hostname: shion-ubuntu-2505
 
 registry:
   # If you see absolute http:// (not https://) URLs in pushed manifests'
@@ -196,23 +205,31 @@ registry:
   # lets the gateway resolve scheme/host. Not currently needed because Harbor
   # uses externalURL for those, and externalURL is https://.
   relativeurls: false
+  priorityClassName: harbor-critical
   nodeSelector:
     kubernetes.io/arch: amd64
+    kubernetes.io/hostname: shion-ubuntu-2505
 
 jobservice:
+  priorityClassName: harbor-critical
   nodeSelector:
     kubernetes.io/arch: amd64
+    kubernetes.io/hostname: shion-ubuntu-2505
 
 trivy:
   enabled: true
   replicas: 1
+  priorityClassName: harbor-critical
   nodeSelector:
     kubernetes.io/arch: amd64
+    kubernetes.io/hostname: shion-ubuntu-2505
 
 exporter:
   enabled: true
+  priorityClassName: harbor-critical
   nodeSelector:
     kubernetes.io/arch: amd64
+    kubernetes.io/hostname: shion-ubuntu-2505
 
 # -----------------------------------------------------------------------------
 # metrics — Prometheus /metrics + ServiceMonitor (kube-prometheus-stack)


### PR DESCRIPTION
## Summary

- Pin every Harbor chart workload and the OIDC configuration Job to `shion-ubuntu-2505`.
- Add the `harbor-critical` PriorityClass at the existing app-critical tier (`1000000`) and apply it to Harbor.
- Document the cluster Pod Priority tiers, preemption model, and operating rules.

## Why

Harbor is the cluster image registry. Under contention on its designated node, its control and data-plane Pods must schedule ahead of default-priority workloads, while remaining below Gateway, storage, and Kubernetes system tiers.

## Impact

Argo CD will reconcile Harbor workloads with both the hostname selector and `harbor-critical` priority. The class is a peer of Argo CD and PostgreSQL app-critical workloads, so it cannot preempt them.

## Validation

- Rendered Harbor chart `1.19.1` with `helm template` and verified `harbor-critical` plus `shion-ubuntu-2505` on all 8 chart workloads.
- Built the Harbor Kustomization and verified the PriorityClass and OIDC Job fields.
- Ran `git diff --check`.
