### PR TITLE
fix(garm): stop runner pods starving on one node's image-pull queue

### DIFF
--- a/github-actions-runner/Justfile
+++ b/github-actions-runner/Justfile
@@ -9,6 +9,11 @@ credentials := env_var_or_default("GARM_CREDENTIALS_NAME", "shion1305-github-app
 runner_image := env_var_or_default("GARM_RUNNER_IMAGE", "harbor.shion1305.com/shion1305/garm-runner:2.335.1-ubuntu24.04")
 max_runners := env_var_or_default("GARM_MAX_RUNNERS", "6")
 min_idle_runners := env_var_or_default("GARM_MIN_IDLE_RUNNERS", "0")
+# Ceilings enforced by `just pool-audit`. Deliberately looser than the creation
+# defaults above so a busy repo may keep one warm runner, but not a standing
+# fleet. See "Pool Sizing" in README.md.
+audit_max_runners := env_var_or_default("GARM_AUDIT_MAX_RUNNERS", "8")
+audit_min_idle_runners := env_var_or_default("GARM_AUDIT_MIN_IDLE_RUNNERS", "1")
 amd_provider := env_var_or_default("GARM_AMD_PROVIDER", "kubernetes_amd64")
 arm_provider := env_var_or_default("GARM_ARM_PROVIDER", "kubernetes_arm64")
 amd_tags := env_var_or_default("GARM_AMD_TAGS", "shion1305-amd")
@@ -138,3 +143,14 @@ repo-list:
 # Show runner pools.
 pool-list:
   kubectl exec -n {{namespace}} {{deployment}} -- /opt/garm/bin/garm-cli pool list
+
+# Flag pools whose sizing drifted above the safe defaults. Pools are configured
+# imperatively via garm-cli, so nothing in Git prevents drift -- run this after
+# any manual pool tuning. See "Pool Sizing" in README.md.
+pool-audit:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  kubectl exec -n {{namespace}} {{deployment}} -- \
+    /opt/garm/bin/garm-cli pool list --format json \
+    | MAX_OK='{{audit_max_runners}}' IDLE_OK='{{audit_min_idle_runners}}' \
+      ./scripts/pool-audit.py

--- a/github-actions-runner/README.md
+++ b/github-actions-runner/README.md
@@ -129,6 +129,38 @@ or:
 runs-on: shion1305-arm
 ```
 
+## Pool Sizing
+
+Pools are configured **imperatively** through `garm-cli`, so nothing in this
+repository prevents their sizing from drifting. `just pool-audit` reports pools
+that exceed the safe ceilings (`max_runners <= 8`, `min_idle_runners <= 1`) and
+exits non-zero, which makes it usable as a check.
+
+Keep `min_idle_runners` at 0, or at most 1 for a repository with continuous CI
+traffic. **Idle runners are not free.** Every idle runner is a *fresh pod* whose
+image must be pulled and unpacked before the runner can register, and:
+
+- `imagePullPolicy: Always` (set in `configmap.yaml`) means each cold start goes
+  back to Harbor rather than reusing a cached layer.
+- kubelet pulls images **one at a time per node** (`serializeImagePulls` defaults
+  to true), so N idle runners become N serialized pulls on whichever node the
+  scheduler picked.
+- The scheduler's `ImageLocality` score actively concentrates runners on the node
+  that already cached the image. `topologySpreadConstraints` in `configmap.yaml`
+  counteracts that, but it is a soft constraint and only spreads so far.
+
+The cost is therefore `min_idle_runners x image_size` of pull-and-unpack work
+per node, repeated every time a runner is consumed and replaced. For a pool on a
+multi-gigabyte image that is enough to saturate a node's disk.
+
+### Pools on large or mutable images
+
+`Shion1305/crypto-auto-trading` (amd64) does not use the shared
+`garm-runner` image; it uses its own ~1.2 GB `crypto-auto-trading-ci:latest`.
+For pools like this, prefer a pinned tag over `:latest` where possible, and keep
+`min_idle_runners` at 0-1. See the incident note under
+[Runners stuck in ContainerCreating](#runners-stuck-in-containercreating).
+
 ## Observability
 
 GARM exposes Prometheus metrics on `garm-server:9997/metrics`. The `[metrics]`
@@ -150,6 +182,103 @@ Prometheus, Envoy, nodes, and runner-pods to port 9997).
 Key metric families: `garm_health`, `garm_runner_status`, `garm_job_status`,
 `garm_pool_*`, `garm_runner_operations_total`, `garm_github_operations_total` /
 `garm_github_errors_total`, `garm_github_rate_limit_*`, `garm_webhook_received`.
+
+## Troubleshooting
+
+### Runners stuck in ContainerCreating
+
+Symptom: many `garm-*` pods sit in `ContainerCreating` for 5-15 minutes, pods
+that are deleted linger in `Terminating`, and unrelated workloads scheduled to
+the same node are slow to start too.
+
+This is almost always **image-pull starvation on one node**, not a GARM fault.
+Confirm before changing anything:
+
+```bash
+# 1. Is the pod just waiting on its image? Compare the two numbers -- a large
+#    "including waiting" with a small actual pull time means queue starvation.
+kubectl describe pod -n github-actions-runner-pods <pod> | tail -20
+# -> Successfully pulled image "..." in 619ms (10m13s including waiting)
+
+# 2. Is the node I/O-bound? `full` is the share of time ALL tasks were stalled.
+kubectl get --raw "/api/v1/nodes/<node>/proxy/stats/summary" \
+  | jq '.node.io.psi.full, .node.cpu.psi.full'
+
+# 3. How slow are that node's pulls, compared with a healthy node?
+kubectl get --raw "/api/v1/nodes/<node>/proxy/metrics" \
+  | grep 'runtime_operations_duration_seconds_.*pull_image'
+# sum/count is the average seconds per pull.
+
+# 4. Which pools are oversized?
+just pool-audit
+```
+
+A healthy node averages a couple of seconds per pull with I/O pressure in the
+single digits. Tens of seconds per pull with `io.psi.full` above ~50% means the
+node's container filesystem is the bottleneck, and every pod scheduled there —
+runner or not — pays for it.
+
+Recovery, in order:
+
+1. `just pool-audit`, then shrink any oversized pool:
+   `just cli pool update <id> --max-runners 6 --min-idle-runners 1`.
+2. Delete the runners that never registered. Only ever delete instances whose
+   `runner_status` is `pending`; `active` ones may be executing a job:
+   `just cli runner list --format json` then
+   `just cli runner delete <name> -f`.
+3. Let the node drain. Teardown is itself I/O work, so `Terminating` pods clear
+   slowly while pressure is still high.
+
+**2026-07-29 incident.** The `crypto-auto-trading` amd64 pool had drifted to
+`min_idle_runners: 8` / `max_runners: 20` on the ~1.2 GB
+`crypto-auto-trading-ci:latest` image. All of those pods landed on
+`shion-ubuntu-2605`, whose write-saturated root SSD (see below) sustains only
+~25 MB/s and left the node I/O-stalled ~75% of the time; pulls there averaged
+~50 s versus ~1.5 s on `shion-ubuntu-2505`, a 33x gap on identical images.
+Runners could not register inside the 20-minute bootstrap
+timeout, so GARM reaped and recreated them, which fed the queue further.
+Collateral damage reached unrelated workloads — an `atc-executor` pod spent
+12m46s waiting on its image. Fixes: pool resized to 6/1, stuck runners deleted,
+and `topologySpreadConstraints` added to `configmap.yaml`.
+
+### Node-level follow-ups
+
+These are **not** applied by this repository because they need node-level
+changes, but they are what actually caps runner throughput.
+
+**`shion-ubuntu-2605`'s root SSD is write-saturated, not worn out.** Everything
+— `/`, `/var/lib/containerd`, `/var/lib/kubelet`, and therefore every runner's
+`emptyDir` workspace — lives on a single 2 TB `SPCC M.2 PCIe SSD`
+(`/dev/nvme0n1p2`). Its SMART data:
+
+| Metric | Value | Reading |
+| --- | --- | --- |
+| Percentage Used | 0% | not worn out |
+| Media/Data Integrity Errors | 0 | not failing |
+| Data Units Written | 39.6 TB over 1,177 power-on hours | ~34 GB/h sustained |
+| Controller Busy Time | 1,178 h of 1,177 h powered on | **never idle** |
+
+Controller busy time equalling power-on time is the finding. A DRAM-less
+consumer drive that never gets idle time cannot run garbage collection, so its
+fast-write cache stays exhausted and it degrades to its slowest write path.
+That shows up as ~25 MB/s of sustained writes and NVMe command timeouts in
+`dmesg`:
+
+```text
+nvme nvme0: I/O tag 30 (d01e) opcode 0x1 (I/O Cmd) QID 1 timeout, aborting req_op:WRITE(1) size:262144
+```
+
+A 30-second write timeout on an NVMe device stalls containerd, which is why pod
+teardown (`stop_podsandbox`) and pod startup fail together. Replacing the drive
+without reducing the write volume would only postpone this. Worth pursuing:
+give CI workspaces a separate volume rather than the node root disk, and check
+what else on this node writes continuously.
+
+**kubelet serializes image pulls.** `serializeImagePulls` defaults to true, so
+one slow pull blocks every other pod's start on that node — including pods that
+have nothing to do with CI. Setting `serializeImagePulls: false` with
+`maxParallelImagePulls: 3-5` in the node's kubelet config would contain the
+blast radius.
 
 ## Notes
 

--- a/github-actions-runner/configmap.yaml
+++ b/github-actions-runner/configmap.yaml
@@ -14,6 +14,18 @@ data:
       spec:
         nodeSelector:
           kubernetes.io/arch: amd64
+        # Spread runners across amd64 nodes. Without this the scheduler's
+        # ImageLocality score piles every runner onto whichever node already
+        # cached the (large) runner image, and that node's serialized image-pull
+        # queue becomes the bottleneck for the whole cluster. Soft
+        # (ScheduleAnyway) so a single reachable node still accepts runners.
+        topologySpreadConstraints:
+          - maxSkew: 2
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: ScheduleAnyway
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/managed-by: garm
         # Re-pull the mutable image tag on every cold start so runners pick up
         # image rebuilds (e.g. the buildx wiring) instead of a stale cached layer.
         containers:
@@ -36,6 +48,14 @@ data:
       spec:
         nodeSelector:
           kubernetes.io/arch: arm64
+        # See the amd64 template above for why runners are spread by hostname.
+        topologySpreadConstraints:
+          - maxSkew: 2
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: ScheduleAnyway
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/managed-by: garm
         # Re-pull the mutable image tag on every cold start so runners pick up
         # image rebuilds (e.g. the buildx wiring) instead of a stale cached layer.
         containers:

--- a/github-actions-runner/scripts/pool-audit.py
+++ b/github-actions-runner/scripts/pool-audit.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Flag GARM pools whose sizing drifted above the safe defaults.
+
+Reads `garm-cli pool list --format json` on stdin. Exits non-zero if any pool
+exceeds MAX_OK / IDLE_OK, so it can be used as a check.
+
+Pools are configured imperatively via garm-cli, so nothing in Git prevents
+drift. Oversized pools are not merely wasteful: every idle runner is a fresh
+pod that must pull and unpack the pool image before it can register, and
+kubelet pulls images one at a time per node by default. See "Pool Sizing" in
+../README.md.
+"""
+
+import json
+import os
+import sys
+
+
+def main() -> int:
+    max_ok = int(os.environ.get("MAX_OK", "6"))
+    idle_ok = int(os.environ.get("IDLE_OK", "0"))
+
+    pools = json.load(sys.stdin)
+    drifted = []
+
+    for pool in pools:
+        # garm omits min_idle_runners from its JSON when the value is 0.
+        max_runners = pool.get("max_runners", 0)
+        min_idle = pool.get("min_idle_runners", 0)
+
+        over = []
+        if max_runners > max_ok:
+            over.append(f"max_runners={max_runners} > {max_ok}")
+        if min_idle > idle_ok:
+            over.append(f"min_idle_runners={min_idle} > {idle_ok}")
+
+        if over:
+            drifted.append((pool, over))
+
+    for pool, over in drifted:
+        print(
+            f"DRIFT {pool['id'][:8]} {pool.get('repo_name')} "
+            f"({pool['os_arch']}): {', '.join(over)}"
+        )
+        print(f"      image={pool['image']}")
+
+    if not drifted:
+        print(f"OK: {len(pools)} pool(s) within limits "
+              f"(max_runners<={max_ok}, min_idle_runners<={idle_ok})")
+        return 0
+
+    print(f"\n{len(drifted)} of {len(pools)} pool(s) over limits. Fix with:")
+    print("  just cli pool update <id> --max-runners N --min-idle-runners N")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Symptom

`garm-*` runner pods sat in `ContainerCreating` for 5–15 minutes, deleted pods lingered in `Terminating`, and unrelated workloads on the same node were slow to start (an `atc-executor` pod spent **12m46s** waiting on its image).

## Root cause

Image-pull starvation on one node — not a GARM fault.

The `crypto-auto-trading` amd64 pool had drifted to `min_idle_runners: 8` / `max_runners: 20` on its ~1.2 GB `crypto-auto-trading-ci:latest` image (the Justfile defaults are 0 / 6; every other pool was still at defaults). Each idle runner is a *fresh pod* that must pull and unpack that image.

Three amplifiers turned that into a spiral:

1. **`imagePullPolicy: Always`** — no reuse across pod starts.
2. **kubelet pulls one image at a time per node** (`serializeImagePulls` defaults to true), so N idle runners become N serialized pulls.
3. **The scheduler's `ImageLocality` score** concentrated *every* runner onto `shion-ubuntu-2605`, the node that already cached the image.

Runners then missed the 20-minute bootstrap timeout, so GARM reaped and recreated them, feeding the queue further. GARM's `timeout_reaper` was also erroring out for that pool (`invalid status returned (pending_create)`), so its own safety net wasn't running.

Measured, comparing the two amd64 nodes on identical images:

| | `shion-ubuntu-2605` | `shion-ubuntu-2505` |
| --- | --- | --- |
| avg `pull_image` | **49.7 s** (3,950 pulls) | 1.5 s (604 pulls) |
| `io.psi.full` (avg300) | **74.5%** | 5.4% |

## Underlying constraint

`shion-ubuntu-2605`'s root SSD is **write-saturated, not worn out**. `/`, `/var/lib/containerd`, `/var/lib/kubelet` and every runner `emptyDir` share one 2 TB `SPCC M.2 PCIe SSD`. SMART: `Percentage Used: 0%`, `Media Errors: 0` — but **`Controller Busy Time` 1,178 h out of 1,177 h powered on**, with 39.6 TB written. A DRAM-less consumer drive that never idles cannot garbage-collect, so it degrades to its slowest write path — ~25 MB/s, with NVMe command timeouts in `dmesg`:

```
nvme nvme0: I/O tag 30 (d01e) opcode 0x1 (I/O Cmd) QID 1 timeout, aborting req_op:WRITE(1) size:262144
```

A 30-second write timeout on NVMe stalls containerd, which is why pod startup *and* teardown failed together.

## Already applied live

Pools are imperative state, so these were done on the controller, not in Git:

- Resized pool `34d064e6` to `max_runners: 6` / `min_idle_runners: 1`.
- Deleted the 13 runners stuck in `pending` (kept the 3 `active` ones — they were executing jobs).

The backlog drained and pods now reach `Running`.

## In this PR

- **`configmap.yaml`** — soft `topologySpreadConstraints` on `kubernetes.io/hostname` for both provider templates, so runners stop concentrating on whichever node cached the image. `ScheduleAnyway`, so a single reachable node still accepts runners. `garm-provider-k8s` applies `podTemplate` as a strategic merge patch, so the field passes through (verified against v0.3.2 source; spec also validated with a server-side dry-run).
- **`scripts/pool-audit.py` + `just pool-audit`** — pools are configured through `garm-cli` and nothing in Git prevents drift, so make drift visible and non-zero-exit.
- **`README.md`** — pool sizing rules, a diagnosis walkthrough with the commands used here, and the two node-level mitigations this repo cannot apply.

## Not addressed here (needs node access)

- The saturated SSD. Replacing it without reducing write volume only postpones the problem — CI workspaces want a volume separate from the node root disk.
- `serializeImagePulls: false` + `maxParallelImagePulls: 3-5` in kubelet config, so one slow pull cannot block every other pod on the node.