### PR TITLE
fix(argocd): preserve HTTPRoute match diffs

### DIFF
--- a/argocd/values.yaml
+++ b/argocd/values.yaml
@@ -127,7 +127,10 @@ configs:
         - '.spec.rules[].backendRefs[].group'
         - '.spec.rules[].backendRefs[].kind'
         - '.spec.rules[].backendRefs[].weight'
-        - '.spec.rules[].matches'
+        # Admission supplies this exact catch-all match when a rule omits
+        # `matches`. Ignore only that default; path, method, header, and query
+        # changes on explicitly configured matches must remain visible.
+        - '.spec.rules[] | select(.matches == [{"path":{"type":"PathPrefix","value":"/"}}]) | .matches'
     resource.customizations.ignoreDifferences.gateway.networking.k8s.io_TLSRoute: |
       jqPathExpressions:
         - '.spec.parentRefs[].group'

--- a/scripts/render-validate.sh
+++ b/scripts/render-validate.sh
@@ -57,6 +57,110 @@ fail() { printf '\033[31m✗\033[0m %s\n' "$*" >&2; }
 ok()   { printf '\033[32m✓\033[0m %s\n' "$*" >&2; }
 warn() { printf '\033[33m!\033[0m %s\n' "$*" >&2; }
 
+# HTTPRoute matches contain routing semantics (path, method, headers, and
+# query parameters). Ignoring the entire list makes ArgoCD report path changes
+# as Synced without applying them. Admission's exact catch-all default may be
+# ignored conditionally, but never the whole field.
+validate_argocd_diff_safety() {
+  local http_route_ignores ignore_program explicit_route near_default_route
+  local default_route
+  http_route_ignores="$(
+    yq -o=json \
+      '.configs.cm."resource.customizations.ignoreDifferences.gateway.networking.k8s.io_HTTPRoute" | from_yaml' \
+      "${ROOT}/argocd/values.yaml"
+  )"
+  if ! ignore_program="$(
+    jq -er '
+      .jqPathExpressions
+      | select(type == "array" and length > 0)
+      | "del((" + join("), (") + "))"
+    ' <<<"${http_route_ignores}"
+  )"; then
+    fail "argocd: HTTPRoute ignore-difference expressions are missing or invalid"
+    return 1
+  fi
+
+  explicit_route="$(
+    jq -cn '{
+      spec: {
+        parentRefs: [{group: "gateway.networking.k8s.io", kind: "Gateway"}],
+        rules: [{
+          backendRefs: [{group: "", kind: "Service", weight: 1}],
+          matches: [{
+            path: {type: "Exact", value: "/must-remain"},
+            method: "GET",
+            headers: [{name: "x-atc-test", value: "present"}],
+            queryParams: [{name: "mode", value: "safe"}]
+          }, {
+            path: {type: "PathPrefix", value: "/"},
+            method: "POST",
+            headers: [{name: "x-near-default", value: "constrained"}],
+            queryParams: [{name: "scope", value: "narrow"}]
+          }]
+        }]
+      }
+    }'
+  )"
+  if ! jq -e "${ignore_program} | .spec.rules[0].matches == [{
+    \"path\":{\"type\":\"Exact\",\"value\":\"/must-remain\"},
+    \"method\":\"GET\",
+    \"headers\":[{\"name\":\"x-atc-test\",\"value\":\"present\"}],
+    \"queryParams\":[{\"name\":\"mode\",\"value\":\"safe\"}]
+  }, {
+    \"path\":{\"type\":\"PathPrefix\",\"value\":\"/\"},
+    \"method\":\"POST\",
+    \"headers\":[{\"name\":\"x-near-default\",\"value\":\"constrained\"}],
+    \"queryParams\":[{\"name\":\"scope\",\"value\":\"narrow\"}]
+  }]" >/dev/null <<<"${explicit_route}"; then
+    fail "argocd: HTTPRoute ignore rules erase explicit routing semantics"
+    return 1
+  fi
+
+  near_default_route="$(
+    jq -cn '{
+      spec: {
+        parentRefs: [{group: "gateway.networking.k8s.io", kind: "Gateway"}],
+        rules: [{
+          backendRefs: [{group: "", kind: "Service", weight: 1}],
+          matches: [{
+            path: {type: "PathPrefix", value: "/"},
+            method: "POST",
+            headers: [{name: "x-near-default", value: "constrained"}],
+            queryParams: [{name: "scope", value: "narrow"}]
+          }]
+        }]
+      }
+    }'
+  )"
+  if ! jq -e "${ignore_program} | .spec.rules[0].matches == [{
+    \"path\":{\"type\":\"PathPrefix\",\"value\":\"/\"},
+    \"method\":\"POST\",
+    \"headers\":[{\"name\":\"x-near-default\",\"value\":\"constrained\"}],
+    \"queryParams\":[{\"name\":\"scope\",\"value\":\"narrow\"}]
+  }]" >/dev/null <<<"${near_default_route}"; then
+    fail "argocd: HTTPRoute ignore rules erase a constrained catch-all match"
+    return 1
+  fi
+
+  default_route="$(
+    jq -cn '{
+      spec: {
+        parentRefs: [{group: "gateway.networking.k8s.io", kind: "Gateway"}],
+        rules: [{
+          backendRefs: [{group: "", kind: "Service", weight: 1}],
+          matches: [{path: {type: "PathPrefix", value: "/"}}]
+        }]
+      }
+    }'
+  )"
+  if ! jq -e "${ignore_program} | (.spec.rules[0] | has(\"matches\") | not)" \
+    >/dev/null <<<"${default_route}"; then
+    fail "argocd: HTTPRoute admission's exact catch-all default is not ignored"
+    return 1
+  fi
+  ok "ArgoCD HTTPRoute diff coverage"
+}
+
 # Extract a field from an ArgoCD Application manifest. Returns empty string if
 # the field is missing — callers MUST handle the empty case explicitly.
 yq_get() {
@@ -355,6 +459,8 @@ validate_app() {
 
 main() {
   local app_file
+  validate_argocd_diff_safety || exit 1
+
   for app_file in "${APPS_DIR}"/*.yaml; do
     [[ -e "${app_file}" ]] || continue
     if ! validate_app "${app_file}"; then


### PR DESCRIPTION
## What

- narrow ArgoCD's HTTPRoute ignore-difference rule from the complete `spec.rules[].matches` field to only the exact admission-default catch-all match
- add a render-validation guard that applies every configured ignore expression to explicit, near-default, multi-match, and default fixtures
- require path, method, header, and query semantics to survive while still suppressing the exact cosmetic API default

## Why / root cause

After #577 merged, ArgoCD resolved the new revision and reported the Vault Application `Synced`, but the live `vault-external` HTTPRoute still lacked `/v1/k8s/data/ci-dashboard-restarter` and the public path returned 404. The cluster-wide ArgoCD config ignored the entire HTTPRoute `matches` list, making semantic route changes invisible and preventing auto-sync.

## Impact

ArgoCD will once again detect and apply HTTPRoute path/method changes cluster-wide. The 33 live rules that use the exact admission-default `PathPrefix /` remain free of cosmetic OutOfSync noise. Once this config reconciles, the already-merged Vault route change becomes visible and auto-syncs.

## Checks

- `bash -n scripts/render-validate.sh`
- `shellcheck scripts/render-validate.sh`
- `./scripts/render-validate.sh` (all Applications pass)
- explicit/near-default/multi-match/default ignore-expression fixtures
- `git diff --check`
- independent review: APPROVE on exact HEAD `a766ed6340e23dd232deb5559c066242f4cc2abe`